### PR TITLE
MANGO 2279 Minor refactoring of testutils and local device

### DIFF
--- a/src/test/java/com/serotonin/bacnet4j/TestUtils.java
+++ b/src/test/java/com/serotonin/bacnet4j/TestUtils.java
@@ -191,6 +191,7 @@ public class TestUtils {
         }
     }
 
+
     @FunctionalInterface
     public interface BACnetExceptionCommand {
         void call() throws BACnetException;
@@ -274,12 +275,9 @@ public class TestUtils {
     /**
      * A utility to busy-wait up to a given timeout for the given condition to become true.
      *
-     * @param condition
-     *         the condition to which to wait
-     * @param timeoutMs
-     *         the maximum amount of time to wait
-     * @throws Exception
-     *         the exception if any that the condition threw
+     * @param condition the condition to which to wait
+     * @param timeoutMs the maximum amount of time to wait
+     * @throws Exception the exception if any that the condition threw
      */
     public static void awaitTrue(BooleanSupplierWithException condition, long timeoutMs) throws Exception {
         if (await(condition, true, timeoutMs)) {
@@ -291,12 +289,9 @@ public class TestUtils {
     /**
      * Utility to busy-wait up to a given timeout for the given condition to become false.
      *
-     * @param condition
-     *         the condition to which to wait
-     * @param timeoutMs
-     *         the maximum amount of time to wait
-     * @throws Exception
-     *         the exception if any thrown by the condition
+     * @param condition the condition to which to wait
+     * @param timeoutMs the maximum amount of time to wait
+     * @throws Exception the exception if any thrown by the condition
      */
     public static void awaitFalse(BooleanSupplierWithException condition, long timeoutMs) throws Exception {
         if (await(condition, false, timeoutMs)) {
@@ -308,10 +303,8 @@ public class TestUtils {
     /**
      * Lifted from Assert to test whether a given object pair are either both null or equal.
      *
-     * @param expected
-     *         the expected value
-     * @param actual
-     *         the value to check
+     * @param expected the expected value
+     * @param actual   the value to check
      * @return true if they are both null or equal, false otherwise
      */
     public static boolean equalsRegardingNull(Object expected, Object actual) {
@@ -332,14 +325,10 @@ public class TestUtils {
     /**
      * Utility to busy-wait up to a given timeout for the given supplier to supply a value that matches that given.
      *
-     * @param supplier
-     *         the supplier the value of which to check
-     * @param constant
-     *         the value to match
-     * @param timeoutMs
-     *         the maximum amount of time to wait
-     * @throws Exception
-     *         the exception if any thrown by the supplier
+     * @param supplier  the supplier the value of which to check
+     * @param constant  the value to match
+     * @param timeoutMs the maximum amount of time to wait
+     * @throws Exception the exception if any thrown by the supplier
      */
     public static void awaitEquals(final IntSupplierWithException supplier, int constant, long timeoutMs)
             throws Exception {
@@ -360,14 +349,10 @@ public class TestUtils {
     /**
      * Utility to busy-wait up to a given timeout for the given supplier to supply a value that matches that given.
      *
-     * @param supplier
-     *         the supplier the value of which to check
-     * @param constant
-     *         the value to match
-     * @param timeoutMs
-     *         the maximum amount of time to wait
-     * @throws Exception
-     *         the exception if any thrown by the supplier
+     * @param supplier  the supplier the value of which to check
+     * @param constant  the value to match
+     * @param timeoutMs the maximum amount of time to wait
+     * @throws Exception the exception if any thrown by the supplier
      */
     public static void awaitEquals(final EncodableSupplierWithException supplier, Encodable constant, long timeoutMs)
             throws Exception {
@@ -384,15 +369,11 @@ public class TestUtils {
     /**
      * Utility that will "busy-wait" up to a given timeout for a condition to match the given value.
      *
-     * @param condition
-     *         the condition to which to wait
-     * @param value
-     *         the value the condition should match
-     * @param timeoutMs
-     *         the maximum amount of time to wait
+     * @param condition the condition to which to wait
+     * @param value     the value the condition should match
+     * @param timeoutMs the maximum amount of time to wait
      * @return true if the condition was matched, false otherwise
-     * @throws Exception
-     *         the exception if any thrown by the condition
+     * @throws Exception the exception if any thrown by the condition
      */
     public static boolean await(BooleanSupplierWithException condition, boolean value, long timeoutMs)
             throws Exception {

--- a/src/test/java/com/serotonin/bacnet4j/TestUtils.java
+++ b/src/test/java/com/serotonin/bacnet4j/TestUtils.java
@@ -347,6 +347,17 @@ public class TestUtils {
     }
 
     /**
+     * Convenience formulation of the awaitEquals implementation that looks more like an assert.
+     *
+     * @param expected       the value to match
+     * @param actualSupplier the supplier the value of which to check
+     */
+    public static void awaitEquals(Encodable expected, final EncodableSupplierWithException actualSupplier)
+            throws Exception {
+        awaitEquals(actualSupplier, expected, 5000);
+    }
+
+    /**
      * Utility to busy-wait up to a given timeout for the given supplier to supply a value that matches that given.
      *
      * @param supplier  the supplier the value of which to check
@@ -387,5 +398,13 @@ public class TestUtils {
             }
             ThreadUtils.sleep(2);
         }
+    }
+
+    /**
+     * Sleep for a given period before continuing to ensure that nothing happens during that time. This is frequently
+     * used to ensure that notifications are not sent following some activity.
+     */
+    public static void quiesce() {
+        ThreadUtils.sleep(500);
     }
 }


### PR DESCRIPTION
- The LocalDevice change was already made in another PR
- TestUtils change is pretty much just code cleanup
- Found that there were failure out-of-test-thread in `RemoteDeviceDiscoveryTest`, which is fixed with a `synchronize` block.