### PR TITLE
MANGO-2640 Fix BBMD problems re wildcard addresses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,13 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>pl.pragmatists</groupId>
+            <artifactId>JUnitParams</artifactId>
+            <version>1.1.1</version>
+            <scope>test</scope>
+        </dependency>
+        
     </dependencies>
     <issueManagement>
         <url>https://github.com/infiniteautomation/BACnet4J/issues</url>

--- a/src/main/java/com/serotonin/bacnet4j/LocalDevice.java
+++ b/src/main/java/com/serotonin/bacnet4j/LocalDevice.java
@@ -365,7 +365,7 @@ public class LocalDevice implements AutoCloseable {
         //
         // Send restart notifications.
 
-        // The defaulting of the list of receipients is done here because sometimes the network has to be initialized
+        // The defaulting of the list of recipients is done here because sometimes the network has to be initialized
         // before the local broadcast address is known.
         SequenceOf<Recipient> restartNotificationRecipients = getPersistence().loadSequenceOf(
                 deviceObject.getPersistenceKey(PropertyIdentifier.restartNotificationRecipients), Recipient.class);

--- a/src/main/java/com/serotonin/bacnet4j/npdu/ip/IpNetworkUtils.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/ip/IpNetworkUtils.java
@@ -198,4 +198,29 @@ public class IpNetworkUtils {
         sb.append(addr & 0xFF);
         return sb.toString();
     }
+
+    public static boolean matchWithMask(String address1, String address2, String mask) {
+        return matchWithMask(IpAddressUtils.toIpAddress(address1), IpAddressUtils.toIpAddress(address2),
+                IpAddressUtils.toIpAddress(mask));
+    }
+
+    /**
+     * Determines if the given addresses are equal when applying the given mask. All arrays must have at least 4 bytes,
+     * and only those 4 bytes are considered.
+     *
+     * @param address1 the first address to match
+     * @param address2 the second address to match
+     * @param mask     the mask to apply
+     * @return true if the addresses match
+     */
+    public static boolean matchWithMask(byte[] address1, byte[] address2, byte[] mask) {
+        for (int i = 0; i < 4; i++) {
+            final int b1 = address1[i] & mask[i];
+            final int b2 = address2[i] & mask[i];
+            if (b1 != b2) {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/src/test/java/com/serotonin/bacnet4j/npdu/ip/IpNetworkDistributeBroadcastToNetworkTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/npdu/ip/IpNetworkDistributeBroadcastToNetworkTest.java
@@ -1,0 +1,151 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2025 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
+package com.serotonin.bacnet4j.npdu.ip;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.net.InetSocketAddress;
+import java.time.Clock;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.serotonin.bacnet4j.LocalDevice;
+import com.serotonin.bacnet4j.transport.Transport;
+import com.serotonin.bacnet4j.type.constructed.Address;
+import com.serotonin.bacnet4j.type.primitive.OctetString;
+import com.serotonin.bacnet4j.util.sero.ByteQueue;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+
+@RunWith(JUnitParamsRunner.class)
+public class IpNetworkDistributeBroadcastToNetworkTest {
+    // Note that this is not the default port. This is to ensure the default isn't assumed when it shouldn't be.
+    int port = 47806;
+    LocalDevice localDevice;
+    IpNetwork network;
+
+    void setUp(boolean wildcard) throws Exception {
+        var bindAddress = wildcard ? "0.0.0.0" : "1.2.3.4";
+
+        network = spy(new IpNetworkBuilder()
+                .withLocalBindAddress(bindAddress)
+                .withBroadcast("1.2.3.255", 24)
+                .withPort(port)
+                .build());
+
+        doNothing().when(network).listen(any());
+        doReturn(null).when(network).createSocket(any());
+        doReturn(null).when(network).parseNpduData(any(), any());
+        doNothing().when(network).sendPacket(any(), any());
+        doNothing().when(network).sendToBDT(any(), any());
+        doReturn(List.of(
+                new Address(IpNetworkUtils.toOctetString("0.0.0.0", port)),
+                new Address(IpNetworkUtils.toOctetString("1.2.3.4", port))
+        )).when(network).getLocalAddressList();
+
+        localDevice = mock(LocalDevice.class);
+        Transport transport = mock(Transport.class);
+        doReturn(localDevice).when(transport).getLocalDevice();
+        network.initialize(transport);
+        network.enableBBMD();
+    }
+
+    byte[] getResponse(boolean nak) {
+        final ByteQueue response = new ByteQueue();
+        response.push(IpNetwork.BVLC_TYPE);
+        response.push(0); // Response type
+        response.pushU2B(6); // Length
+        response.pushU2B(nak ? 0x60 : 0x0);
+        return response.popAll();
+    }
+
+    @Test
+    @Parameters({"false", "true"})
+    public void unknownForeignDevice(boolean wildcard) throws Exception {
+        setUp(wildcard);
+        ByteQueue queue = new ByteQueue();
+        queue.push(IpNetwork.BVLC_TYPE);
+        queue.push(0x9); // Distribute-Broadcast-To-Network
+        queue.pushShort((short) 4); // Length
+
+        OctetString linkService = IpNetworkUtils.toOctetString("2.3.4.5", port);
+        network.handleIncomingDataImpl(queue, linkService);
+
+        verify(network, times(1)).sendPacket(any(), any());
+        verify(network).sendPacket(IpNetworkUtils.getInetSocketAddress(linkService), getResponse(true));
+        verify(network, never()).parseNpduData(any(), any());
+    }
+
+    @Test
+    @Parameters({"false", "true"})
+    public void bdtAndFdtDistribution(boolean wildcard) throws Exception {
+        setUp(wildcard);
+        doReturn(Clock.systemUTC()).when(localDevice).getClock();
+
+        network.writeFDT(List.of(
+                network.new FDTEntry(new InetSocketAddress("2.3.4.5", port), 1000),
+                network.new FDTEntry(new InetSocketAddress("3.4.5.6", port), 1200)
+        ));
+
+        var otherBdtEntry = new IpNetwork.BDTEntry("1.2.4.4", port);
+        network.writeBDT(List.of(new IpNetwork.BDTEntry("1.2.3.4", port), otherBdtEntry));
+
+        ByteQueue queue = new ByteQueue();
+        queue.push(IpNetwork.BVLC_TYPE);
+        queue.push(0x9); // Distribute-Broadcast-To-Network
+        queue.pushShort((short) 4); // Length
+
+        OctetString linkService = IpNetworkUtils.toOctetString("2.3.4.5", port);
+        network.handleIncomingDataImpl((ByteQueue) queue.clone(), linkService);
+
+        ByteQueue fwd = new ByteQueue();
+        fwd.push(IpNetwork.BVLC_TYPE);
+        fwd.push(4); // Forward
+        fwd.pushU2B(10); // Length
+        fwd.push(linkService.getBytes()); // Origin
+        var data = fwd.popAll();
+
+        verify(network, times(3)).sendPacket(any(), any());
+        verify(network).sendPacket(InetAddrCache.get("1.2.3.255", port), data);
+        verify(network, times(1)).sendToBDT(any(), any());
+        verify(network).sendToBDT(otherBdtEntry, data);
+        verify(network).sendPacket(InetAddrCache.get("3.4.5.6", port), data);
+        verify(network).sendPacket(IpNetworkUtils.getInetSocketAddress(linkService), getResponse(false));
+        verify(network).parseNpduData(any(), any());
+    }
+}

--- a/src/test/java/com/serotonin/bacnet4j/npdu/ip/IpNetworkForwardNPDUTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/npdu/ip/IpNetworkForwardNPDUTest.java
@@ -1,0 +1,252 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2025 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
+package com.serotonin.bacnet4j.npdu.ip;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.net.InetSocketAddress;
+import java.time.Clock;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.serotonin.bacnet4j.LocalDevice;
+import com.serotonin.bacnet4j.transport.Transport;
+import com.serotonin.bacnet4j.type.constructed.Address;
+import com.serotonin.bacnet4j.type.primitive.OctetString;
+import com.serotonin.bacnet4j.util.sero.ByteQueue;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+
+@RunWith(JUnitParamsRunner.class)
+public class IpNetworkForwardNPDUTest {
+    // Note that this is not the default port. This is to ensure the default isn't assumed when it shouldn't be.
+    int port = 47806;
+    LocalDevice localDevice;
+    IpNetwork network;
+
+    void setUp(boolean wildcard) throws Exception {
+        var bindAddress = wildcard ? "0.0.0.0" : "1.2.3.4";
+
+        network = spy(new IpNetworkBuilder()
+                .withLocalBindAddress(bindAddress)
+                .withBroadcast("1.2.3.255", 24)
+                .withPort(port)
+                .build());
+
+        doNothing().when(network).listen(any());
+        doReturn(null).when(network).createSocket(any());
+        doReturn(null).when(network).parseNpduData(any(), any());
+        doNothing().when(network).sendPacket(any(), any());
+        doReturn(List.of(
+                new Address(IpNetworkUtils.toOctetString("0.0.0.0", port)),
+                new Address(IpNetworkUtils.toOctetString("1.2.3.4", port))
+        )).when(network).getLocalAddressList();
+
+        localDevice = mock(LocalDevice.class);
+        Transport transport = mock(Transport.class);
+        doReturn(localDevice).when(transport).getLocalDevice();
+        network.initialize(transport);
+        network.enableBBMD();
+    }
+
+    @Test
+    @Parameters({"false", "true"})
+    public void fromSameLinkService(boolean wildcard) throws Exception {
+        setUp(wildcard);
+        ByteQueue queue = new ByteQueue();
+        queue.push(IpNetwork.BVLC_TYPE);
+        queue.push(0x4); // Forwarded-NPDU
+        queue.pushShort((short) 4); // Length
+
+        OctetString linkService = IpNetworkUtils.toOctetString("1.2.3.4", port);
+        network.handleIncomingDataImpl(queue, linkService);
+
+        // If the link service matches the local bind address then the NPDU was forwarded to itself, and should be
+        // ignored.
+        verify(network, never()).forwardNPDU(any(), any());
+    }
+
+    @Test
+    @Parameters({"false", "true"})
+    public void noBDTorFDTEntries(boolean wildcard) throws Exception {
+        setUp(wildcard);
+        // Clear the default value out of the BDT.
+        network.writeBDT(List.of());
+
+        ByteQueue queue = new ByteQueue();
+        queue.push(IpNetwork.BVLC_TYPE);
+        queue.push(0x4); // Forwarded-NPDU
+        queue.pushShort((short) 10); // Length
+        queue.push(IpNetworkUtils.toOctetString("2.3.4.5", port).getBytes());
+
+        OctetString linkService = IpNetworkUtils.toOctetString("1.2.3.40", port);
+        network.handleIncomingDataImpl(queue, linkService);
+
+        // If the link service matches the local bind address then the NPDU was forwarded to itself, and should be
+        // ignored.
+        verify(network, never()).sendPacket(any(), any());
+    }
+
+    @Test
+    @Parameters({"false", "true"})
+    public void fromLinkServiceInSameNetworkSegment(boolean wildcard) throws Exception {
+        setUp(wildcard);
+        ByteQueue queue = new ByteQueue();
+        queue.push(IpNetwork.BVLC_TYPE);
+        queue.push(0x4); // Forwarded-NPDU
+        queue.pushShort((short) 10); // Length
+        queue.push(IpNetworkUtils.toOctetString("2.3.4.5", port).getBytes());
+
+        OctetString linkService = IpNetworkUtils.toOctetString("1.2.3.40", port);
+        network.handleIncomingDataImpl(queue, linkService);
+
+        // If the network portion of the link service matches that of the local bind address then the NPDU was forwarded
+        // from a device in the same local network, and so should be ignored.
+        verify(network, never()).sendPacket(any(), any());
+    }
+
+    @Test
+    @Parameters({"false", "true"})
+    public void noMatchingBDTEntry(boolean wildcard) throws Exception {
+        setUp(wildcard);
+        // Replace the BDT with an entry that doesn't match the local address. This should not actually happen except
+        // in the case of a configuration error.
+        network.writeBDT(List.of(new IpNetwork.BDTEntry("1.2.3.4", port + 1)));
+
+        ByteQueue queue = new ByteQueue();
+        queue.push(IpNetwork.BVLC_TYPE);
+        queue.push(0x4); // Forwarded-NPDU
+        queue.pushShort((short) 10); // Length
+        queue.push(IpNetworkUtils.toOctetString("2.3.4.5", port).getBytes()); // Message OP
+
+        OctetString linkService = IpNetworkUtils.toOctetString("1.2.4.4", port);
+        network.handleIncomingDataImpl(queue, linkService);
+
+        // If the network portion of the link service matches that of the local bind address then the NPDU was forwarded
+        // from a device in the same local network, and so should be ignored.
+        verify(network, never()).sendPacket(any(), any());
+    }
+
+    @Test
+    @Parameters({"false", "true"})
+    public void nonOnesDistributionMask(boolean wildcard) throws Exception {
+        setUp(wildcard);
+        // Replace the BDT with an entry that doesn't have the default distribution mask.
+        network.writeBDT(List.of(new IpNetwork.BDTEntry("1.2.3.4", port, "255.255.255.250")));
+
+        ByteQueue queue = new ByteQueue();
+        queue.push(IpNetwork.BVLC_TYPE);
+        queue.push(0x4); // Forwarded-NPDU
+        queue.pushShort((short) 10); // Length
+        queue.push(IpNetworkUtils.toOctetString("2.3.4.5", port).getBytes());
+
+        OctetString linkService = IpNetworkUtils.toOctetString("1.2.4.4", port);
+        network.handleIncomingDataImpl(queue, linkService);
+
+        // If the network portion of the link service matches that of the local bind address then the NPDU was forwarded
+        // from a device in the same local network, and so should be ignored.
+        verify(network, never()).sendPacket(any(), any());
+    }
+
+    @Test
+    @Parameters({"false", "true"})
+    public void bdtDistribution(boolean wildcard) throws Exception {
+        setUp(wildcard);
+        ByteQueue queue = new ByteQueue();
+        queue.push(IpNetwork.BVLC_TYPE);
+        queue.push(0x4); // Forwarded-NPDU
+        queue.pushShort((short) 10); // Length
+        queue.push(IpNetworkUtils.toOctetString("2.3.4.5", port).getBytes());
+
+        OctetString linkService = IpNetworkUtils.toOctetString("1.2.2.4", port);
+        network.handleIncomingDataImpl((ByteQueue) queue.clone(), linkService);
+
+        // Message is resent verbatim on the local broadcast address.
+        verify(network).sendPacket(InetAddrCache.get("1.2.3.255", port), queue.popAll());
+    }
+
+    @Test
+    @Parameters({"false", "true"})
+    public void bdtAndFdtDistribution(boolean wildcard) throws Exception {
+        setUp(wildcard);
+        doReturn(Clock.systemUTC()).when(localDevice).getClock();
+
+        network.writeFDT(List.of(
+                network.new FDTEntry(new InetSocketAddress("2.3.4.5", port), 1000),
+                network.new FDTEntry(new InetSocketAddress("3.4.5.6", port), 1200)
+        ));
+
+        ByteQueue queue = new ByteQueue();
+        queue.push(IpNetwork.BVLC_TYPE);
+        queue.push(0x4); // Forwarded-NPDU
+        queue.pushShort((short) 10); // Length
+        queue.push(IpNetworkUtils.toOctetString("2.3.4.5", port).getBytes());
+
+        OctetString linkService = IpNetworkUtils.toOctetString("1.2.2.4", port);
+        network.handleIncomingDataImpl((ByteQueue) queue.clone(), linkService);
+
+        byte[] data = queue.popAll();
+        verify(network).sendPacket(InetAddrCache.get("1.2.3.255", port), data);
+        verify(network).sendPacket(InetAddrCache.get("2.3.4.5", port), data);
+        verify(network).sendPacket(InetAddrCache.get("3.4.5.6", port), data);
+    }
+
+    @Test
+    @Parameters({"false", "true"})
+    public void fdtDistribution(boolean wildcard) throws Exception {
+        setUp(wildcard);
+        doReturn(Clock.systemUTC()).when(localDevice).getClock();
+
+        network.writeFDT(List.of(
+                network.new FDTEntry(new InetSocketAddress("2.3.4.5", port), 1000),
+                network.new FDTEntry(new InetSocketAddress("3.4.5.6", port), 1200)
+        ));
+
+        ByteQueue queue = new ByteQueue();
+        queue.push(IpNetwork.BVLC_TYPE);
+        queue.push(0x4); // Forwarded-NPDU
+        queue.pushShort((short) 10); // Length
+        queue.push(IpNetworkUtils.toOctetString("2.3.4.5", port).getBytes());
+
+        OctetString linkService = IpNetworkUtils.toOctetString("1.2.3.40", port);
+        network.handleIncomingDataImpl((ByteQueue) queue.clone(), linkService);
+
+        byte[] data = queue.popAll();
+        verify(network).sendPacket(InetAddrCache.get("2.3.4.5", port), data);
+        verify(network).sendPacket(InetAddrCache.get("3.4.5.6", port), data);
+    }
+}

--- a/src/test/java/com/serotonin/bacnet4j/npdu/ip/IpNetworkOriginalBroadcastTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/npdu/ip/IpNetworkOriginalBroadcastTest.java
@@ -1,0 +1,174 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2025 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
+package com.serotonin.bacnet4j.npdu.ip;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.net.InetSocketAddress;
+import java.time.Clock;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.serotonin.bacnet4j.LocalDevice;
+import com.serotonin.bacnet4j.transport.Transport;
+import com.serotonin.bacnet4j.type.constructed.Address;
+import com.serotonin.bacnet4j.type.primitive.OctetString;
+import com.serotonin.bacnet4j.util.BACnetUtils;
+import com.serotonin.bacnet4j.util.sero.ByteQueue;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+
+@RunWith(JUnitParamsRunner.class)
+public class IpNetworkOriginalBroadcastTest {
+    // Note that this is not the default port. This is to ensure the default isn't assumed when it shouldn't be.
+    int port = 47806;
+    LocalDevice localDevice;
+    IpNetwork network;
+
+    void setUp(boolean wildcard) throws Exception {
+        var bindAddress = wildcard ? "0.0.0.0" : "1.2.3.4";
+
+        network = spy(new IpNetworkBuilder()
+                .withLocalBindAddress(bindAddress)
+                .withBroadcast("1.2.3.255", 24)
+                .withPort(port)
+                .build());
+
+        doNothing().when(network).listen(any());
+        doReturn(null).when(network).createSocket(any());
+        doReturn(null).when(network).parseNpduData(any(), any());
+        doNothing().when(network).sendPacket(any(), any());
+        doNothing().when(network).sendToBDT(any(), any());
+        doReturn(List.of(
+                new Address(IpNetworkUtils.toOctetString("0.0.0.0", port)),
+                new Address(IpNetworkUtils.toOctetString("1.2.3.4", port))
+        )).when(network).getLocalAddressList();
+
+        localDevice = mock(LocalDevice.class);
+        Transport transport = mock(Transport.class);
+        doReturn(localDevice).when(transport).getLocalDevice();
+        network.initialize(transport);
+        network.enableBBMD();
+    }
+
+    @Test
+    @Parameters({"false", "true"})
+    public void noBDTorFDTEntries(boolean wildcard) throws Exception {
+        setUp(wildcard);
+        // Clear the default value out of the BDT.
+        network.writeBDT(List.of());
+
+        ByteQueue queue = new ByteQueue();
+        queue.push(IpNetwork.BVLC_TYPE);
+        queue.push(0xB); // Original-Broadcast-NPDU
+        queue.pushShort((short) 4); // Length
+
+        OctetString linkService = IpNetworkUtils.toOctetString("1.2.3.40", port);
+        network.handleIncomingDataImpl(queue, linkService);
+
+        // If the link service matches the local bind address then the NPDU was forwarded to itself, and should be
+        // ignored.
+        verify(network).originalBroadcast(queue, linkService);
+        verify(network, never()).sendToBDT(any(), any());
+        verify(network, never()).sendPacket(any(), any());
+    }
+
+    @Test
+    @Parameters({"false", "true"})
+    public void bdtDistribution(boolean wildcard) throws Exception {
+        setUp(wildcard);
+        var otherBdtEntry = new IpNetwork.BDTEntry("1.2.4.4", port);
+
+        network.writeBDT(List.of(new IpNetwork.BDTEntry("1.2.3.4", port), otherBdtEntry));
+
+        ByteQueue queue = new ByteQueue();
+        queue.push(IpNetwork.BVLC_TYPE);
+        queue.push(0xB); // Original-Broadcast-NPDU
+        queue.pushShort((short) 4); // Length
+
+        OctetString linkService = IpNetworkUtils.toOctetString("1.2.2.4", port);
+        network.handleIncomingDataImpl((ByteQueue) queue.clone(), linkService);
+
+        final ByteQueue fwd = new ByteQueue();
+        fwd.push(IpNetwork.BVLC_TYPE);
+        fwd.push(4); // Forward
+        fwd.pushU2B(10); // Length
+        fwd.push(BACnetUtils.dottedStringToBytes("1.2.2.4")); // Origin
+        fwd.pushShort((short) port);
+
+        // Message is resent verbatim on the local broadcast address.
+        verify(network).originalBroadcast(new ByteQueue(), linkService);
+        verify(network, times(1)).sendToBDT(any(), any());
+        verify(network).sendToBDT(otherBdtEntry, fwd.popAll());
+        verify(network, never()).sendPacket(any(), any());
+    }
+
+    @Test
+    @Parameters({"false", "true"})
+    public void fdtDistribution(boolean wildcard) throws Exception {
+        setUp(wildcard);
+        doReturn(Clock.systemUTC()).when(localDevice).getClock();
+
+        network.writeFDT(List.of(
+                network.new FDTEntry(new InetSocketAddress("2.3.4.5", port), 1000),
+                network.new FDTEntry(new InetSocketAddress("3.4.5.6", port), 1200)
+        ));
+
+        ByteQueue queue = new ByteQueue();
+        queue.push(IpNetwork.BVLC_TYPE);
+        queue.push(0xB); // Original-Broadcast-NPDU
+        queue.pushShort((short) 4); // Length
+
+        OctetString linkService = IpNetworkUtils.toOctetString("1.2.3.40", port);
+        network.handleIncomingDataImpl((ByteQueue) queue.clone(), linkService);
+
+        final ByteQueue fwd = new ByteQueue();
+        fwd.push(IpNetwork.BVLC_TYPE);
+        fwd.push(4); // Forward
+        fwd.pushU2B(10); // Length
+        fwd.push(BACnetUtils.dottedStringToBytes("1.2.3.40")); // Origin
+        fwd.pushShort((short) port);
+        var data = fwd.popAll();
+
+        verify(network).originalBroadcast(new ByteQueue(), linkService);
+        verify(network, never()).sendToBDT(any(), any());
+        verify(network, times(2)).sendPacket(any(), any());
+        verify(network).sendPacket(InetAddrCache.get("2.3.4.5", port), data);
+        verify(network).sendPacket(InetAddrCache.get("3.4.5.6", port), data);
+    }
+}

--- a/src/test/java/com/serotonin/bacnet4j/npdu/ip/IpNetworkOriginalBroadcastTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/npdu/ip/IpNetworkOriginalBroadcastTest.java
@@ -82,8 +82,9 @@ public class IpNetworkOriginalBroadcastTest {
         localDevice = mock(LocalDevice.class);
         Transport transport = mock(Transport.class);
         doReturn(localDevice).when(transport).getLocalDevice();
-        network.initialize(transport);
+        // Ensure that BBMD can be enabled before the network is initialized.
         network.enableBBMD();
+        network.initialize(transport);
     }
 
     @Test

--- a/src/test/java/com/serotonin/bacnet4j/npdu/ip/IpNetworkUtilsTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/npdu/ip/IpNetworkUtilsTest.java
@@ -28,6 +28,8 @@
 package com.serotonin.bacnet4j.npdu.ip;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -67,5 +69,15 @@ public class IpNetworkUtilsTest {
         assertEquals(0xFFFFFFFCL, IpNetworkUtils.createMask(30));
         assertEquals(0xFFFFFFFEL, IpNetworkUtils.createMask(31));
         assertEquals(0xFFFFFFFFL, IpNetworkUtils.createMask(32));
+    }
+
+    @Test
+    public void matchWithMask() {
+        assertTrue(IpNetworkUtils.matchWithMask("1.2.3.4", "1.2.3.5", "255.255.255.0"));
+        assertTrue(IpNetworkUtils.matchWithMask("1.2.3.4", "1.2.3.5", "255.255.255.254"));
+        assertFalse(IpNetworkUtils.matchWithMask("1.2.3.4", "1.2.3.5", "255.255.255.255"));
+        assertTrue(IpNetworkUtils.matchWithMask("0.0.0.0", "255.255.255.255", "0.0.0.0"));
+        assertFalse(IpNetworkUtils.matchWithMask("0.0.0.0", "255.255.255.255", "128.0.0.0"));
+        assertFalse(IpNetworkUtils.matchWithMask("0.0.0.0", "255.255.255.255", "0.64.0.0"));
     }
 }


### PR DESCRIPTION
BBMD depends on knowing its own IP address so that it can recognize when, e.g. a forwarded messages was broadcast by itself, or an original messages was broadcast within its own local network. These behaviours were not working correctly in the case of a local bind address of 0.0.0.0. The fixes here introduce another field in `IpNetwork` called `localAddress` to represent a "canonical" version of the `localBindAddress`. If the bind address is not the wildcard address, then the two are the same. If it is the wild card address, the local interfaces are searched for the first IPv4 address that is not the wildcard address, and that is used instead.

In addition - mostly to facilitate testing - the `BDTEntry` and `FDTEntry` classes have been filled out a little so that they can be managed with user code. Also, since the spec requires that one of the BDT entries is the device itself, this entry is automatically created when BBMD is enabled.