### PR TITLE
Allow test network identifiers to be comparable

### DIFF
--- a/src/main/java/com/serotonin/bacnet4j/npdu/test/TestNetwork.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/test/TestNetwork.java
@@ -65,6 +65,7 @@ public class TestNetwork extends Network implements Runnable {
 
     private volatile boolean running = true;
     private Thread thread;
+    private final NetworkIdentifier networkIdentifier = new TestNetworkIdentifier();
 
     /**
      * This is the list of outgoing messages queued up for sending.
@@ -96,7 +97,7 @@ public class TestNetwork extends Network implements Runnable {
 
     @Override
     public NetworkIdentifier getNetworkIdentifier() {
-        return new TestNetworkIdentifier();
+        return networkIdentifier;
     }
 
     @Override

--- a/src/test/java/com/serotonin/bacnet4j/npdu/test/TestNetworkIdentifierTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/npdu/test/TestNetworkIdentifierTest.java
@@ -27,21 +27,15 @@
 
 package com.serotonin.bacnet4j.npdu.test;
 
-import com.serotonin.bacnet4j.npdu.NetworkIdentifier;
+import static org.junit.Assert.assertEquals;
 
-public class TestNetworkIdentifier extends NetworkIdentifier {
-    @Override
-    public String getIdString() {
-        return "test";
-    }
+import org.junit.Test;
 
-    @Override
-    public int hashCode() {
-        return -12345;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        return obj instanceof TestNetworkIdentifier;
+public class TestNetworkIdentifierTest {
+    @Test
+    public void twoTestNetworkIdentifiersAreEqual() {
+        TestNetworkIdentifier testNetworkIdentifier1 = new TestNetworkIdentifier();
+        TestNetworkIdentifier testNetworkIdentifier2 = new TestNetworkIdentifier();
+        assertEquals(testNetworkIdentifier1, testNetworkIdentifier2);
     }
 }


### PR DESCRIPTION
Allow test network identifiers to be comparable. These test classes are quite useful on BACnet module tests, but the lack of comparability and equality is an unfortunate gap.