### PR TITLE
MANGO-2327 Minor test code cleanup

### DIFF
--- a/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadRangeRequestTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadRangeRequestTest.java
@@ -155,10 +155,10 @@ public class ReadRangeRequestTest {
     private static void doTriggers(final TrendLogMultipleObject tl, final int count) throws Exception {
         int remaining = count;
         while (remaining > 0) {
-            await(tl::trigger, 5000);
+            await(tl::trigger);
             remaining--;
         }
-        await(() -> !((Boolean) tl.get(PropertyIdentifier.trigger)).booleanValue(), 5000);
+        await(() -> !((Boolean) tl.get(PropertyIdentifier.trigger)).booleanValue());
     }
 
     /**


### PR DESCRIPTION
This is the last one, i swear. (I hope.)

Just a bit of cleanup and normalization:
- removing code that isn't used.
- refactoring the `await` methods to have the expected value as the first parameter (to be like `assert` methods)
- fixing one test that was sending a timeout value (that wasn't different from default)