### PR TITLE
MANGO 2276 Remove sleep calls from device event log and life safety tests

### DIFF
--- a/src/test/java/com/serotonin/bacnet4j/TestUtils.java
+++ b/src/test/java/com/serotonin/bacnet4j/TestUtils.java
@@ -6,11 +6,13 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.time.Clock;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiPredicate;
 
 import org.junit.Assert;
@@ -32,6 +34,8 @@ import com.serotonin.bacnet4j.type.error.ErrorClassAndCode;
 import com.serotonin.bacnet4j.type.primitive.Time;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
 import com.serotonin.bacnet4j.util.sero.ThreadUtils;
+
+import lohbihler.warp.WarpClock;
 
 public class TestUtils {
     public static <T, U> void assertListEqualsIgnoreOrder(final List<T> expectedList, final List<U> actualList,
@@ -333,6 +337,16 @@ public class TestUtils {
     }
 
     /**
+     * Convenience formulation of the awaitEquals implementation that looks more like an assert.
+     *
+     * @param expected       the value to match
+     * @param actualSupplier the supplier the value of which to check
+     */
+    public static void awaitEquals(int expected, final IntSupplierWithException actualSupplier) throws Exception {
+        awaitEquals(actualSupplier, expected, 5000);
+    }
+
+    /**
      * Utility to busy-wait up to a given timeout for the given supplier to supply a value that matches that given.
      *
      * @param supplier  the supplier the value of which to check
@@ -354,6 +368,17 @@ public class TestUtils {
     @FunctionalInterface
     public interface EncodableSupplierWithException {
         Encodable get() throws Exception;
+    }
+
+    /**
+     * Convenience formulation of the awaitEquals implementation that looks more like an assert.
+     *
+     * @param expected       the value to match
+     * @param actualSupplier the supplier the value of which to check
+     */
+    public static void awaitEquals(Encodable expected, final EncodableSupplierWithException actualSupplier)
+            throws Exception {
+        awaitEquals(actualSupplier, expected, 5000);
     }
 
     /**
@@ -397,5 +422,95 @@ public class TestUtils {
             }
             ThreadUtils.sleep(2);
         }
+    }
+
+
+    @FunctionalInterface
+    public interface RunnableWithException {
+        void run() throws Exception;
+    }
+
+    /**
+     * Convenience method for only advancing the clock.
+     *
+     * @param clock  the clock to advance
+     * @param amount the amount of time to advance
+     * @param unit   the unit of total time amount
+     * @return the final datetime
+     */
+    public static LocalDateTime advanceClock(WarpClock clock, int amount, TimeUnit unit) throws Exception {
+        return advanceClock(clock, amount, unit, 0, null, null, null);
+    }
+
+    /**
+     * Lifted from the WarpClock.plus method, but instead of sleep intervals this uses runnables.
+     *
+     * @param clock       the clock to advance
+     * @param amount      the amount of time to advance
+     * @param unit        the unit of total time amount
+     * @param preAdvance  a function to run before each increment
+     * @param postAdvance a function to run after each increment, including after the total time has advanced
+     * @return the final datetime
+     */
+    public static LocalDateTime advanceClock(WarpClock clock, int amount, TimeUnit unit,
+            RunnableWithException preAdvance, RunnableWithException postAdvance) throws Exception {
+        return advanceClock(clock, amount, unit, 0, null, preAdvance, postAdvance);
+    }
+
+    /**
+     * Lifted from the WarpClock.plus method, but instead of sleep intervals this uses runnables.
+     *
+     * @param clock           the clock to advance
+     * @param totalAmount     the total amount of time to advance
+     * @param unit            the unit of total time amount
+     * @param incrementAmount the amount of time between each increment
+     * @param incrementUnit   the unit of time increment
+     * @param preAdvance      a function to run before each increment
+     * @param postAdvance     a function to run after each increment, including after the total time has advanced
+     * @return the final datetime
+     */
+    public static LocalDateTime advanceClock(WarpClock clock, int totalAmount, TimeUnit unit, int incrementAmount,
+            TimeUnit incrementUnit, RunnableWithException preAdvance, RunnableWithException postAdvance)
+            throws Exception {
+        long remainder = unit.toNanos(totalAmount);
+        long each = (incrementUnit == null ? unit : incrementUnit).toNanos(
+                incrementAmount == 0 ? (long) totalAmount : (long) incrementAmount);
+        LocalDateTime result = null;
+
+        try {
+            if (remainder <= 0L) {
+                if (preAdvance != null)
+                    preAdvance.run();
+                result = clock.plusNanos(0L);
+                if (postAdvance != null)
+                    postAdvance.run();
+            } else {
+                while (remainder > 0L) {
+                    long nanos = each;
+                    if (each > remainder) {
+                        nanos = remainder;
+                    }
+
+                    if (preAdvance != null)
+                        preAdvance.run();
+                    result = clock.plusNanos(nanos);
+                    remainder -= nanos;
+                    if (postAdvance != null)
+                        postAdvance.run();
+                }
+            }
+
+            return result;
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Sleep for a given period before continuing to ensure that nothing happens during that time. This is frequently
+     * used to ensure that notifications are not sent following some activity.
+     */
+    public static void quiesce() {
+        ThreadUtils.sleep(500);
     }
 }


### PR DESCRIPTION
Introduces await methods that look more like asserts, and `quiesce` instead of `Thread.sleep(500)`