### PR TITLE
Set LocalDevice version from build version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,18 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>test.App</mainClass>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <dependencies>

--- a/src/main/java/com/serotonin/bacnet4j/LocalDevice.java
+++ b/src/main/java/com/serotonin/bacnet4j/LocalDevice.java
@@ -107,7 +107,8 @@ import lohbihler.warp.WarpUtils;
  */
 public class LocalDevice implements AutoCloseable {
     static final Logger LOG = LoggerFactory.getLogger(LocalDevice.class);
-    public static final String VERSION = "6.0.0";
+    public static final String VERSION =
+            Objects.requireNonNullElse(LocalDevice.class.getPackage().getImplementationVersion(), "unknown");
 
     private final Transport transport;
 

--- a/src/test/java/com/serotonin/bacnet4j/TestUtils.java
+++ b/src/test/java/com/serotonin/bacnet4j/TestUtils.java
@@ -366,7 +366,7 @@ public class TestUtils {
      * @param actualSupplier the supplier the value of which to check
      */
     public static void awaitEquals(int expected, final IntSupplierWithException actualSupplier) throws Exception {
-        awaitEquals(expected, actualSupplier, 5000);
+        awaitEquals(expected, actualSupplier, 10000);
     }
 
     /**


### PR DESCRIPTION
Instead of having to keep the local device version in sync with the builds, have the version value read from the jar meta data. This only works when the code is accessed from a build jar. Otherwise the value will be "unknown".

I included an increase in the test poll wait time because of repeated test run failures.