### PR TITLE
MANGO-2633 Simplify the addition of character encodings

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ The dependency information is BACnet4J pre 5.0 is:
 
 Releases
 ========
+*Version 6.1.0*
+
+- The way in which new character encodings for `CharacterString`s can be added has been simplified. Thanks to
+  https://github.com/balbusm for this submission.
+
 *Version 6.0.2*
 
 - Previously, when an IAm was received, calls to `DeviceEventListener.iAmReceived` would be called in the transport

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/CharacterString.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/CharacterString.java
@@ -35,7 +35,6 @@ import static com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEn
 import java.util.List;
 import java.util.Objects;
 import java.util.ServiceLoader;
-import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import com.serotonin.bacnet4j.exception.BACnetErrorException;
@@ -47,10 +46,7 @@ import com.serotonin.bacnet4j.type.primitive.encoding.CharacterEncoding;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
 
 public class CharacterString extends Primitive {
-
     public static final byte TYPE_ID = 7;
-
-
 
     // load encoders before creating EMPTY
     private static final List<CharacterEncoder> characterEncoders = loadEncoders();
@@ -66,17 +62,17 @@ public class CharacterString extends Primitive {
     }
 
     /**
-     * According to Oracle java documentation about Charset, the behavior of optional charsets may vary between java
-     * platform implementations.
-     * This concerns ISO_10646_UCS_4 (UTF-32), IBM_MS_DBCS and JIS_C_6226.
-     *
-     * @param encoding
-     * @param value
+     * @deprecated use CharacterEncoding constructor instead.
      */
+    @Deprecated(since = "6.1.0")
     public CharacterString(final byte encoding, final String value) {
         this(new CharacterEncoding(encoding, defaultCodingPage(encoding)), value);
     }
 
+    /**
+     * According to Oracle java documentation about Charset, the behavior of optional charsets may vary between java
+     * platform implementations. This concerns ISO_10646_UCS_4 (UTF-32), IBM_MS_DBCS and JIS_C_6226.
+     */
     public CharacterString(final CharacterEncoding encoding, final String value) {
         this.encoding = encoding;
         try {
@@ -140,7 +136,7 @@ public class CharacterString extends Primitive {
     private CharacterEncoding createCharacterEncoding(ByteQueue queue) {
         byte encodingValue = queue.pop();
         if (encodingValue != IBM_MS_DBCS) {
-            return new CharacterEncoding(encodingValue, NO_CODE_PAGE);
+            return new CharacterEncoding(encodingValue);
         }
         //Decode the codePage
         int codePage = queue.popU2B();
@@ -167,8 +163,7 @@ public class CharacterString extends Primitive {
 
     private static List<CharacterEncoder> loadEncoders() {
         ServiceLoader<CharacterEncoder> loader = ServiceLoader.load(CharacterEncoder.class);
-        return StreamSupport.stream(loader.spliterator(), false)
-                .collect(Collectors.toList());
+        return StreamSupport.stream(loader.spliterator(), false).toList();
     }
 
     @Override

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/CharacterString.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/CharacterString.java
@@ -27,37 +27,42 @@
 
 package com.serotonin.bacnet4j.type.primitive;
 
-import java.io.UnsupportedEncodingException;
+import static com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEncodings.ANSI_X3_4;
+import static com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEncodings.CODE_PAGE_LATIN_1;
+import static com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEncodings.IBM_MS_DBCS;
+import static com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEncodings.NO_CODE_PAGE;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import com.serotonin.bacnet4j.exception.BACnetErrorException;
 import com.serotonin.bacnet4j.exception.BACnetRuntimeException;
 import com.serotonin.bacnet4j.type.enumerated.ErrorClass;
 import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
+import com.serotonin.bacnet4j.type.primitive.encoding.CharacterEncoder;
+import com.serotonin.bacnet4j.type.primitive.encoding.CharacterEncoding;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
 
 public class CharacterString extends Primitive {
+
     public static final byte TYPE_ID = 7;
-    public static final int IBM_MS_DBCS_CODEPAGE = 850;
 
 
-    public interface Encodings {
-        byte ANSI_X3_4 = 0;
-        byte IBM_MS_DBCS = 1;
-        byte JIS_C_6226 = 2;
-        byte ISO_10646_UCS_4 = 3;
-        byte ISO_10646_UCS_2 = 4;
-        byte ISO_8859_1 = 5;
-    }
 
+    // load encoders before creating EMPTY
+    private static final List<CharacterEncoder> characterEncoders = loadEncoders();
 
     public static final CharacterString EMPTY = new CharacterString("");
 
-    private final byte encoding;
+    private final CharacterEncoding encoding;
+    private final CharacterEncoder encoder;
     private final String value;
 
     public CharacterString(final String value) {
-        encoding = Encodings.ANSI_X3_4;
-        this.value = value == null ? "" : value;
+        this(new CharacterEncoding(ANSI_X3_4), value);
     }
 
     /**
@@ -69,22 +74,18 @@ public class CharacterString extends Primitive {
      * @param value
      */
     public CharacterString(final byte encoding, final String value) {
+        this(new CharacterEncoding(encoding, defaultCodingPage(encoding)), value);
+    }
+
+    public CharacterString(final CharacterEncoding encoding, final String value) {
+        this.encoding = encoding;
         try {
-            validateEncoding();
+            encoder = findEncoder(encoding);
         } catch (final BACnetErrorException e) {
             // This is an API constructor, so it doesn't need to throw checked exceptions. Convert to runtime.
             throw new BACnetRuntimeException(e);
         }
-        this.encoding = encoding;
         this.value = value == null ? "" : value;
-    }
-
-    public byte getEncoding() {
-        return encoding;
-    }
-
-    public String getValue() {
-        return value;
     }
 
     //
@@ -93,35 +94,34 @@ public class CharacterString extends Primitive {
     public CharacterString(final ByteQueue queue) throws BACnetErrorException {
         final int length = (int) readTag(queue, TYPE_ID);
 
-        encoding = queue.pop();
-        validateEncoding();
-        int headerLength = 1;
-        if (encoding == Encodings.IBM_MS_DBCS) {
-            headerLength += 2;
-            //Decode the codePage
-            int codePage = queue.popU2B();
-            //Currently only the codepage 850 is supported for IBM_MS_DBCS.
-            if (codePage != IBM_MS_DBCS_CODEPAGE) {
-                throw new BACnetErrorException(ErrorClass.property, ErrorCode.characterSetNotSupported,
-                        Byte.toString(encoding));
-            }
-        }
+        encoding = createCharacterEncoding(queue);
+        encoder = findEncoder(encoding);
+
+        int headerLength = calcHeaderLength();
 
         final byte[] bytes = new byte[length - headerLength];
         queue.pop(bytes);
 
-        value = decode(encoding, bytes);
+        value = encoder.decode(bytes);
+    }
+
+    public CharacterEncoding getEncoding() {
+        return encoding;
+    }
+
+    public String getValue() {
+        return value;
     }
 
     @Override
     public void writeImpl(final ByteQueue queue) {
-        queue.push(encoding);
-        queue.push(encode(encoding, value));
+        queue.push(encoding.getEncoding());
+        queue.push(encoder.encode(value));
     }
 
     @Override
     protected long getLength() {
-        return encode(encoding, value).length + 1;
+        return encoder.encode(value).length + 1;
     }
 
     @Override
@@ -129,88 +129,65 @@ public class CharacterString extends Primitive {
         return TYPE_ID;
     }
 
-    private static byte[] encode(final byte encoding, final String value) {
-        try {
-            switch (encoding) {
-                case Encodings.ANSI_X3_4:
-                    return value.getBytes("UTF-8");
-                case Encodings.ISO_10646_UCS_2:
-                    return value.getBytes("UTF-16");
-                case Encodings.ISO_8859_1:
-                    return value.getBytes("ISO-8859-1");
-                case Encodings.ISO_10646_UCS_4:
-                    return value.getBytes("UTF-32");
-                case Encodings.IBM_MS_DBCS:
-                    byte[] bytes = value.getBytes("IBM" + IBM_MS_DBCS_CODEPAGE);
-                    //Add the codePage
-                    byte[] result = new byte[2 + bytes.length];
-                    result[0] = (byte) (IBM_MS_DBCS_CODEPAGE >> 8);
-                    result[1] = (byte) IBM_MS_DBCS_CODEPAGE;
-                    System.arraycopy(bytes, 0, result, 2, bytes.length);
-                    return result;
-                default:
-                    return null;
-            }
-        } catch (final UnsupportedEncodingException e) {
-            // Should never happen, so convert to a runtime exception.
-            throw new RuntimeException(e);
+    private int calcHeaderLength() {
+        int headerLength = 1;
+        if (encoding.getCodePage() != NO_CODE_PAGE) {
+            headerLength += 2;
         }
+        return headerLength;
     }
 
-    private static String decode(final byte encoding, final byte[] bytes) {
-        try {
-            switch (encoding) {
-                case Encodings.ANSI_X3_4:
-                    return new String(bytes, "UTF-8");
-                case Encodings.ISO_10646_UCS_2:
-                    return new String(bytes, "UTF-16");
-                case Encodings.ISO_8859_1:
-                    return new String(bytes, "ISO-8859-1");
-                case Encodings.ISO_10646_UCS_4:
-                    return new String(bytes, "UTF-32");
-                case Encodings.IBM_MS_DBCS:
-                    return new String(bytes, "IBM" + IBM_MS_DBCS_CODEPAGE);
-                default:
-                    return "";
-            }
-        } catch (final UnsupportedEncodingException e) {
-            // Should never happen, so convert to a runtime exception.
-            throw new RuntimeException(e);
+    private CharacterEncoding createCharacterEncoding(ByteQueue queue) {
+        byte encodingValue = queue.pop();
+        if (encodingValue != IBM_MS_DBCS) {
+            return new CharacterEncoding(encodingValue, NO_CODE_PAGE);
         }
+        //Decode the codePage
+        int codePage = queue.popU2B();
+        return new CharacterEncoding(encodingValue, codePage);
     }
 
-    private void validateEncoding() throws BACnetErrorException {
-        if (encoding != Encodings.ANSI_X3_4 && encoding != Encodings.ISO_10646_UCS_2
-                && encoding != Encodings.ISO_8859_1 && encoding != Encodings.ISO_10646_UCS_4 && encoding != Encodings.IBM_MS_DBCS)
-            throw new BACnetErrorException(ErrorClass.property, ErrorCode.characterSetNotSupported,
-                    Byte.toString(encoding));
+    private static CharacterEncoder findEncoder(CharacterEncoding encoding) throws BACnetErrorException {
+        return characterEncoders.stream()
+                .filter(encoder -> encoder.isEncodingSupported(encoding))
+                .findFirst()
+                .orElseThrow(() -> new BACnetErrorException(
+                        ErrorClass.property,
+                        ErrorCode.characterSetNotSupported,
+                        encoding.toString())
+                );
+    }
+
+    private static int defaultCodingPage(byte encoding) {
+        if (encoding == IBM_MS_DBCS) {
+            return CODE_PAGE_LATIN_1;
+        }
+        return NO_CODE_PAGE;
+    }
+
+    private static List<CharacterEncoder> loadEncoders() {
+        ServiceLoader<CharacterEncoder> loader = ServiceLoader.load(CharacterEncoder.class);
+        return StreamSupport.stream(loader.spliterator(), false)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CharacterString that = (CharacterString) o;
+        return Objects.equals(encoding, that.encoding) &&
+                Objects.equals(encoder, that.encoder) &&
+                Objects.equals(value, that.value);
     }
 
     @Override
     public int hashCode() {
-        final int PRIME = 31;
-        int result = 1;
-        result = PRIME * result + (value == null ? 0 : value.hashCode());
-        return result;
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        final CharacterString other = (CharacterString) obj;
-        if (encoding != other.encoding)
-            return false;
-        if (value == null) {
-            if (other.value != null)
-                return false;
-        } else if (!value.equals(other.value))
-            return false;
-        return true;
+        return Objects.hash(encoding, encoder, value);
     }
 
     @Override

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/AbstractCharacterEncoder.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/AbstractCharacterEncoder.java
@@ -1,0 +1,41 @@
+package com.serotonin.bacnet4j.type.primitive.encoding;
+
+import java.io.UnsupportedEncodingException;
+
+import com.serotonin.bacnet4j.exception.BACnetRuntimeException;
+
+public abstract class AbstractCharacterEncoder implements CharacterEncoder {
+
+    private final CharacterEncoding characterEncoding;
+    private final String javaCharsetName;
+
+    public AbstractCharacterEncoder(CharacterEncoding characterEncoding, String javaCharsetName) {
+        this.characterEncoding = characterEncoding;
+        this.javaCharsetName = javaCharsetName;
+    }
+
+    @Override
+    public boolean isEncodingSupported(CharacterEncoding encoding) {
+        return characterEncoding.equals(encoding);
+    }
+
+    @Override
+    public byte[] encode(String value) {
+        try {
+            return value.getBytes(javaCharsetName);
+        } catch (final UnsupportedEncodingException e) {
+            // Should never happen
+            throw new BACnetRuntimeException(e);
+        }
+    }
+
+    @Override
+    public String decode(byte[] bytes) {
+        try {
+            return new String(bytes, javaCharsetName);
+        } catch (final UnsupportedEncodingException e) {
+            // Should never happen
+            throw new BACnetRuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/AbstractCharacterEncoder.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/AbstractCharacterEncoder.java
@@ -1,3 +1,30 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2025 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
 package com.serotonin.bacnet4j.type.primitive.encoding;
 
 import java.io.UnsupportedEncodingException;

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/AbstractCharacterEncoder.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/AbstractCharacterEncoder.java
@@ -5,11 +5,10 @@ import java.io.UnsupportedEncodingException;
 import com.serotonin.bacnet4j.exception.BACnetRuntimeException;
 
 public abstract class AbstractCharacterEncoder implements CharacterEncoder {
-
     private final CharacterEncoding characterEncoding;
     private final String javaCharsetName;
 
-    public AbstractCharacterEncoder(CharacterEncoding characterEncoding, String javaCharsetName) {
+    protected AbstractCharacterEncoder(CharacterEncoding characterEncoding, String javaCharsetName) {
         this.characterEncoding = characterEncoding;
         this.javaCharsetName = javaCharsetName;
     }

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/AbstractDbcsCharacterEncoder.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/AbstractDbcsCharacterEncoder.java
@@ -1,0 +1,34 @@
+package com.serotonin.bacnet4j.type.primitive.encoding;
+
+import java.io.UnsupportedEncodingException;
+
+import com.serotonin.bacnet4j.exception.BACnetRuntimeException;
+
+public abstract class AbstractDbcsCharacterEncoder extends AbstractCharacterEncoder {
+ 
+    private final CharacterEncoding characterEncoding;
+    private final String javaCharsetName;
+
+    public AbstractDbcsCharacterEncoder(CharacterEncoding characterEncoding, String javaCharsetName) {
+        super(characterEncoding, javaCharsetName);
+        this.characterEncoding = characterEncoding;
+        this.javaCharsetName = javaCharsetName;
+    }
+
+    @Override
+    public byte[] encode(String value) {
+        try {
+            byte[] bytes = value.getBytes(javaCharsetName);
+            //Add the codePage
+            byte[] result = new byte[2 + bytes.length];
+            int codePage = characterEncoding.getCodePage();
+            result[0] = (byte) (codePage >> 8);
+            result[1] = (byte) codePage;
+            System.arraycopy(bytes, 0, result, 2, bytes.length);
+            return result;
+        } catch (final UnsupportedEncodingException e) {
+            // Should never happen
+            throw new BACnetRuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/AbstractDbcsCharacterEncoder.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/AbstractDbcsCharacterEncoder.java
@@ -1,3 +1,30 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2025 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
 package com.serotonin.bacnet4j.type.primitive.encoding;
 
 import java.io.UnsupportedEncodingException;

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/AbstractDbcsCharacterEncoder.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/AbstractDbcsCharacterEncoder.java
@@ -5,11 +5,10 @@ import java.io.UnsupportedEncodingException;
 import com.serotonin.bacnet4j.exception.BACnetRuntimeException;
 
 public abstract class AbstractDbcsCharacterEncoder extends AbstractCharacterEncoder {
- 
     private final CharacterEncoding characterEncoding;
     private final String javaCharsetName;
 
-    public AbstractDbcsCharacterEncoder(CharacterEncoding characterEncoding, String javaCharsetName) {
+    protected AbstractDbcsCharacterEncoder(CharacterEncoding characterEncoding, String javaCharsetName) {
         super(characterEncoding, javaCharsetName);
         this.characterEncoding = characterEncoding;
         this.javaCharsetName = javaCharsetName;

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/AnsiCharacterEncoder.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/AnsiCharacterEncoder.java
@@ -1,0 +1,12 @@
+package com.serotonin.bacnet4j.type.primitive.encoding;
+
+import static com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEncodings.ANSI_X3_4;
+
+public class AnsiCharacterEncoder extends AbstractCharacterEncoder {
+
+    private static final String JAVA_CHARSET_NAME = "UTF-8";
+
+    public AnsiCharacterEncoder() {
+        super(new CharacterEncoding(ANSI_X3_4), JAVA_CHARSET_NAME);
+    }
+}

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/AnsiCharacterEncoder.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/AnsiCharacterEncoder.java
@@ -1,3 +1,30 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2025 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
 package com.serotonin.bacnet4j.type.primitive.encoding;
 
 import static com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEncodings.ANSI_X3_4;

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/AnsiCharacterEncoder.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/AnsiCharacterEncoder.java
@@ -3,7 +3,6 @@ package com.serotonin.bacnet4j.type.primitive.encoding;
 import static com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEncodings.ANSI_X3_4;
 
 public class AnsiCharacterEncoder extends AbstractCharacterEncoder {
-
     private static final String JAVA_CHARSET_NAME = "UTF-8";
 
     public AnsiCharacterEncoder() {

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/CharacterEncoder.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/CharacterEncoder.java
@@ -1,0 +1,10 @@
+package com.serotonin.bacnet4j.type.primitive.encoding;
+
+public interface CharacterEncoder {
+
+    boolean isEncodingSupported(CharacterEncoding encoding);
+
+    byte[] encode(String value);
+
+    String decode(byte[] bytes);
+}

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/CharacterEncoder.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/CharacterEncoder.java
@@ -1,3 +1,30 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2025 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
 package com.serotonin.bacnet4j.type.primitive.encoding;
 
 /**

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/CharacterEncoder.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/CharacterEncoder.java
@@ -1,7 +1,11 @@
 package com.serotonin.bacnet4j.type.primitive.encoding;
 
+/**
+ * To add a new encoder:
+ * - create it as a subclass of CharacterEncoder
+ * - add the class to resources/META-INF.services/com.serotonin.bacnet4j.type.primitive.encoding.CharacterEncoder
+ */
 public interface CharacterEncoder {
-
     boolean isEncodingSupported(CharacterEncoding encoding);
 
     byte[] encode(String value);

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/CharacterEncoding.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/CharacterEncoding.java
@@ -1,0 +1,54 @@
+package com.serotonin.bacnet4j.type.primitive.encoding;
+
+import static com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEncodings.NO_CODE_PAGE;
+
+import java.util.Objects;
+
+public class CharacterEncoding {
+
+    private final byte encoding;
+    private final int codePage;
+
+    public CharacterEncoding(byte encoding) {
+        this(encoding, NO_CODE_PAGE);
+    }
+
+    public CharacterEncoding(byte encoding, int codePage) {
+        this.encoding = encoding;
+        this.codePage = codePage;
+    }
+
+    public byte getEncoding() {
+        return encoding;
+    }
+
+    public int getCodePage() {
+        return codePage;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CharacterEncoding that = (CharacterEncoding) o;
+        return encoding == that.encoding &&
+                codePage == that.codePage;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(encoding, codePage);
+    }
+
+    @Override
+    public String toString() {
+        return "CharacterEncoding{" +
+                "encoding=" + encoding +
+                ", codePage=" + codePage +
+                '}';
+    }
+}

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/CharacterEncoding.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/CharacterEncoding.java
@@ -5,7 +5,6 @@ import static com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEn
 import java.util.Objects;
 
 public class CharacterEncoding {
-
     private final byte encoding;
     private final int codePage;
 

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/CharacterEncoding.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/CharacterEncoding.java
@@ -1,3 +1,30 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2025 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
 package com.serotonin.bacnet4j.type.primitive.encoding;
 
 import static com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEncodings.NO_CODE_PAGE;

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/DbcsCp850CharacterEncoder.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/DbcsCp850CharacterEncoder.java
@@ -1,0 +1,14 @@
+package com.serotonin.bacnet4j.type.primitive.encoding;
+
+import static com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEncodings.IBM_MS_DBCS;
+
+public class DbcsCp850CharacterEncoder extends AbstractDbcsCharacterEncoder {
+
+    public static final int DOS_LATIN_1_CODEPAGE = 850;
+    private static final String JAVA_ENCODING = "IBM850";
+
+    public DbcsCp850CharacterEncoder() {
+        super(new CharacterEncoding(IBM_MS_DBCS, DOS_LATIN_1_CODEPAGE), JAVA_ENCODING);
+    }
+
+}

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/DbcsCp850CharacterEncoder.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/DbcsCp850CharacterEncoder.java
@@ -3,12 +3,10 @@ package com.serotonin.bacnet4j.type.primitive.encoding;
 import static com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEncodings.IBM_MS_DBCS;
 
 public class DbcsCp850CharacterEncoder extends AbstractDbcsCharacterEncoder {
-
     public static final int DOS_LATIN_1_CODEPAGE = 850;
     private static final String JAVA_ENCODING = "IBM850";
 
     public DbcsCp850CharacterEncoder() {
         super(new CharacterEncoding(IBM_MS_DBCS, DOS_LATIN_1_CODEPAGE), JAVA_ENCODING);
     }
-
 }

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/DbcsCp850CharacterEncoder.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/DbcsCp850CharacterEncoder.java
@@ -1,3 +1,30 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2025 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
 package com.serotonin.bacnet4j.type.primitive.encoding;
 
 import static com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEncodings.IBM_MS_DBCS;

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/DbcsCp932CharacterEncoder.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/DbcsCp932CharacterEncoder.java
@@ -1,0 +1,14 @@
+package com.serotonin.bacnet4j.type.primitive.encoding;
+
+import static com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEncodings.IBM_MS_DBCS;
+
+public class DbcsCp932CharacterEncoder extends AbstractDbcsCharacterEncoder {
+
+    public static final int JAPANESE_CODEPAGE = 932;
+    private static final String JAVA_CHARSET_NAME = "MS932";
+
+    public DbcsCp932CharacterEncoder() {
+        super(new CharacterEncoding(IBM_MS_DBCS, JAPANESE_CODEPAGE), JAVA_CHARSET_NAME);
+    }
+
+}

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/DbcsCp932CharacterEncoder.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/DbcsCp932CharacterEncoder.java
@@ -3,12 +3,10 @@ package com.serotonin.bacnet4j.type.primitive.encoding;
 import static com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEncodings.IBM_MS_DBCS;
 
 public class DbcsCp932CharacterEncoder extends AbstractDbcsCharacterEncoder {
-
     public static final int JAPANESE_CODEPAGE = 932;
     private static final String JAVA_CHARSET_NAME = "MS932";
 
     public DbcsCp932CharacterEncoder() {
         super(new CharacterEncoding(IBM_MS_DBCS, JAPANESE_CODEPAGE), JAVA_CHARSET_NAME);
     }
-
 }

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/DbcsCp932CharacterEncoder.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/DbcsCp932CharacterEncoder.java
@@ -1,3 +1,30 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2025 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
 package com.serotonin.bacnet4j.type.primitive.encoding;
 
 import static com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEncodings.IBM_MS_DBCS;

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/Iso8859CharacterEncoder.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/Iso8859CharacterEncoder.java
@@ -1,0 +1,12 @@
+package com.serotonin.bacnet4j.type.primitive.encoding;
+
+import static com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEncodings.ISO_8859_1;
+
+public class Iso8859CharacterEncoder extends AbstractCharacterEncoder {
+
+    private static final String JAVA_CHARSET_NAME = "ISO-8859-1";
+
+    public Iso8859CharacterEncoder() {
+        super(new CharacterEncoding(ISO_8859_1), JAVA_CHARSET_NAME);
+    }
+}

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/Iso8859CharacterEncoder.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/Iso8859CharacterEncoder.java
@@ -1,3 +1,30 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2025 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
 package com.serotonin.bacnet4j.type.primitive.encoding;
 
 import static com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEncodings.ISO_8859_1;

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/Iso8859CharacterEncoder.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/Iso8859CharacterEncoder.java
@@ -3,7 +3,6 @@ package com.serotonin.bacnet4j.type.primitive.encoding;
 import static com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEncodings.ISO_8859_1;
 
 public class Iso8859CharacterEncoder extends AbstractCharacterEncoder {
-
     private static final String JAVA_CHARSET_NAME = "ISO-8859-1";
 
     public Iso8859CharacterEncoder() {

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/StandardCharacterEncodings.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/StandardCharacterEncodings.java
@@ -1,0 +1,18 @@
+package com.serotonin.bacnet4j.type.primitive.encoding;
+
+public class StandardCharacterEncodings {
+
+    private StandardCharacterEncodings() {
+    }
+
+    public static final byte ANSI_X3_4 = 0;
+    public static final byte IBM_MS_DBCS = 1;
+    public static final byte JIS_C_6226 = 2;
+    public static final byte ISO_10646_UCS_4 = 3;
+    public static final byte ISO_10646_UCS_2 = 4;
+    public static final byte ISO_8859_1 = 5;
+
+    public static final int CODE_PAGE_LATIN_1 = 850;
+    public static final int NO_CODE_PAGE = -1;
+
+}

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/StandardCharacterEncodings.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/StandardCharacterEncodings.java
@@ -1,3 +1,30 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2025 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
 package com.serotonin.bacnet4j.type.primitive.encoding;
 
 public class StandardCharacterEncodings {

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/StandardCharacterEncodings.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/StandardCharacterEncodings.java
@@ -1,7 +1,6 @@
 package com.serotonin.bacnet4j.type.primitive.encoding;
 
 public class StandardCharacterEncodings {
-
     private StandardCharacterEncodings() {
     }
 
@@ -14,5 +13,4 @@ public class StandardCharacterEncodings {
 
     public static final int CODE_PAGE_LATIN_1 = 850;
     public static final int NO_CODE_PAGE = -1;
-
 }

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/Ucs2CharacterEncoder.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/Ucs2CharacterEncoder.java
@@ -1,0 +1,12 @@
+package com.serotonin.bacnet4j.type.primitive.encoding;
+
+import static com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEncodings.ISO_10646_UCS_2;
+
+public class Ucs2CharacterEncoder extends AbstractCharacterEncoder {
+
+    private static final String JAVA_CHARSET_NAME = "UTF-16";
+
+    public Ucs2CharacterEncoder() {
+        super(new CharacterEncoding(ISO_10646_UCS_2), JAVA_CHARSET_NAME);
+    }
+}

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/Ucs2CharacterEncoder.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/Ucs2CharacterEncoder.java
@@ -3,8 +3,7 @@ package com.serotonin.bacnet4j.type.primitive.encoding;
 import static com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEncodings.ISO_10646_UCS_2;
 
 public class Ucs2CharacterEncoder extends AbstractCharacterEncoder {
-
-    private static final String JAVA_CHARSET_NAME = "UTF-16";
+    private static final String JAVA_CHARSET_NAME = "UTF-16BE";
 
     public Ucs2CharacterEncoder() {
         super(new CharacterEncoding(ISO_10646_UCS_2), JAVA_CHARSET_NAME);

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/Ucs2CharacterEncoder.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/Ucs2CharacterEncoder.java
@@ -1,3 +1,30 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2025 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
 package com.serotonin.bacnet4j.type.primitive.encoding;
 
 import static com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEncodings.ISO_10646_UCS_2;

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/Ucs4CharacterEncoder.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/Ucs4CharacterEncoder.java
@@ -1,0 +1,12 @@
+package com.serotonin.bacnet4j.type.primitive.encoding;
+
+import static com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEncodings.ISO_10646_UCS_4;
+
+public class Ucs4CharacterEncoder extends AbstractCharacterEncoder {
+
+    private static final String JAVA_CHARSET_NAME = "UTF-32";
+
+    public Ucs4CharacterEncoder() {
+        super(new CharacterEncoding(ISO_10646_UCS_4), JAVA_CHARSET_NAME);
+    }
+}

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/Ucs4CharacterEncoder.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/Ucs4CharacterEncoder.java
@@ -1,3 +1,30 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2025 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
 package com.serotonin.bacnet4j.type.primitive.encoding;
 
 import static com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEncodings.ISO_10646_UCS_4;

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/Ucs4CharacterEncoder.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/encoding/Ucs4CharacterEncoder.java
@@ -3,7 +3,6 @@ package com.serotonin.bacnet4j.type.primitive.encoding;
 import static com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEncodings.ISO_10646_UCS_4;
 
 public class Ucs4CharacterEncoder extends AbstractCharacterEncoder {
-
     private static final String JAVA_CHARSET_NAME = "UTF-32";
 
     public Ucs4CharacterEncoder() {

--- a/src/main/resources/META-INF/services/com.serotonin.bacnet4j.type.primitive.encoding.CharacterEncoder
+++ b/src/main/resources/META-INF/services/com.serotonin.bacnet4j.type.primitive.encoding.CharacterEncoder
@@ -1,0 +1,6 @@
+com.serotonin.bacnet4j.type.primitive.encoding.AnsiCharacterEncoder
+com.serotonin.bacnet4j.type.primitive.encoding.DbcsCp850CharacterEncoder
+com.serotonin.bacnet4j.type.primitive.encoding.DbcsCp932CharacterEncoder
+com.serotonin.bacnet4j.type.primitive.encoding.Iso8859CharacterEncoder
+com.serotonin.bacnet4j.type.primitive.encoding.Ucs2CharacterEncoder
+com.serotonin.bacnet4j.type.primitive.encoding.Ucs4CharacterEncoder

--- a/src/test/java/com/serotonin/bacnet4j/AnnexFEncodingTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/AnnexFEncodingTest.java
@@ -162,6 +162,7 @@ import com.serotonin.bacnet4j.type.primitive.Time;
 import com.serotonin.bacnet4j.type.primitive.Unsigned16;
 import com.serotonin.bacnet4j.type.primitive.Unsigned32;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
+import com.serotonin.bacnet4j.type.primitive.encoding.CharacterEncoding;
 import com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEncodings;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
 
@@ -179,7 +180,7 @@ public class AnnexFEncodingTest {
         final AcknowledgeAlarmRequest acknowledgeAlarmRequest = new AcknowledgeAlarmRequest(new UnsignedInteger(1),
                 new ObjectIdentifier(ObjectType.analogInput, 2), EventState.highLimit,
                 new TimeStamp(new UnsignedInteger(16)),
-                new CharacterString(StandardCharacterEncodings.ANSI_X3_4, "MDL"),
+                new CharacterString(new CharacterEncoding(StandardCharacterEncodings.ANSI_X3_4), "MDL"),
                 new TimeStamp(
                         new DateTime(new Date(1992, Month.JUNE, 21, DayOfWeek.UNSPECIFIED), new Time(13, 3, 41, 9))));
 
@@ -436,7 +437,8 @@ public class AnnexFEncodingTest {
     @Test
     public void e1_9aTest() {
         final LifeSafetyOperationRequest lifeSafetyOperationRequest = new LifeSafetyOperationRequest(
-                new UnsignedInteger(18), new CharacterString(StandardCharacterEncodings.ANSI_X3_4, "MDL"),
+                new UnsignedInteger(18),
+                new CharacterString(new CharacterEncoding(StandardCharacterEncodings.ANSI_X3_4), "MDL"),
                 LifeSafetyOperation.reset, new ObjectIdentifier(ObjectType.lifeSafetyPoint, 1));
 
         final ConfirmedRequest pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED,
@@ -727,7 +729,7 @@ public class AnnexFEncodingTest {
     public void e3_3aTest() {
         final List<PropertyValue> propertyValues = new ArrayList<>();
         propertyValues.add(new PropertyValue(PropertyIdentifier.objectName, null,
-                new CharacterString(StandardCharacterEncodings.ANSI_X3_4, "Trend 1"), null));
+                new CharacterString(new CharacterEncoding(StandardCharacterEncodings.ANSI_X3_4), "Trend 1"), null));
         propertyValues
                 .add(new PropertyValue(PropertyIdentifier.fileAccessMethod, null, FileAccessMethod.recordAccess, null));
         final ConfirmedRequestService service = new CreateObjectRequest(ObjectType.file,
@@ -980,7 +982,8 @@ public class AnnexFEncodingTest {
     @Test
     public void e4_1aTest() {
         final ConfirmedRequestService service = new DeviceCommunicationControlRequest(new UnsignedInteger(5),
-                EnableDisable.disable, new CharacterString(StandardCharacterEncodings.ANSI_X3_4, "#egbdf!"));
+                EnableDisable.disable,
+                new CharacterString(new CharacterEncoding(StandardCharacterEncodings.ANSI_X3_4), "#egbdf!"));
         final APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_1024,
                 (byte) 5, (byte) 0, 0, service);
         compare(pdu, "00040511090519012D080023656762646621");
@@ -1022,7 +1025,7 @@ public class AnnexFEncodingTest {
     @Test
     public void e4_4aTest() {
         final ConfirmedRequestService service = new ReinitializeDeviceRequest(ReinitializedStateOfDevice.warmstart,
-                new CharacterString(StandardCharacterEncodings.ANSI_X3_4, "AbCdEfGh"));
+                new CharacterString(new CharacterEncoding(StandardCharacterEncodings.ANSI_X3_4), "AbCdEfGh"));
         final APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_128,
                 (byte) 2, (byte) 0, 0, service);
         compare(pdu, "0001021409011D09004162436445664768");
@@ -1038,7 +1041,8 @@ public class AnnexFEncodingTest {
     public void e4_5aTest() {
         final ConfirmedRequestService service = new ConfirmedTextMessageRequest(
                 new ObjectIdentifier(ObjectType.device, 5), MessagePriority.normal,
-                new CharacterString(StandardCharacterEncodings.ANSI_X3_4, "PM required for PUMP347"));
+                new CharacterString(new CharacterEncoding(StandardCharacterEncodings.ANSI_X3_4),
+                        "PM required for PUMP347"));
         final APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_128,
                 (byte) 3, (byte) 0, 0, service);
         compare(pdu, "000103130C0200000529003D1800504D20726571756972656420666F722050554D50333437");
@@ -1054,7 +1058,8 @@ public class AnnexFEncodingTest {
     public void e4_6Test() {
         final UnconfirmedRequestService service = new UnconfirmedTextMessageRequest(
                 new ObjectIdentifier(ObjectType.device, 5), MessagePriority.normal,
-                new CharacterString(StandardCharacterEncodings.ANSI_X3_4, "PM required for PUMP347"));
+                new CharacterString(new CharacterEncoding(StandardCharacterEncodings.ANSI_X3_4),
+                        "PM required for PUMP347"));
         final APDU pdu = new UnconfirmedRequest(service);
         compare(pdu, "10050C0200000529003D1800504D20726571756972656420666F722050554D50333437");
     }
@@ -1070,7 +1075,7 @@ public class AnnexFEncodingTest {
     @Test
     public void e4_8aTest() {
         final UnconfirmedRequestService service = new WhoHasRequest(null,
-                new CharacterString(StandardCharacterEncodings.ANSI_X3_4, "OATemp"));
+                new CharacterString(new CharacterEncoding(StandardCharacterEncodings.ANSI_X3_4), "OATemp"));
         final APDU pdu = new UnconfirmedRequest(service);
         compare(pdu, "10073D07004F4154656D70");
     }
@@ -1079,7 +1084,7 @@ public class AnnexFEncodingTest {
     public void e4_8bTest() {
         final UnconfirmedRequestService service = new IHaveRequest(new ObjectIdentifier(ObjectType.device, 8),
                 new ObjectIdentifier(ObjectType.analogInput, 3),
-                new CharacterString(StandardCharacterEncodings.ANSI_X3_4, "OATemp"));
+                new CharacterString(new CharacterEncoding(StandardCharacterEncodings.ANSI_X3_4), "OATemp"));
         final APDU pdu = new UnconfirmedRequest(service);
         compare(pdu, "1001C402000008C4000000037507004F4154656D70");
     }
@@ -1096,7 +1101,7 @@ public class AnnexFEncodingTest {
     public void e4_8dTest() {
         final UnconfirmedRequestService service = new IHaveRequest(new ObjectIdentifier(ObjectType.device, 8),
                 new ObjectIdentifier(ObjectType.analogInput, 3),
-                new CharacterString(StandardCharacterEncodings.ANSI_X3_4, "OATemp"));
+                new CharacterString(new CharacterEncoding(StandardCharacterEncodings.ANSI_X3_4), "OATemp"));
         final APDU pdu = new UnconfirmedRequest(service);
         compare(pdu, "1001C402000008C4000000037507004F4154656D70");
     }

--- a/src/test/java/com/serotonin/bacnet4j/AnnexFEncodingTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/AnnexFEncodingTest.java
@@ -162,6 +162,7 @@ import com.serotonin.bacnet4j.type.primitive.Time;
 import com.serotonin.bacnet4j.type.primitive.Unsigned16;
 import com.serotonin.bacnet4j.type.primitive.Unsigned32;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
+import com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEncodings;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
 
 public class AnnexFEncodingTest {
@@ -177,7 +178,8 @@ public class AnnexFEncodingTest {
     public void e1_1aTest() {
         final AcknowledgeAlarmRequest acknowledgeAlarmRequest = new AcknowledgeAlarmRequest(new UnsignedInteger(1),
                 new ObjectIdentifier(ObjectType.analogInput, 2), EventState.highLimit,
-                new TimeStamp(new UnsignedInteger(16)), new CharacterString(CharacterString.Encodings.ANSI_X3_4, "MDL"),
+                new TimeStamp(new UnsignedInteger(16)),
+                new CharacterString(StandardCharacterEncodings.ANSI_X3_4, "MDL"),
                 new TimeStamp(
                         new DateTime(new Date(1992, Month.JUNE, 21, DayOfWeek.UNSPECIFIED), new Time(13, 3, 41, 9))));
 
@@ -434,7 +436,7 @@ public class AnnexFEncodingTest {
     @Test
     public void e1_9aTest() {
         final LifeSafetyOperationRequest lifeSafetyOperationRequest = new LifeSafetyOperationRequest(
-                new UnsignedInteger(18), new CharacterString(CharacterString.Encodings.ANSI_X3_4, "MDL"),
+                new UnsignedInteger(18), new CharacterString(StandardCharacterEncodings.ANSI_X3_4, "MDL"),
                 LifeSafetyOperation.reset, new ObjectIdentifier(ObjectType.lifeSafetyPoint, 1));
 
         final ConfirmedRequest pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED,
@@ -725,7 +727,7 @@ public class AnnexFEncodingTest {
     public void e3_3aTest() {
         final List<PropertyValue> propertyValues = new ArrayList<>();
         propertyValues.add(new PropertyValue(PropertyIdentifier.objectName, null,
-                new CharacterString(CharacterString.Encodings.ANSI_X3_4, "Trend 1"), null));
+                new CharacterString(StandardCharacterEncodings.ANSI_X3_4, "Trend 1"), null));
         propertyValues
                 .add(new PropertyValue(PropertyIdentifier.fileAccessMethod, null, FileAccessMethod.recordAccess, null));
         final ConfirmedRequestService service = new CreateObjectRequest(ObjectType.file,
@@ -978,7 +980,7 @@ public class AnnexFEncodingTest {
     @Test
     public void e4_1aTest() {
         final ConfirmedRequestService service = new DeviceCommunicationControlRequest(new UnsignedInteger(5),
-                EnableDisable.disable, new CharacterString(CharacterString.Encodings.ANSI_X3_4, "#egbdf!"));
+                EnableDisable.disable, new CharacterString(StandardCharacterEncodings.ANSI_X3_4, "#egbdf!"));
         final APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_1024,
                 (byte) 5, (byte) 0, 0, service);
         compare(pdu, "00040511090519012D080023656762646621");
@@ -1020,7 +1022,7 @@ public class AnnexFEncodingTest {
     @Test
     public void e4_4aTest() {
         final ConfirmedRequestService service = new ReinitializeDeviceRequest(ReinitializedStateOfDevice.warmstart,
-                new CharacterString(CharacterString.Encodings.ANSI_X3_4, "AbCdEfGh"));
+                new CharacterString(StandardCharacterEncodings.ANSI_X3_4, "AbCdEfGh"));
         final APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_128,
                 (byte) 2, (byte) 0, 0, service);
         compare(pdu, "0001021409011D09004162436445664768");
@@ -1036,7 +1038,7 @@ public class AnnexFEncodingTest {
     public void e4_5aTest() {
         final ConfirmedRequestService service = new ConfirmedTextMessageRequest(
                 new ObjectIdentifier(ObjectType.device, 5), MessagePriority.normal,
-                new CharacterString(CharacterString.Encodings.ANSI_X3_4, "PM required for PUMP347"));
+                new CharacterString(StandardCharacterEncodings.ANSI_X3_4, "PM required for PUMP347"));
         final APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_128,
                 (byte) 3, (byte) 0, 0, service);
         compare(pdu, "000103130C0200000529003D1800504D20726571756972656420666F722050554D50333437");
@@ -1052,7 +1054,7 @@ public class AnnexFEncodingTest {
     public void e4_6Test() {
         final UnconfirmedRequestService service = new UnconfirmedTextMessageRequest(
                 new ObjectIdentifier(ObjectType.device, 5), MessagePriority.normal,
-                new CharacterString(CharacterString.Encodings.ANSI_X3_4, "PM required for PUMP347"));
+                new CharacterString(StandardCharacterEncodings.ANSI_X3_4, "PM required for PUMP347"));
         final APDU pdu = new UnconfirmedRequest(service);
         compare(pdu, "10050C0200000529003D1800504D20726571756972656420666F722050554D50333437");
     }
@@ -1068,7 +1070,7 @@ public class AnnexFEncodingTest {
     @Test
     public void e4_8aTest() {
         final UnconfirmedRequestService service = new WhoHasRequest(null,
-                new CharacterString(CharacterString.Encodings.ANSI_X3_4, "OATemp"));
+                new CharacterString(StandardCharacterEncodings.ANSI_X3_4, "OATemp"));
         final APDU pdu = new UnconfirmedRequest(service);
         compare(pdu, "10073D07004F4154656D70");
     }
@@ -1077,7 +1079,7 @@ public class AnnexFEncodingTest {
     public void e4_8bTest() {
         final UnconfirmedRequestService service = new IHaveRequest(new ObjectIdentifier(ObjectType.device, 8),
                 new ObjectIdentifier(ObjectType.analogInput, 3),
-                new CharacterString(CharacterString.Encodings.ANSI_X3_4, "OATemp"));
+                new CharacterString(StandardCharacterEncodings.ANSI_X3_4, "OATemp"));
         final APDU pdu = new UnconfirmedRequest(service);
         compare(pdu, "1001C402000008C4000000037507004F4154656D70");
     }
@@ -1094,7 +1096,7 @@ public class AnnexFEncodingTest {
     public void e4_8dTest() {
         final UnconfirmedRequestService service = new IHaveRequest(new ObjectIdentifier(ObjectType.device, 8),
                 new ObjectIdentifier(ObjectType.analogInput, 3),
-                new CharacterString(CharacterString.Encodings.ANSI_X3_4, "OATemp"));
+                new CharacterString(StandardCharacterEncodings.ANSI_X3_4, "OATemp"));
         final APDU pdu = new UnconfirmedRequest(service);
         compare(pdu, "1001C402000008C4000000037507004F4154656D70");
     }

--- a/src/test/java/com/serotonin/bacnet4j/obj/BACnetObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/BACnetObjectTest.java
@@ -57,6 +57,7 @@ import com.serotonin.bacnet4j.type.primitive.Real;
 import com.serotonin.bacnet4j.type.primitive.SignedInteger;
 import com.serotonin.bacnet4j.type.primitive.Unsigned32;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
+import com.serotonin.bacnet4j.type.primitive.encoding.CharacterEncoding;
 import com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEncodings;
 import com.serotonin.bacnet4j.util.RequestUtils;
 
@@ -73,7 +74,7 @@ public class BACnetObjectTest extends AbstractTest {
         d2.writePropertyInternal(PropertyIdentifier.forId(6789),
                 new BACnetArray<>(new Real(0), new Real(1), new Real(2)));
         d2.writePropertyInternal(PropertyIdentifier.protocolVersion,
-                new CharacterString(StandardCharacterEncodings.ANSI_X3_4, "hxzy-1.01"));
+                new CharacterString(new CharacterEncoding(StandardCharacterEncodings.ANSI_X3_4), "hxzy-1.01"));
     }
 
     @Test

--- a/src/test/java/com/serotonin/bacnet4j/obj/BACnetObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/BACnetObjectTest.java
@@ -57,6 +57,7 @@ import com.serotonin.bacnet4j.type.primitive.Real;
 import com.serotonin.bacnet4j.type.primitive.SignedInteger;
 import com.serotonin.bacnet4j.type.primitive.Unsigned32;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
+import com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEncodings;
 import com.serotonin.bacnet4j.util.RequestUtils;
 
 public class BACnetObjectTest extends AbstractTest {
@@ -72,7 +73,7 @@ public class BACnetObjectTest extends AbstractTest {
         d2.writePropertyInternal(PropertyIdentifier.forId(6789),
                 new BACnetArray<>(new Real(0), new Real(1), new Real(2)));
         d2.writePropertyInternal(PropertyIdentifier.protocolVersion,
-                new CharacterString(CharacterString.Encodings.ANSI_X3_4, "hxzy-1.01"));
+                new CharacterString(StandardCharacterEncodings.ANSI_X3_4, "hxzy-1.01"));
     }
 
     @Test

--- a/src/test/java/com/serotonin/bacnet4j/service/acknowledgement/InvalidPropertyValueTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/service/acknowledgement/InvalidPropertyValueTest.java
@@ -29,6 +29,11 @@ package com.serotonin.bacnet4j.service.acknowledgement;
 
 import static org.junit.Assert.fail;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
 import com.serotonin.bacnet4j.exception.BACnetException;
 import com.serotonin.bacnet4j.type.constructed.ReadAccessResult;
 import com.serotonin.bacnet4j.type.constructed.ReadAccessResult.Result;
@@ -41,11 +46,9 @@ import com.serotonin.bacnet4j.type.error.ErrorClassAndCode;
 import com.serotonin.bacnet4j.type.primitive.CharacterString;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
+import com.serotonin.bacnet4j.type.primitive.encoding.CharacterEncoding;
 import com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEncodings;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
-import java.util.ArrayList;
-import java.util.List;
-import org.junit.Test;
 
 /**
  * Test to show that reading a protocol version on a device will throw an exception and fail if it is not the correct
@@ -69,8 +72,8 @@ public class InvalidPropertyValueTest {
         deviceResultList.add(new Result(PropertyIdentifier.maxSegmentsAccepted, propertyArrayIndex, errorResponse));
 
         //String protocol version which is Invalid as per the spec
-        deviceResultList.add(new Result(PropertyIdentifier.protocolVersion, new UnsignedInteger(0), new CharacterString(
-                StandardCharacterEncodings.ANSI_X3_4, "hxzy-1.01")));
+        deviceResultList.add(new Result(PropertyIdentifier.protocolVersion, new UnsignedInteger(0),
+                new CharacterString(new CharacterEncoding(StandardCharacterEncodings.ANSI_X3_4), "hxzy-1.01")));
 
         SequenceOf<Result> deviceResults = new SequenceOf<>(deviceResultList);
 

--- a/src/test/java/com/serotonin/bacnet4j/service/acknowledgement/InvalidPropertyValueTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/service/acknowledgement/InvalidPropertyValueTest.java
@@ -29,11 +29,6 @@ package com.serotonin.bacnet4j.service.acknowledgement;
 
 import static org.junit.Assert.fail;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.junit.Test;
-
 import com.serotonin.bacnet4j.exception.BACnetException;
 import com.serotonin.bacnet4j.type.constructed.ReadAccessResult;
 import com.serotonin.bacnet4j.type.constructed.ReadAccessResult.Result;
@@ -46,7 +41,11 @@ import com.serotonin.bacnet4j.type.error.ErrorClassAndCode;
 import com.serotonin.bacnet4j.type.primitive.CharacterString;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
+import com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEncodings;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
 
 /**
  * Test to show that reading a protocol version on a device will throw an exception and fail if it is not the correct
@@ -70,8 +69,8 @@ public class InvalidPropertyValueTest {
         deviceResultList.add(new Result(PropertyIdentifier.maxSegmentsAccepted, propertyArrayIndex, errorResponse));
 
         //String protocol version which is Invalid as per the spec
-        deviceResultList.add(new Result(PropertyIdentifier.protocolVersion, new UnsignedInteger(0),
-                new CharacterString(CharacterString.Encodings.ANSI_X3_4, "hxzy-1.01")));
+        deviceResultList.add(new Result(PropertyIdentifier.protocolVersion, new UnsignedInteger(0), new CharacterString(
+                StandardCharacterEncodings.ANSI_X3_4, "hxzy-1.01")));
 
         SequenceOf<Result> deviceResults = new SequenceOf<>(deviceResultList);
 

--- a/src/test/java/com/serotonin/bacnet4j/type/EncodableTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/type/EncodableTest.java
@@ -29,6 +29,8 @@ package com.serotonin.bacnet4j.type;
 
 import static org.junit.Assert.assertEquals;
 
+import java.io.UnsupportedEncodingException;
+
 import org.junit.Test;
 
 import com.serotonin.bacnet4j.enums.DayOfWeek;
@@ -58,6 +60,9 @@ import com.serotonin.bacnet4j.type.primitive.SignedInteger;
 import com.serotonin.bacnet4j.type.primitive.Time;
 import com.serotonin.bacnet4j.type.primitive.Unsigned8;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
+import com.serotonin.bacnet4j.type.primitive.encoding.CharacterEncoding;
+import com.serotonin.bacnet4j.type.primitive.encoding.DbcsCp932CharacterEncoder;
+import com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEncodings;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
 
 public class EncodableTest {
@@ -152,6 +157,20 @@ public class EncodableTest {
         decodePrimitive("9C5B011804", 9, new Date(1991, Month.JANUARY, 24, DayOfWeek.THURSDAY));
         decodePrimitive("4C11232D11", 4, new Time(17, 35, 45, 17));
         decodePrimitive("4C00C0000F", 4, new ObjectIdentifier(ObjectType.binaryInput, 15));
+    }
+
+    @Test
+    public void shouldDecodeJapaneseEncoding() throws BACnetException, UnsupportedEncodingException {
+        ByteQueue queue = new ByteQueue();
+        String text = "JapaneseEncoding ｦ";
+        CharacterString value = new CharacterString(
+                new CharacterEncoding(StandardCharacterEncodings.IBM_MS_DBCS,
+                        DbcsCp932CharacterEncoder.JAPANESE_CODEPAGE),
+                text);
+        value.write(queue);
+
+        CharacterString characterString = Encodable.read(queue, CharacterString.class);
+        assertEquals(text, characterString.getValue());
     }
 
     private static void decodePrimitive(final String hex, final Primitive expected) throws BACnetException {

--- a/src/test/java/com/serotonin/bacnet4j/type/primitive/CharacterStringTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/type/primitive/CharacterStringTest.java
@@ -1,0 +1,80 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2026 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
+package com.serotonin.bacnet4j.type.primitive;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.serotonin.bacnet4j.type.primitive.encoding.CharacterEncoding;
+import com.serotonin.bacnet4j.type.primitive.encoding.DbcsCp850CharacterEncoder;
+import com.serotonin.bacnet4j.type.primitive.encoding.StandardCharacterEncodings;
+import com.serotonin.bacnet4j.util.sero.ByteQueue;
+
+public class CharacterStringTest {
+    @Test
+    public void spec20_2_9_a() {
+        var str = new CharacterString(new CharacterEncoding(StandardCharacterEncodings.ANSI_X3_4),
+                "This is a BACnet string!");
+        ByteQueue queue = new ByteQueue();
+        str.write(queue);
+        assertEquals(new ByteQueue("751900546869732069732061204241436E657420737472696E6721"), queue);
+    }
+
+    @Test
+    public void spec20_2_9_b() {
+        var str = new CharacterString(new CharacterEncoding(StandardCharacterEncodings.IBM_MS_DBCS,
+                DbcsCp850CharacterEncoder.DOS_LATIN_1_CODEPAGE), "This is a BACnet string!");
+        ByteQueue queue = new ByteQueue();
+        str.write(queue);
+        assertEquals(new ByteQueue("751B010352546869732069732061204241436E657420737472696E6721"), queue);
+    }
+
+    @Test
+    public void spec20_2_9_c1() {
+        var str = new CharacterString(new CharacterEncoding(StandardCharacterEncodings.ISO_10646_UCS_2),
+                "This is a BACnet string!");
+        ByteQueue queue = new ByteQueue();
+        str.write(queue);
+        assertEquals(new ByteQueue(
+                        "7531040054006800690073002000690073002000610020004200410043006E0065007400200073007400720069006E00670021"),
+                queue);
+    }
+
+    // This test is added to ensure that UTF-32 doesn't add a byte order mark.
+    @Test
+    public void spec20_2_9_c2() {
+        var str = new CharacterString(new CharacterEncoding(StandardCharacterEncodings.ISO_10646_UCS_4),
+                "This is a BACnet string!");
+        ByteQueue queue = new ByteQueue();
+        str.write(queue);
+        assertEquals(new ByteQueue(
+                        "756103000000540000006800000069000000730000002000000069000000730000002000000061000000200000004200000041000000430000006E000000650000007400000020000000730000007400000072000000690000006E0000006700000021"),
+                queue);
+    }
+}


### PR DESCRIPTION
This is a copy of a community PR: https://github.com/RadixIoT/BACnet4J/pull/55

In addition to simplifying adding new encodings, the IBM_MS_DBCS japanese codepage was added. Note that this work still has encoding support depend upon support of the encoding within Java.

Changes to that PR:
- changed `UTF-16` to `UTF-16BE` to avoid the writing of a byte order mark, as BACnet assumes big-endian.
- changed all calls to the existing `CharacterString` constructor to use the new constructor with `CharacterEncoding`, and deprecated the original constructor
- added a new test that uses the encoding examples at 20.2.9

