### PR TITLE
MANGO-2609 Remove NAK message from segment final timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,19 @@ The dependency information is BACnet4J pre 5.0 is:
 
 Releases
 ========
+*Version 6.1.0*
+
+- Previously upon a final timeout for a segmented request or response, BACnet4J would issue a segment NAK to the peer  
+  device. This was deemed to be inappropriate, and so was removed.
+- Issues regarding the use of BACnet4J as a BBMD and initializing it with a wildcard bind address (i.e. 0.0.0.0) have
+  been fixed.
+- The means by which multistate text can be altered has been expanded. There are now four ways: 1) the state text
+  array can be rewritten entirely, 2) the number of states can be changed, 3) the size of the array can be changed by
+  writing a new value to the array's 0 index, and 4) by writing new individual state text values.
+- A request to an object for all properties will now also return proprietary properties.
+- The timeout for the termination of a local device can now be specified in user code.
+- Bug fixes and dependency upgrades.
+
 *Version 6.0.2*
 
 - Previously, when an IAm was received, calls to `DeviceEventListener.iAmReceived` would be called in the transport

--- a/src/main/java/com/serotonin/bacnet4j/service/confirmed/ConfirmedRequestService.java
+++ b/src/main/java/com/serotonin/bacnet4j/service/confirmed/ConfirmedRequestService.java
@@ -37,7 +37,7 @@ import com.serotonin.bacnet4j.type.constructed.ServicesSupported;
 import com.serotonin.bacnet4j.type.enumerated.RejectReason;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
 
-abstract public class ConfirmedRequestService extends Service {
+public abstract class ConfirmedRequestService extends Service {
     public static void checkConfirmedRequestService(final ServicesSupported services, final byte type)
             throws BACnetRejectException {
         if (type == AcknowledgeAlarmRequest.TYPE_ID && services.isAcknowledgeAlarm()) // 0
@@ -206,7 +206,7 @@ abstract public class ConfirmedRequestService extends Service {
         return result;
     }
 
-    abstract public AcknowledgementService handle(LocalDevice localDevice, Address from) throws BACnetException;
+    public abstract AcknowledgementService handle(LocalDevice localDevice, Address from) throws BACnetException;
 
     /**
      * This method determines whether responses to requests are sent when the device has had its communication set

--- a/src/main/java/com/serotonin/bacnet4j/transport/DefaultTransport.java
+++ b/src/main/java/com/serotonin/bacnet4j/transport/DefaultTransport.java
@@ -1019,24 +1019,6 @@ public class DefaultTransport implements Transport, Runnable {
                         if (ctx.getConsumer() == null) {
                             LOG.warn("Timeout waiting for segment(s)", timeoutEx);
                         }
-
-                        if (!ctx.getSegmentWindow().isEmpty()) {
-                            // Return a NAK with the last sequence id received in order and start over.
-                            // NOTE: Sending a NAK here is not appropriate
-                            // This is the "FinalTimeout" event described in the 2020 BACnet spec section
-                            // 5.4.4.2 (or maybe 5.4.5.4) In either case, sending a NAK is not part of the transition
-                            // to the next state. If 5.4.4.2, sending an ABORT is required as part of the transition.
-                            // The state machine only defines sending a NAK as part of the transition for the
-                            // "TooManyDuplicateSegmentsReceived" or "SegmentReceivedOutOfOrder" events
-                            try {
-                                network.sendAPDU(key.getAddress(), key.getLinkService(),
-                                        new SegmentACK(true, key.isFromServer(), key.getInvokeId(),
-                                                ctx.getSegmentWindow().getLatestSequenceId(),
-                                                ctx.getSegmentWindow().getWindowSize(), true), false);
-                            } catch (final BACnetException ex) {
-                                LOG.warn("Error sending NAK after timeout", ex);
-                            }
-                        }
                     }
                 }
 

--- a/src/test/java/com/serotonin/bacnet4j/transport/DefaultTransportTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/transport/DefaultTransportTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.inOrder;
@@ -116,11 +117,6 @@ public class DefaultTransportTest {
 
         // Clean up
         transport.terminate();
-
-        // Ensure the NAK was sent.
-        final SegmentACK nak = new SegmentACK(true, false, (byte) 0, 1, 3, true);
-        final ByteQueue nakNpdu = createNPDU(nak);
-        verify(network).sendNPDU(from, null, nakNpdu, false, nak.expectsReply());
     }
 
     private static ByteQueue createNPDU(final APDU apdu) {
@@ -422,9 +418,13 @@ public class DefaultTransportTest {
 
         assertThrows(BACnetTimeoutException.class, future::get);
 
-        // verify that 3 APDUs (1 request, 2 segAcks) and optionally the Broadcast NPDU were sent over the network
-        verify(network, times(3)).sendAPDU(any(), any(), any(), anyBoolean());
-        await(() -> sendNPDUInvokeCount.get() >= 3, 10000);
+        // verify that 2 APDUs (1 request, 1 segAck) and optionally the Broadcast NPDU were sent over the network
+        await(() -> sendNPDUInvokeCount.get() >= 2, 10000);
+        verify(network, times(2)).sendAPDU(any(), any(), any(), anyBoolean());
+        verify(network, times(1)).sendAPDU(eq(new Address(new byte[] {0x1})), eq(null), any(ConfirmedRequest.class),
+                eq(false));
+        var segAck = new SegmentACK(false, false, (byte) 0, 0, 2, true);
+        verify(network, times(1)).sendAPDU(new Address(new byte[] {0x1}), null, segAck, false);
 
         transport.terminate();
     }

--- a/src/test/java/com/serotonin/bacnet4j/transport/DefaultTransportTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/transport/DefaultTransportTest.java
@@ -62,7 +62,6 @@ import com.serotonin.bacnet4j.enums.MaxApduLength;
 import com.serotonin.bacnet4j.event.DeviceEventHandler;
 import com.serotonin.bacnet4j.exception.BACnetException;
 import com.serotonin.bacnet4j.exception.BACnetTimeoutException;
-import com.serotonin.bacnet4j.npdu.NPCI;
 import com.serotonin.bacnet4j.npdu.NPDU;
 import com.serotonin.bacnet4j.npdu.Network;
 import com.serotonin.bacnet4j.service.acknowledgement.ReadPropertyMultipleAck;
@@ -117,14 +116,6 @@ public class DefaultTransportTest {
 
         // Clean up
         transport.terminate();
-    }
-
-    private static ByteQueue createNPDU(final APDU apdu) {
-        final ByteQueue npdu = new ByteQueue();
-        final NPCI npci = new NPCI(null, null, apdu.expectsReply());
-        npci.write(npdu);
-        apdu.write(npdu);
-        return npdu;
     }
 
     private static Address getSourceAddress() {


### PR DESCRIPTION
The comment in the code was left by a contributor. After reviewing the specification i agree that the NAK message is not appropriate.

Segmented Response: If SegmentTimer becomes greater than Tseg and SegmentRetryCount is greater than or equal to
Number_Of_APDU_Retries, then stop the SegmentTimer, and enter the IDLE state.

Segmented Request: If SegmentTimer becomes greater than Tseg and SegmentRetryCount is greater than or equal to Nretry, then stop SegmentTimer; send ABORT.indication with 'server' = FALSE and 'abort-reason' = TSM_TIMEOUT to
the local application program; and enter the IDLE state.

The segmented response in fact only says that the state change to IDLE, but a timeout exception is issued to the future anyway (in the code above). This only results in the logging of a message, and so it was left.