### PR TITLE
MANGO 2273 Remove sleep calls from read range request and device communications control request tests

### DIFF
--- a/src/main/java/com/serotonin/bacnet4j/ResponseConsumer.java
+++ b/src/main/java/com/serotonin/bacnet4j/ResponseConsumer.java
@@ -33,6 +33,14 @@ import com.serotonin.bacnet4j.exception.BACnetException;
 import com.serotonin.bacnet4j.service.acknowledgement.AcknowledgementService;
 
 public interface ResponseConsumer {
+    default void queued() {
+        // Implementations can choose to support this or not.
+    }
+
+    default void sent() {
+        // Implementations can choose to support this or not.
+    }
+
     void success(AcknowledgementService ack);
 
     void fail(AckAPDU ack);

--- a/src/main/java/com/serotonin/bacnet4j/ServiceFuture.java
+++ b/src/main/java/com/serotonin/bacnet4j/ServiceFuture.java
@@ -32,5 +32,14 @@ import com.serotonin.bacnet4j.exception.BACnetException;
 import com.serotonin.bacnet4j.service.acknowledgement.AcknowledgementService;
 
 public interface ServiceFuture {
+    enum State {
+        NEW, QUEUED, SENT, DONE, FAILED, EXCEPTION;
+    }
+
     <T extends AcknowledgementService> T get() throws BACnetException;
+
+    default State getState() {
+        // Implementations can choose to support this or not.
+        throw new UnsupportedOperationException();
+    }
 }

--- a/src/main/java/com/serotonin/bacnet4j/transport/DefaultTransport.java
+++ b/src/main/java/com/serotonin/bacnet4j/transport/DefaultTransport.java
@@ -291,7 +291,9 @@ public class DefaultTransport implements Transport, Runnable {
         if (EnableDisable.enable.equals(localDevice.getCommunicationControlState())) {
             outgoing.add(new OutgoingConfirmed(address, maxAPDULengthAccepted, segmentationSupported, service, consumer,
                     new Exception()));
-            consumer.queued();
+            if (consumer != null) {
+                consumer.queued();
+            }
             ThreadUtils.notifySync(pauseLock);
         } else {
             // Communication has been disabled as the result of a DeviceCommunicationControlRequest. The consumer
@@ -404,7 +406,9 @@ public class DefaultTransport implements Transport, Runnable {
 
             ctx.setOriginalApdu(apdu);
             sendForResponse(key, ctx);
-            consumer.sent();
+            if (consumer != null) {
+                consumer.sent();
+            }
         }
 
         @Override
@@ -659,7 +663,7 @@ public class DefaultTransport implements Transport, Runnable {
             }
         } else {
             // Must be an acknowledgement
-            LOG.debug("incomingApdu: recieved an acknowledgement from {}", from);
+            LOG.debug("incomingApdu: received an acknowledgement from {}", from);
 
             final AckAPDU ack = (AckAPDU) apdu;
             final UnackedMessageKey key = new UnackedMessageKey(from, linkService, ack.getOriginalInvokeId(),

--- a/src/main/java/com/serotonin/bacnet4j/transport/DefaultTransport.java
+++ b/src/main/java/com/serotonin/bacnet4j/transport/DefaultTransport.java
@@ -542,46 +542,45 @@ public class DefaultTransport implements Transport, Runnable {
     private void receiveImpl(final NPDU in) {
         if (in.isNetworkMessage()) {
             switch (in.getNetworkMessageType()) {
-                case 0x1: // I-Am-Router-To-Network
-                case 0x2: // I-Could-Be-Router-To-Network
-                    final ByteQueue data = in.getNetworkMessageData();
-                    while (data.size() > 1) {
-                        final int nn = data.popU2B();
-                        LOG.debug("Adding network router {} for network {}", in.getFrom().getMacAddress(), nn);
-                        networkRouters.put(nn, in.getFrom().getMacAddress());
-                    }
-                    break;
-                case 0x3: // Reject-Message-To-Network
-                    String reason;
-                    final int reasonCode = in.getNetworkMessageData().popU1B();
-                    if (reasonCode == 0)
-                        reason = "Other error";
-                    else if (reasonCode == 1)
-                        reason = "The router is not directly connected to DNET and cannot find a router to DNET on any "
-                                //
-                                + "directly connected network using Who-Is-Router-To-Network messages.";
-                    else if (reasonCode == 2)
-                        reason = "The router is busy and unable to accept messages for the specified DNET at the " //
-                                + "present time.";
-                    else if (reasonCode == 3)
-                        reason = "It is an unknown network layer message type. The DNET returned in this case is a " //
-                                + "local matter.";
-                    else if (reasonCode == 4)
-                        reason = "The message is too long to be routed to this DNET.";
-                    else if (reasonCode == 5)
-                        reason = "The source message was rejected due to a BACnet security error and that error cannot "
-                                //
-                                + " be forwarded to the source device. See Clause 24.12.1.1 for more details on the " //
-                                + "generation of Reject-Message-To-Network messages indicating this reason.";
-                    else if (reasonCode == 6)
-                        reason =
-                                "The source message was rejected due to errors in the addressing. The length of the " //
-                                        + "DADR or SADR was determined to be invalid.";
-                    else
-                        reason = "Unknown reason code";
-                    LOG.warn("Received Reject-Message-To-Network with reason '{}': {}", reasonCode, reason);
-                    break;
-                default:
+            case 0x1: // I-Am-Router-To-Network
+            case 0x2: // I-Could-Be-Router-To-Network
+                final ByteQueue data = in.getNetworkMessageData();
+                while (data.size() > 1) {
+                    final int nn = data.popU2B();
+                    LOG.debug("Adding network router {} for network {}", in.getFrom().getMacAddress(), nn);
+                    networkRouters.put(nn, in.getFrom().getMacAddress());
+                }
+                break;
+            case 0x3: // Reject-Message-To-Network
+                String reason;
+                final int reasonCode = in.getNetworkMessageData().popU1B();
+                if (reasonCode == 0)
+                    reason = "Other error";
+                else if (reasonCode == 1)
+                    reason = "The router is not directly connected to DNET and cannot find a router to DNET on any "
+                            //
+                            + "directly connected network using Who-Is-Router-To-Network messages.";
+                else if (reasonCode == 2)
+                    reason = "The router is busy and unable to accept messages for the specified DNET at the " //
+                            + "present time.";
+                else if (reasonCode == 3)
+                    reason = "It is an unknown network layer message type. The DNET returned in this case is a " //
+                            + "local matter.";
+                else if (reasonCode == 4)
+                    reason = "The message is too long to be routed to this DNET.";
+                else if (reasonCode == 5)
+                    reason = "The source message was rejected due to a BACnet security error and that error cannot "
+                            //
+                            + " be forwarded to the source device. See Clause 24.12.1.1 for more details on the " //
+                            + "generation of Reject-Message-To-Network messages indicating this reason.";
+                else if (reasonCode == 6)
+                    reason = "The source message was rejected due to errors in the addressing. The length of the " //
+                            + "DADR or SADR was determined to be invalid.";
+                else
+                    reason = "Unknown reason code";
+                LOG.warn("Received Reject-Message-To-Network with reason '{}': {}", reasonCode, reason);
+                break;
+            default:
             }
         } else {
             receiveAPDU(in);

--- a/src/main/java/com/serotonin/bacnet4j/transport/DefaultTransport.java
+++ b/src/main/java/com/serotonin/bacnet4j/transport/DefaultTransport.java
@@ -291,6 +291,7 @@ public class DefaultTransport implements Transport, Runnable {
         if (EnableDisable.enable.equals(localDevice.getCommunicationControlState())) {
             outgoing.add(new OutgoingConfirmed(address, maxAPDULengthAccepted, segmentationSupported, service, consumer,
                     new Exception()));
+            consumer.queued();
             ThreadUtils.notifySync(pauseLock);
         } else {
             // Communication has been disabled as the result of a DeviceCommunicationControlRequest. The consumer
@@ -403,6 +404,7 @@ public class DefaultTransport implements Transport, Runnable {
 
             ctx.setOriginalApdu(apdu);
             sendForResponse(key, ctx);
+            consumer.sent();
         }
 
         @Override
@@ -536,43 +538,46 @@ public class DefaultTransport implements Transport, Runnable {
     private void receiveImpl(final NPDU in) {
         if (in.isNetworkMessage()) {
             switch (in.getNetworkMessageType()) {
-            case 0x1: // I-Am-Router-To-Network
-            case 0x2: // I-Could-Be-Router-To-Network
-                final ByteQueue data = in.getNetworkMessageData();
-                while (data.size() > 1) {
-                    final int nn = data.popU2B();
-                    LOG.debug("Adding network router {} for network {}", in.getFrom().getMacAddress(), nn);
-                    networkRouters.put(nn, in.getFrom().getMacAddress());
-                }
-                break;
-            case 0x3: // Reject-Message-To-Network
-                String reason;
-                final int reasonCode = in.getNetworkMessageData().popU1B();
-                if (reasonCode == 0)
-                    reason = "Other error";
-                else if (reasonCode == 1)
-                    reason = "The router is not directly connected to DNET and cannot find a router to DNET on any " //
-                            + "directly connected network using Who-Is-Router-To-Network messages.";
-                else if (reasonCode == 2)
-                    reason = "The router is busy and unable to accept messages for the specified DNET at the " //
-                            + "present time.";
-                else if (reasonCode == 3)
-                    reason = "It is an unknown network layer message type. The DNET returned in this case is a " //
-                            + "local matter.";
-                else if (reasonCode == 4)
-                    reason = "The message is too long to be routed to this DNET.";
-                else if (reasonCode == 5)
-                    reason = "The source message was rejected due to a BACnet security error and that error cannot " //
-                            + " be forwarded to the source device. See Clause 24.12.1.1 for more details on the " //
-                            + "generation of Reject-Message-To-Network messages indicating this reason.";
-                else if (reasonCode == 6)
-                    reason = "The source message was rejected due to errors in the addressing. The length of the " //
-                            + "DADR or SADR was determined to be invalid.";
-                else
-                    reason = "Unknown reason code";
-                LOG.warn("Received Reject-Message-To-Network with reason '{}': {}", reasonCode, reason);
-                break;
-            default:
+                case 0x1: // I-Am-Router-To-Network
+                case 0x2: // I-Could-Be-Router-To-Network
+                    final ByteQueue data = in.getNetworkMessageData();
+                    while (data.size() > 1) {
+                        final int nn = data.popU2B();
+                        LOG.debug("Adding network router {} for network {}", in.getFrom().getMacAddress(), nn);
+                        networkRouters.put(nn, in.getFrom().getMacAddress());
+                    }
+                    break;
+                case 0x3: // Reject-Message-To-Network
+                    String reason;
+                    final int reasonCode = in.getNetworkMessageData().popU1B();
+                    if (reasonCode == 0)
+                        reason = "Other error";
+                    else if (reasonCode == 1)
+                        reason = "The router is not directly connected to DNET and cannot find a router to DNET on any "
+                                //
+                                + "directly connected network using Who-Is-Router-To-Network messages.";
+                    else if (reasonCode == 2)
+                        reason = "The router is busy and unable to accept messages for the specified DNET at the " //
+                                + "present time.";
+                    else if (reasonCode == 3)
+                        reason = "It is an unknown network layer message type. The DNET returned in this case is a " //
+                                + "local matter.";
+                    else if (reasonCode == 4)
+                        reason = "The message is too long to be routed to this DNET.";
+                    else if (reasonCode == 5)
+                        reason = "The source message was rejected due to a BACnet security error and that error cannot "
+                                //
+                                + " be forwarded to the source device. See Clause 24.12.1.1 for more details on the " //
+                                + "generation of Reject-Message-To-Network messages indicating this reason.";
+                    else if (reasonCode == 6)
+                        reason =
+                                "The source message was rejected due to errors in the addressing. The length of the " //
+                                        + "DADR or SADR was determined to be invalid.";
+                    else
+                        reason = "Unknown reason code";
+                    LOG.warn("Received Reject-Message-To-Network with reason '{}': {}", reasonCode, reason);
+                    break;
+                default:
             }
         } else {
             receiveAPDU(in);
@@ -605,7 +610,8 @@ public class DefaultTransport implements Transport, Runnable {
                 } catch (final BACnetException e1) {
                     LOG.warn("Error sending error response", e1);
                 }
-                LOG.warn("Receiving a confirmed service request that ist not supported or available. TYPE_ID '{}'", confAPDU.getServiceChoice());
+                LOG.warn("Receiving a confirmed service request that ist not supported or available. TYPE_ID '{}'",
+                        confAPDU.getServiceChoice());
                 return;
             }
 
@@ -725,8 +731,9 @@ public class DefaultTransport implements Transport, Runnable {
                     LOG.debug("Sending ack for segment {}, key={}", lastSeq, key);
 
                     // Send an acknowledgement
-                    network.sendAPDU(key.getAddress(), key.getLinkService(), new SegmentACK(false, !key.isFromServer(),
-                            msg.getInvokeId(), lastSeq, windowSize, !segmentWindow.isMessageComplete()), false);
+                    network.sendAPDU(key.getAddress(), key.getLinkService(),
+                            new SegmentACK(false, !key.isFromServer(), msg.getInvokeId(), lastSeq, windowSize,
+                                    !segmentWindow.isMessageComplete()), false);
 
                     // Append the window onto the original response.
                     for (final Segmentable segment : segmentWindow.getSegments()) {
@@ -799,8 +806,8 @@ public class DefaultTransport implements Transport, Runnable {
         int sequenceNumber = ctx.getLastIdSent();
         while (remaining > 0 && ctx.getServiceData().size() > 0) {
             final ByteQueue segData = ctx.getNextSegment();
-            final APDU segment = ctx.getSegmentTemplate().clone(ctx.getServiceData().size() > 0, ++sequenceNumber,
-                    ack.getActualWindowSize(), segData);
+            final APDU segment = ctx.getSegmentTemplate()
+                    .clone(ctx.getServiceData().size() > 0, ++sequenceNumber, ack.getActualWindowSize(), segData);
 
             LOG.debug("Sending segment {} for {}", sequenceNumber, key);
             try {
@@ -891,19 +898,19 @@ public class DefaultTransport implements Transport, Runnable {
             response.write(serviceData);
 
             // Check if we need to segment the message.
-            if (serviceData.size() > request.getMaxApduLengthAccepted().getMaxLengthInt()
-                    - ComplexACK.getHeaderSize(false)) {
-                final int maxServiceData = request.getMaxApduLengthAccepted().getMaxLengthInt()
-                        - ComplexACK.getHeaderSize(true);
+            if (serviceData.size() > request.getMaxApduLengthAccepted().getMaxLengthInt() - ComplexACK.getHeaderSize(
+                    false)) {
+                final int maxServiceData =
+                        request.getMaxApduLengthAccepted().getMaxLengthInt() - ComplexACK.getHeaderSize(true);
                 // Check if the device can accept what we want to send.
                 if (!request.isSegmentedResponseAccepted()) {
-                    LOG.warn("Response too big to send to device without segmentation");                   
-                    throw new BACnetAbortException(AbortReason.bufferOverflow);         
+                    LOG.warn("Response too big to send to device without segmentation");
+                    throw new BACnetAbortException(AbortReason.bufferOverflow);
                 }
                 final int segmentsRequired = serviceData.size() / maxServiceData + 1;
                 if (segmentsRequired > request.getMaxSegmentsAccepted().getMaxSegments() || segmentsRequired > 255) {
                     LOG.warn("Response too big to send to device; too many segments required");
-                    throw new BACnetAbortException(AbortReason.bufferOverflow); 
+                    throw new BACnetAbortException(AbortReason.bufferOverflow);
                 }
                 LOG.debug("Sending confirmed response as segmented with {} segments", segmentsRequired);
                 // Prepare the segmenting session.
@@ -970,8 +977,7 @@ public class DefaultTransport implements Transport, Runnable {
                                 network.sendAPDU(key.getAddress(), key.getLinkService(),
                                         new SegmentACK(true, key.isFromServer(), key.getInvokeId(),
                                                 ctx.getSegmentWindow().getLatestSequenceId(),
-                                                ctx.getSegmentWindow().getWindowSize(), true),
-                                        false);
+                                                ctx.getSegmentWindow().getWindowSize(), true), false);
                             } catch (final BACnetException ex) {
                                 ctx.useConsumer((consumer) -> consumer.ex(ex));
                             }

--- a/src/test/java/com/serotonin/bacnet4j/service/confirmed/DeviceCommunicationControlRequestTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/service/confirmed/DeviceCommunicationControlRequestTest.java
@@ -1,5 +1,7 @@
 package com.serotonin.bacnet4j.service.confirmed;
 
+import static com.serotonin.bacnet4j.TestUtils.awaitEquals;
+import static com.serotonin.bacnet4j.TestUtils.awaitTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
@@ -31,7 +33,6 @@ import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
 import com.serotonin.bacnet4j.type.primitive.CharacterString;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
-import com.serotonin.bacnet4j.util.sero.ThreadUtils;
 
 /**
  * All tests modify the communication control in device d1.
@@ -44,14 +45,16 @@ public class DeviceCommunicationControlRequestTest extends AbstractTest {
     public void communicationEnabled() throws BACnetException {
         // Send a request.
         assertNull(d2.get(PropertyIdentifier.description));
-        d1.send(rd2, new WritePropertyRequest(new ObjectIdentifier(ObjectType.device, 2),
-                PropertyIdentifier.description, null, new CharacterString("a"), null)).get();
+        d1.send(rd2,
+                new WritePropertyRequest(new ObjectIdentifier(ObjectType.device, 2), PropertyIdentifier.description,
+                        null, new CharacterString("a"), null)).get();
         assertEquals(new CharacterString("a"), d2.get(PropertyIdentifier.description));
 
         // Receive a request.
         assertNull(d1.get(PropertyIdentifier.description));
-        d2.send(rd1, new WritePropertyRequest(new ObjectIdentifier(ObjectType.device, 1),
-                PropertyIdentifier.description, null, new CharacterString("a"), null)).get();
+        d2.send(rd1,
+                new WritePropertyRequest(new ObjectIdentifier(ObjectType.device, 1), PropertyIdentifier.description,
+                        null, new CharacterString("a"), null)).get();
         assertEquals(new CharacterString("a"), d1.get(PropertyIdentifier.description));
     }
 
@@ -66,8 +69,9 @@ public class DeviceCommunicationControlRequestTest extends AbstractTest {
 
         // Fail to send a request.
         try {
-            d1.send(rd2, new WritePropertyRequest(new ObjectIdentifier(ObjectType.device, 2),
-                    PropertyIdentifier.description, null, new CharacterString("a"), null)).get();
+            d1.send(rd2,
+                    new WritePropertyRequest(new ObjectIdentifier(ObjectType.device, 2), PropertyIdentifier.description,
+                            null, new CharacterString("a"), null)).get();
             fail("BACnetException should have been thrown");
         } catch (final BACnetException e) {
             // Inner exception must be a BACCommunicationDisabledException
@@ -78,8 +82,9 @@ public class DeviceCommunicationControlRequestTest extends AbstractTest {
 
         // Receive a request
         assertNull(d1.get(PropertyIdentifier.description));
-        d2.send(rd1, new WritePropertyRequest(new ObjectIdentifier(ObjectType.device, 1),
-                PropertyIdentifier.description, null, new CharacterString("a"), null)).get();
+        d2.send(rd1,
+                new WritePropertyRequest(new ObjectIdentifier(ObjectType.device, 1), PropertyIdentifier.description,
+                        null, new CharacterString("a"), null)).get();
         assertEquals(new CharacterString("a"), d1.get(PropertyIdentifier.description));
 
         // Sending of IAms...
@@ -93,21 +98,22 @@ public class DeviceCommunicationControlRequestTest extends AbstractTest {
 
         // Should also fail to send an IAm
         d1.send(rd2, d1.getIAm());
-        Thread.sleep(100);
+        // Wait a bit to ensure nothing changes.
+        Thread.sleep(500);
         assertEquals(0, iamCount.get());
 
         // But should still respond to a WhoIs
         d2.send(rd1, new WhoIsRequest(1, 1));
-        Thread.sleep(100);
-        assertEquals(1, iamCount.get());
+        awaitEquals(iamCount::get, 1, 5000);
 
         // Re-enable
         d2.send(rd1, new DeviceCommunicationControlRequest(null, EnableDisable.enable, null)).get();
 
         // Send a request. This time it succeeds.
         assertNull(d2.get(PropertyIdentifier.description));
-        d1.send(rd2, new WritePropertyRequest(new ObjectIdentifier(ObjectType.device, 2),
-                PropertyIdentifier.description, null, new CharacterString("a"), null)).get();
+        d1.send(rd2,
+                new WritePropertyRequest(new ObjectIdentifier(ObjectType.device, 2), PropertyIdentifier.description,
+                        null, new CharacterString("a"), null)).get();
         assertEquals(new CharacterString("a"), d2.get(PropertyIdentifier.description));
     }
 
@@ -115,14 +121,15 @@ public class DeviceCommunicationControlRequestTest extends AbstractTest {
      * Ensure that only DCCR and reinitialize are handled when disabled
      */
     @Test
-    public void disable() throws BACnetException {
+    public void disable() throws Exception {
         // Disable
         d2.send(rd1, new DeviceCommunicationControlRequest(null, EnableDisable.disable, null)).get();
 
         // Fail to send a request.
         try {
-            d1.send(rd2, new WritePropertyRequest(new ObjectIdentifier(ObjectType.device, 2),
-                    PropertyIdentifier.description, null, new CharacterString("a"), null)).get();
+            d1.send(rd2,
+                    new WritePropertyRequest(new ObjectIdentifier(ObjectType.device, 2), PropertyIdentifier.description,
+                            null, new CharacterString("a"), null)).get();
             fail("BACnetException should have been thrown");
         } catch (final BACnetException e) {
             // Inner exception must be a BACCommunicationDisabledException
@@ -139,7 +146,7 @@ public class DeviceCommunicationControlRequestTest extends AbstractTest {
 
             // We need to advance the clock because otherwise the request will never time out.
             // First give the transport a chance to send the request.
-            ThreadUtils.sleep(5);
+            awaitTrue(() -> future.getState() == ServiceFuture.State.SENT, 5000);
             // Then advance past the timeout.
             clock.plusMillis(TIMEOUT + 1);
 
@@ -169,15 +176,17 @@ public class DeviceCommunicationControlRequestTest extends AbstractTest {
 
         // Send a request. This time it succeeds.
         assertNull(d2.get(PropertyIdentifier.description));
-        d1.send(rd2, new WritePropertyRequest(new ObjectIdentifier(ObjectType.device, 2),
-                PropertyIdentifier.description, null, new CharacterString("a"), null)).get();
+        d1.send(rd2,
+                new WritePropertyRequest(new ObjectIdentifier(ObjectType.device, 2), PropertyIdentifier.description,
+                        null, new CharacterString("a"), null)).get();
         assertEquals(new CharacterString("a"), d2.get(PropertyIdentifier.description));
 
         // Receive a request. This time it too succeeds. Note that the value is already "a", because requests are
         // still processed, just not responded.
         assertEquals(new CharacterString("a"), d1.get(PropertyIdentifier.description));
-        d2.send(rd1, new WritePropertyRequest(new ObjectIdentifier(ObjectType.device, 1),
-                PropertyIdentifier.description, null, new CharacterString("b"), null)).get();
+        d2.send(rd1,
+                new WritePropertyRequest(new ObjectIdentifier(ObjectType.device, 1), PropertyIdentifier.description,
+                        null, new CharacterString("b"), null)).get();
         assertEquals(new CharacterString("b"), d1.get(PropertyIdentifier.description));
     }
 
@@ -185,9 +194,10 @@ public class DeviceCommunicationControlRequestTest extends AbstractTest {
      * Ensure that the timer works.
      */
     @Test
-    public void timer() throws BACnetException {
+    public void timer() throws Exception {
         // Disable for 5 minutes.
         d2.send(rd1, new DeviceCommunicationControlRequest(new UnsignedInteger(5), EnableDisable.disable, null)).get();
+        awaitEquals(d1::getCommunicationControlState, EnableDisable.disable, 5000);
 
         // Fail to receive a request
         try {
@@ -197,7 +207,8 @@ public class DeviceCommunicationControlRequestTest extends AbstractTest {
 
             // We need to advance the clock because otherwise the request will never time out.
             // First give the transport a chance to send the request.
-            ThreadUtils.sleep(5);
+            awaitTrue(() -> future.getState() == ServiceFuture.State.SENT, 5000);
+
             // Then advance past the timeout.
             clock.plusMillis(TIMEOUT + 1);
 
@@ -209,12 +220,14 @@ public class DeviceCommunicationControlRequestTest extends AbstractTest {
 
         // Let the 5 minutes elapse.
         clock.plusMinutes(6);
+        awaitEquals(d1::getCommunicationControlState, EnableDisable.enable, 5000);
 
         // Receive a request. This time it too succeeds. Note that the value is already "a", because requests are
         // still processed, just not responded.
         assertEquals(new CharacterString("a"), d1.get(PropertyIdentifier.description));
-        d2.send(rd1, new WritePropertyRequest(new ObjectIdentifier(ObjectType.device, 1),
-                PropertyIdentifier.description, null, new CharacterString("b"), null)).get();
+        d2.send(rd1,
+                new WritePropertyRequest(new ObjectIdentifier(ObjectType.device, 1), PropertyIdentifier.description,
+                        null, new CharacterString("b"), null)).get();
         assertEquals(new CharacterString("b"), d1.get(PropertyIdentifier.description));
     }
 
@@ -222,7 +235,7 @@ public class DeviceCommunicationControlRequestTest extends AbstractTest {
      * Ensure that the timer gets cancelled.
      */
     @Test
-    public void timerCancel() throws BACnetException {
+    public void timerCancel() throws Exception {
         // Disable for 5 minutes.
         d2.send(rd1, new DeviceCommunicationControlRequest(new UnsignedInteger(5), EnableDisable.disable, null)).get();
 
@@ -234,7 +247,8 @@ public class DeviceCommunicationControlRequestTest extends AbstractTest {
 
             // We need to advance the clock because otherwise the request will never time out.
             // First give the transport a chance to send the request.
-            ThreadUtils.sleep(5);
+            awaitTrue(() -> future.getState() == ServiceFuture.State.SENT, 5000);
+            //            ThreadUtils.sleep(5);
             // Then advance past the timeout.
             clock.plusMillis(TIMEOUT + 1);
 
@@ -253,8 +267,9 @@ public class DeviceCommunicationControlRequestTest extends AbstractTest {
         // Receive a request. This time it too succeeds. Note that the value is already "a", because requests are
         // still processed, just not responded.
         assertEquals(new CharacterString("a"), d1.get(PropertyIdentifier.description));
-        d2.send(rd1, new WritePropertyRequest(new ObjectIdentifier(ObjectType.device, 1),
-                PropertyIdentifier.description, null, new CharacterString("b"), null)).get();
+        d2.send(rd1,
+                new WritePropertyRequest(new ObjectIdentifier(ObjectType.device, 1), PropertyIdentifier.description,
+                        null, new CharacterString("b"), null)).get();
         assertEquals(new CharacterString("b"), d1.get(PropertyIdentifier.description));
     }
 
@@ -276,7 +291,7 @@ public class DeviceCommunicationControlRequestTest extends AbstractTest {
         // Try to disable with incorrect password
         try {
             d2.send(rd1,
-                    new DeviceCommunicationControlRequest(null, EnableDisable.disable, new CharacterString("qwer")))
+                            new DeviceCommunicationControlRequest(null, EnableDisable.disable, new CharacterString("qwer")))
                     .get();
             fail("ErrorAPDUException should have been thrown");
         } catch (final ErrorAPDUException e) {


### PR DESCRIPTION
Note that the changes to read range request were already made in another PR.

To remove the sleeps from device communication control it was necessary to add state tracking to confirmed messages. 