### PR TITLE
Changes for schedule object test to be reliable.

### DIFF
--- a/src/main/java/com/serotonin/bacnet4j/obj/BACnetObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/BACnetObject.java
@@ -28,16 +28,6 @@
  */
 package com.serotonin.bacnet4j.obj;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.serotonin.bacnet4j.LocalDevice;
 import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.obj.mixin.CommandableMixin;
@@ -72,6 +62,15 @@ import com.serotonin.bacnet4j.type.primitive.CharacterString;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
 import com.serotonin.bacnet4j.type.primitive.Real;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * @author Matthew
@@ -201,8 +200,14 @@ public class BACnetObject {
     //
     // Mixins
     //
-    protected final void addMixin(final AbstractMixin mixin) {
-        mixins.add(mixin);
+
+    /**
+     * Add Mixin to known location in the list of mixins, usually first position=0
+     * @param position
+     * @param mixin
+     */
+    protected void addMixin(final int position, final AbstractMixin mixin) {
+        mixins.add(position, mixin);
 
         if (mixin instanceof HasStatusFlagsMixin)
             hasStatusFlagsMixin = (HasStatusFlagsMixin) mixin;
@@ -212,6 +217,14 @@ public class BACnetObject {
             intrinsicReportingMixin = (IntrinsicReportingMixin) mixin;
         else if (mixin instanceof CovReportingMixin)
             changeOfValueMixin = (CovReportingMixin) mixin;
+    }
+
+    /**
+     * Add mixin to the end of the mixin list
+     * @param mixin
+     */
+    protected final void addMixin(final AbstractMixin mixin) {
+        addMixin(mixins.size(), mixin);
     }
 
     public void setOverridden(final boolean b) {

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/Date.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/Date.java
@@ -28,9 +28,6 @@
  */
 package com.serotonin.bacnet4j.type.primitive;
 
-import java.util.Calendar;
-import java.util.GregorianCalendar;
-
 import com.serotonin.bacnet4j.LocalDevice;
 import com.serotonin.bacnet4j.enums.DayOfWeek;
 import com.serotonin.bacnet4j.enums.Month;
@@ -38,6 +35,9 @@ import com.serotonin.bacnet4j.exception.BACnetErrorException;
 import com.serotonin.bacnet4j.exception.BACnetRuntimeException;
 import com.serotonin.bacnet4j.type.DateMatchable;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
 
 public class Date extends Primitive implements Comparable<Date>, DateMatchable {
     public static final Date MINIMUM_DATE = new Date(0, Month.JANUARY, 1, null);
@@ -86,6 +86,7 @@ public class Date extends Primitive implements Comparable<Date>, DateMatchable {
     public Date(final LocalDevice localDevice) {
         final GregorianCalendar gc = new GregorianCalendar();
         gc.setTimeInMillis(localDevice.getClock().millis());
+
         resetTo(gc);
     }
 

--- a/src/main/java/com/serotonin/warp/OneTime.java
+++ b/src/main/java/com/serotonin/warp/OneTime.java
@@ -28,6 +28,7 @@
  */
 package com.serotonin.warp;
 
+import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -57,7 +58,12 @@ class OneTime extends ScheduleFutureImpl<Void> {
 
     @Override
     public long getDelay(final TimeUnit unit) {
-        final long millis = runtime - executorService.getClock().millis();
+        return getDelay(unit, executorService.getClock().instant());
+    }
+
+    @Override
+    public long getDelay(TimeUnit unit, Instant from) {
+        final long millis = runtime - from.toEpochMilli();
         return unit.convert(millis, TimeUnit.MILLISECONDS);
     }
 }

--- a/src/main/java/com/serotonin/warp/OneTimeCallable.java
+++ b/src/main/java/com/serotonin/warp/OneTimeCallable.java
@@ -28,6 +28,7 @@
  */
 package com.serotonin.warp;
 
+import java.time.Instant;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
@@ -67,7 +68,12 @@ class OneTimeCallable<V> extends ScheduleFutureImpl<V> {
 
     @Override
     public long getDelay(final TimeUnit unit) {
-        final long millis = runtime - executorService.getClock().millis();
+        return getDelay(unit, executorService.getClock().instant());
+    }
+
+    @Override
+    public long getDelay(TimeUnit unit, Instant from) {
+        final long millis = runtime - from.toEpochMilli();
         return unit.convert(millis, TimeUnit.MILLISECONDS);
     }
 }

--- a/src/main/java/com/serotonin/warp/Repeating.java
+++ b/src/main/java/com/serotonin/warp/Repeating.java
@@ -28,6 +28,7 @@
  */
 package com.serotonin.warp;
 
+import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -40,7 +41,7 @@ abstract class Repeating extends ScheduleFutureImpl<Void> {
 
     protected long nextRuntime;
 
-    public Repeating(WarpTaskExecutingScheduledExecutorService executorService, final Runnable command, final long initialDelay, final TimeUnit unit) {
+    protected Repeating(WarpTaskExecutingScheduledExecutorService executorService, final Runnable command, final long initialDelay, final TimeUnit unit) {
         super(executorService);
         this.command = () -> {
             command.run();
@@ -66,7 +67,12 @@ abstract class Repeating extends ScheduleFutureImpl<Void> {
 
     @Override
     public long getDelay(final TimeUnit unit) {
-        final long millis = nextRuntime - executorService.getClock().millis();
+        return getDelay(unit, executorService.getClock().instant());
+    }
+
+    @Override
+    public long getDelay(TimeUnit unit, Instant from) {
+        final long millis = nextRuntime - from.toEpochMilli();
         return unit.convert(millis, TimeUnit.MILLISECONDS);
     }
 

--- a/src/main/java/com/serotonin/warp/ScheduleFutureImpl.java
+++ b/src/main/java/com/serotonin/warp/ScheduleFutureImpl.java
@@ -28,6 +28,7 @@
  */
 package com.serotonin.warp;
 
+import java.time.Instant;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.Delayed;
 import java.util.concurrent.ExecutionException;
@@ -47,17 +48,25 @@ abstract class ScheduleFutureImpl<V> implements ScheduledFuture<V> {
     private volatile boolean cancelled;
     private volatile boolean done;
 
-    public ScheduleFutureImpl(WarpTaskExecutingScheduledExecutorService executorService) {
+    protected ScheduleFutureImpl(WarpTaskExecutingScheduledExecutorService executorService) {
         this.executorService = executorService;
     }
 
     public void execute() {
-        executorService.submit(() -> executeImpl());
+        executorService.submit(this::executeImpl);
     }
 
     abstract void executeImpl();
 
     abstract Runnable getRunnable();
+
+    /**
+     * Get the delay from a given time
+     * @param unit
+     * @param from
+     * @return
+     */
+    abstract long getDelay(TimeUnit unit, Instant from);
 
     @Override
     public int compareTo(final Delayed that) {

--- a/src/main/java/com/serotonin/warp/WarpScheduledExecutorService.java
+++ b/src/main/java/com/serotonin/warp/WarpScheduledExecutorService.java
@@ -87,16 +87,26 @@ public class WarpScheduledExecutorService implements WarpTaskExecutingScheduledE
                     break;
                 }
                 task = tasks.get(0);
-                final long waitTime = task.getDelay(TimeUnit.MILLISECONDS);
+                final long waitTime = task.getDelay(TimeUnit.MILLISECONDS, dateTime.atZone(clock.getZone()).toInstant());
                 if (waitTime > 0) {
                     break;
                 }
                 // Remove the task
                 tasks.remove(0);
             }
+            //Execute the task without the lock
             if (!task.isCancelled()) {
                 // Execute the task
                 task.execute();
+                //TODO FIX ME, in order for us to be sure
+                // we have all the new tasks that were scheduled during
+                // this tasks execution we need to wait to make
+                // sure the tasks list has all the entries in it
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
             }
         }
     }


### PR DESCRIPTION
Some generic changes that are likely un-necessary that were made along the way to main points:

1.  Add a Thread.sleep to the warp scheduled executor
2. Fix the logic in the ScheduleObjectTest to be reliable by waiting for certain actions to complete  before making the assertions.