### PR TITLE
MANGO-2630 Allow BACnetArray to be resized by writing to index 0

### DIFF
--- a/src/main/java/com/serotonin/bacnet4j/obj/BACnetObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/BACnetObject.java
@@ -558,10 +558,14 @@ public class BACnetObject {
                 }
 
                 if (pin.intValue() == 0) {
-                    // Writing the size of the array is not allowed here because specific cases need to define what
-                    // value to use as a default when an array is being expanded. This condition therefore needs to
-                    // be handled in mixins or objects.
-                    throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
+                    if (value.getValue() instanceof UnsignedInteger) {
+                        // Writing the size of the array is not allowed here because specific cases need to define what
+                        // value to use as a default when an array is being expanded. This condition therefore needs to
+                        // be handled in mixins or objects.
+                        throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
+                    }
+                    // Can only write an unsigned integer to the zero-index.
+                    throw new BACnetServiceException(ErrorClass.property, ErrorCode.invalidArrayIndex);
                 } else {
                     if (def == null) {
                         // No property definition available, but we can check that the data type to write matches that

--- a/src/main/java/com/serotonin/bacnet4j/obj/BACnetObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/BACnetObject.java
@@ -557,22 +557,29 @@ public class BACnetObject {
                     throw new BACnetServiceException(ErrorClass.property, ErrorCode.propertyIsNotAnArray);
                 }
 
-                if (def == null) {
-                    // No property definition available, but we can check that the data type to write matches that
-                    // of any existing elements.
-                    if (arr.getCount() > 0) {
-                        if (arr.getBase1(1).getClass() != value.getValue().getClass()) {
-                            throw new BACnetServiceException(ErrorClass.property, ErrorCode.invalidDataType);
-                        }
-                    }
+                if (pin.intValue() == 0) {
+                    // Writing the size of the array is not allowed here because specific cases need to define what
+                    // value to use as a default when an array is being expanded. This condition therefore needs to
+                    // be handled in mixins or objects.
+                    throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
                 } else {
-                    if (!def.getPropertyTypeDefinition().getClazz().isAssignableFrom(value.getValue().getClass()))
-                        throw new BACnetServiceException(ErrorClass.property, ErrorCode.invalidDataType);
-                }
+                    if (def == null) {
+                        // No property definition available, but we can check that the data type to write matches that
+                        // of any existing elements.
+                        if (arr.getCount() > 0) {
+                            if (arr.getBase1(1).getClass() != value.getValue().getClass()) {
+                                throw new BACnetServiceException(ErrorClass.property, ErrorCode.invalidDataType);
+                            }
+                        }
+                    } else {
+                        if (!def.getPropertyTypeDefinition().getClazz().isAssignableFrom(value.getValue().getClass()))
+                            throw new BACnetServiceException(ErrorClass.property, ErrorCode.invalidDataType);
+                    }
 
-                // Index check.
-                if (pin.intValue() < 1 || pin.intValue() > arr.getCount()) {
-                    throw new BACnetServiceException(ErrorClass.property, ErrorCode.invalidArrayIndex);
+                    // Index check.
+                    if (pin.intValue() < 1 || pin.intValue() > arr.getCount()) {
+                        throw new BACnetServiceException(ErrorClass.property, ErrorCode.invalidArrayIndex);
+                    }
                 }
             }
         }

--- a/src/main/java/com/serotonin/bacnet4j/type/constructed/BACnetArray.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/constructed/BACnetArray.java
@@ -32,7 +32,10 @@ import java.util.List;
 
 import com.serotonin.bacnet4j.exception.BACnetException;
 import com.serotonin.bacnet4j.exception.BACnetRuntimeException;
+import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.type.Encodable;
+import com.serotonin.bacnet4j.type.enumerated.ErrorClass;
+import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
 
 public class BACnetArray<E extends Encodable> extends SequenceOf<E> {
@@ -66,6 +69,19 @@ public class BACnetArray<E extends Encodable> extends SequenceOf<E> {
 
     public BACnetArray(final ByteQueue queue, final Class<E> clazz, final int contextId) throws BACnetException {
         super(queue, clazz, contextId);
+    }
+
+    public void setSize(final int size, E defaultValue) throws BACnetServiceException {
+        if (size < 0) {
+            throw new BACnetServiceException(ErrorClass.property, ErrorCode.valueOutOfRange);
+        }
+        while (size != values.size()) {
+            if (size > values.size()) {
+                values.add(defaultValue);
+            } else {
+                values.remove(values.size() - 1);
+            }
+        }
     }
 
     public BACnetArray<E> putBase1(final int indexBase1, final E value) {

--- a/src/test/java/com/serotonin/bacnet4j/obj/BACnetObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/BACnetObjectTest.java
@@ -160,6 +160,15 @@ public class BACnetObjectTest extends AbstractTest {
     }
 
     @Test
+    public void undefinedArrayWriteDataToArraySize() {
+        TestUtils.assertBACnetServiceException(() -> {
+            d2.getObject(d2.getId()).writeProperty(null,
+                    new PropertyValue(PropertyIdentifier.forId(6789), UnsignedInteger.ZERO, new UnsignedInteger(10),
+                            null));
+        }, ErrorClass.property, ErrorCode.writeAccessDenied);
+    }
+
+    @Test
     public void undefinedArrayWriteElementLowIndex() {
         // Returns invalid data type because the index of 0 indicates a write to the array length, which expects
         // an UnsignedInteger

--- a/src/test/java/com/serotonin/bacnet4j/obj/MultistateOutputObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/MultistateOutputObjectTest.java
@@ -31,13 +31,11 @@ import static com.serotonin.bacnet4j.TestUtils.awaitEquals;
 import static com.serotonin.bacnet4j.TestUtils.quiesce;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import com.serotonin.bacnet4j.AbstractTest;
-import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.type.AmbiguousValue;
 import com.serotonin.bacnet4j.type.constructed.BACnetArray;
 import com.serotonin.bacnet4j.type.constructed.Destination;
@@ -48,8 +46,6 @@ import com.serotonin.bacnet4j.type.constructed.Recipient;
 import com.serotonin.bacnet4j.type.constructed.SequenceOf;
 import com.serotonin.bacnet4j.type.constructed.StatusFlags;
 import com.serotonin.bacnet4j.type.constructed.TimeStamp;
-import com.serotonin.bacnet4j.type.enumerated.ErrorClass;
-import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
 import com.serotonin.bacnet4j.type.enumerated.EventState;
 import com.serotonin.bacnet4j.type.enumerated.EventType;
 import com.serotonin.bacnet4j.type.enumerated.NotifyType;
@@ -79,37 +75,24 @@ public class MultistateOutputObjectTest extends AbstractTest {
     @Test
     public void initialization() throws Exception {
         new MultistateOutputObject(d1, 1, "mo1", 7, null, 1, 1, false);
-
-        try {
-            new MultistateOutputObject(d1, 2, "mv2", 0, null, 1, 1, false);
-            Assert.fail("Should have thrown an IllegalArgumentException");
-        } catch (@SuppressWarnings("unused") final IllegalArgumentException e) {
-            // Expected
-        }
+        assertThrows(IllegalArgumentException.class,
+                () -> new MultistateOutputObject(d1, 2, "mv2", 0, null, 1, 1, false));
     }
 
     @Test
-    public void inconsistentStateText() throws Exception {
-        try {
-            new MultistateOutputObject(d1, 1, "mv1", 7, new BACnetArray<>(new CharacterString("a")), 1, 1, true);
-            Assert.fail("Should have thrown an IllegalArgumentException");
-        } catch (@SuppressWarnings("unused") final IllegalArgumentException e) {
-            // Expected
-        }
+    public void inconsistentStateText() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new MultistateOutputObject(d1, 1, "mv1", 7, new BACnetArray<>(new CharacterString("a")), 1, 1,
+                        true));
     }
 
     @Test
     public void missingStateText() throws Exception {
         final MultistateOutputObject mv = new MultistateOutputObject(d1, 1, "mv1", 7, null, 1, 1, true);
 
-        try {
-            mv.writeProperty(null,
-                    new PropertyValue(PropertyIdentifier.stateText, new BACnetArray<>(new CharacterString("a"))));
-            fail("Should have thrown an exception");
-        } catch (final BACnetServiceException e) {
-            assertEquals(ErrorClass.property, e.getErrorClass());
-            assertEquals(ErrorCode.inconsistentConfiguration, e.getErrorCode());
-        }
+        mv.writeProperty(null,
+                new PropertyValue(PropertyIdentifier.stateText, new BACnetArray<>(new CharacterString("a"))));
+        assertEquals(new UnsignedInteger(1), mv.get(PropertyIdentifier.numberOfStates));
     }
 
     @Test

--- a/src/test/java/com/serotonin/bacnet4j/obj/MultistateValueObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/MultistateValueObjectTest.java
@@ -28,18 +28,14 @@
 package com.serotonin.bacnet4j.obj;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import com.serotonin.bacnet4j.AbstractTest;
-import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.type.constructed.BACnetArray;
 import com.serotonin.bacnet4j.type.constructed.PropertyValue;
 import com.serotonin.bacnet4j.type.constructed.StatusFlags;
-import com.serotonin.bacnet4j.type.enumerated.ErrorClass;
-import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
 import com.serotonin.bacnet4j.type.primitive.CharacterString;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
@@ -48,38 +44,29 @@ public class MultistateValueObjectTest extends AbstractTest {
     @Test
     public void initialization() throws Exception {
         final MultistateValueObject mv = new MultistateValueObject(d1, 1, "mv1", 7, null, 1, false);
+        // Allowed to create with a number of states but no text.
         assertEquals(new StatusFlags(false, false, false, false), mv.get(PropertyIdentifier.statusFlags));
 
-        try {
-            new MultistateValueObject(d1, 2, "mv2", 0, null, 1, false);
-            Assert.fail("Should have thrown an IllegalArgumentException");
-        } catch (@SuppressWarnings("unused") final IllegalArgumentException e) {
-            // Expected
-        }
+        // Not allowed to create with 0 states.
+        assertThrows(IllegalArgumentException.class, () -> new MultistateValueObject(d1, 2, "mv2", 0, null, 1, false));
     }
 
     @Test
-    public void inconsistentStateText() throws Exception {
-        try {
-            new MultistateValueObject(d1, 0, "mv0", 7, new BACnetArray<>(new CharacterString("a")), 1, true);
-            Assert.fail("Should have thrown an IllegalArgumentException");
-        } catch (@SuppressWarnings("unused") final IllegalArgumentException e) {
-            // Expected
-        }
+    public void inconsistentStateText() {
+        // Can't create when number of states doesn't match the length of state text.
+        assertThrows(IllegalArgumentException.class,
+                () -> new MultistateValueObject(d1, 0, "mv0", 7, new BACnetArray<>(new CharacterString("a")), 1, true));
     }
 
     @Test
     public void missingStateText() throws Exception {
+        // Allowed to create with a number of states but no text.
         final MultistateValueObject mv = new MultistateValueObject(d1, 0, "mv0", 7, null, 1, true);
 
-        try {
-            mv.writeProperty(null,
-                    new PropertyValue(PropertyIdentifier.stateText, new BACnetArray<>(new CharacterString("a"))));
-            fail("Should have thrown an exception");
-        } catch (final BACnetServiceException e) {
-            assertEquals(ErrorClass.property, e.getErrorClass());
-            assertEquals(ErrorCode.inconsistentConfiguration, e.getErrorCode());
-        }
+        // If the state text array is written, change the number of states to match.
+        mv.writeProperty(null,
+                new PropertyValue(PropertyIdentifier.stateText, new BACnetArray<>(new CharacterString("a"))));
+        assertEquals(new UnsignedInteger(1), mv.get(PropertyIdentifier.numberOfStates));
     }
 
     @Test

--- a/src/test/java/com/serotonin/bacnet4j/type/constructed/BACnetArrayTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/type/constructed/BACnetArrayTest.java
@@ -28,11 +28,12 @@
 package com.serotonin.bacnet4j.type.constructed;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import com.serotonin.bacnet4j.exception.BACnetRuntimeException;
+import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.type.primitive.CharacterString;
 
 public class BACnetArrayTest {
@@ -44,22 +45,41 @@ public class BACnetArrayTest {
         arr.setBase1(1, new CharacterString("A"));
         arr.setBase1(3, new CharacterString("C"));
         assertEquals(3, arr.getCount());
-        assertEquals(arr.getBase1(1), new CharacterString("A"));
-        assertEquals(arr.getBase1(2), CharacterString.EMPTY);
-        assertEquals(arr.getBase1(3), new CharacterString("C"));
+        assertEquals(new CharacterString("A"), arr.getBase1(1));
+        assertEquals(CharacterString.EMPTY, arr.getBase1(2));
+        assertEquals(new CharacterString("C"), arr.getBase1(3));
 
-        try {
-            arr.remove(2);
-            Assert.fail("Should have failed");
-        } catch (@SuppressWarnings("unused") final BACnetRuntimeException e) {
-            // no op
-        }
+        assertThrows(BACnetRuntimeException.class, () -> arr.remove(2));
+        assertThrows(BACnetRuntimeException.class, () -> arr.add(CharacterString.EMPTY));
+    }
 
-        try {
-            arr.add(new CharacterString("D"));
-            Assert.fail("Should have failed");
-        } catch (@SuppressWarnings("unused") final BACnetRuntimeException e) {
-            // no op
-        }
+    @Test
+    public void changeSize() throws BACnetServiceException {
+        final BACnetArray<CharacterString> arr = new BACnetArray<>(
+                new CharacterString("a"),
+                new CharacterString("b"),
+                new CharacterString("c"),
+                new CharacterString("d")
+        );
+
+        arr.setSize(7, CharacterString.EMPTY);
+        assertEquals(7, arr.getCount());
+        assertEquals(new CharacterString("a"), arr.getBase1(1));
+        assertEquals(new CharacterString("b"), arr.getBase1(2));
+        assertEquals(new CharacterString("c"), arr.getBase1(3));
+        assertEquals(new CharacterString("d"), arr.getBase1(4));
+        assertEquals(CharacterString.EMPTY, arr.getBase1(5));
+        assertEquals(CharacterString.EMPTY, arr.getBase1(6));
+        assertEquals(CharacterString.EMPTY, arr.getBase1(7));
+
+        arr.setSize(2, CharacterString.EMPTY);
+        assertEquals(2, arr.getCount());
+        assertEquals(new CharacterString("a"), arr.getBase1(1));
+        assertEquals(new CharacterString("b"), arr.getBase1(2));
+
+        assertThrows(BACnetServiceException.class, () -> arr.setSize(-1, CharacterString.EMPTY));
+
+        arr.setSize(0, CharacterString.EMPTY);
+        assertEquals(0, arr.getCount());
     }
 }


### PR DESCRIPTION
Arrays (including sequences) in BACnet are 1-indexed, where the 0 index property represents the length of the array. This property is writable for Arrays, allowing it to be resized by client code. BACnet4J did not previously support this ability, but this PR addresses that.

In particular, it allows the length of the state text array in a multistate to be changed in three ways: by rewriting the entire array object (already supported), by changing the value of the "number of states" property (already supported), and now by changing the 0-value of the state text array (which also updates the "number of states" value).

Tests were previously incorrect in disallowing a state text array from being of a size that did not match the number of states. The spec states that changing one should update the other.