### PR TITLE
MANGO-2732 Allow single handler for BBMD registration failures

### DIFF
--- a/src/main/java/com/serotonin/bacnet4j/npdu/ip/IpNetwork.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/ip/IpNetwork.java
@@ -36,6 +36,7 @@ import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.net.UnknownHostException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -243,19 +244,22 @@ public class IpNetwork extends Network {
     /**
      * Attempts an initial registration of this device as a foreign device in a BBMD. This method blocks until the
      * response (ACK or NAK) is received, or a timeout occurs (no response).
-     *
+     * <p>
      * If the device is successfully registered (ACK), regular re-registration requests will be sent to maintain the
      * registration. If any of these requests fail, the local device's exception dispatcher will be notified.
-     *
-     * If the device is to be un-registered, the registerAsForeignDevice method should be called. This will be done
+     * <p>
+     * If the device is to be un-registered, the unregisterAsForeignDevice method should be called. This will be done
      * automatically if the local device is terminated.
      *
      * @param addr       The address of the BBMD where our device wants to be registered
      * @param timeToLive The time until we are automatically removed out of the FDT
      * @throws BACnetException if a timeout occurs, a NAK is received, the device is already registered as a foreign
-     *                         device, or
-     *                         the request could not be sent.
+     *                         device, or the request could not be sent.
+     * @deprecated This method has two different mechanisms for handling registration failures: one when first called,
+     * and a second for re-registrations. Plus, the handling for the second case is . The new method below that
+     * consolidates error handling should be used instead.
      */
+    @Deprecated(since = "6.1.0")
     public void registerAsForeignDevice(final InetSocketAddress addr, final int timeToLive) throws BACnetException {
         if (timeToLive < 1)
             throw new IllegalArgumentException("timeToLive cannot be less than 1");
@@ -297,6 +301,105 @@ public class IpNetwork extends Network {
                     }
                 }
             }, interval, interval, TimeUnit.SECONDS);
+        }
+    }
+
+    /**
+     * The provider that tells the foreign device registration process how long to wait before a retry is attempted
+     * after a registration failure.
+     * <p>
+     * Default methods are an example of how it can work. More sophisticated implementations might provide exponential
+     * backoff or different results based upon the given exception.
+     */
+    public interface ForeignDeviceRegistrationRetryDelayProvider {
+        default void registrationSucceeded() {
+            // Allows implementations to reset after a series of failures.
+        }
+
+        default Duration registrationFailed(BACnetException e) {
+            return Duration.ofSeconds(10);
+        }
+    }
+
+    /**
+     * Starts the process of registration and re-registration of this device as a foreign device in a BBMD. This method
+     * is non-blocking.
+     * <p>
+     * If a registration attempt succeeds, a re-registration will be scheduled for just before the current registration
+     * times out. If the registration attempt fails, the `retryDelayProvider` will be asked for the delay before a
+     * retry. This process will not end until the unregisterAsForeignDevice method is called.
+     * <p>
+     * The unregisterAsForeignDevice method will be called automatically if the local device is terminated.
+     *
+     * @param addr               The address of the BBMD where our device wants to be registered
+     * @param timeToLive         The time in seconds until we are automatically removed out of the FDT
+     * @param retryDelayProvider provides the amount of
+     */
+    public void registerAsForeignDevice(InetSocketAddress addr, Duration timeToLive,
+            ForeignDeviceRegistrationRetryDelayProvider retryDelayProvider) {
+        int ttlSeconds = (int) timeToLive.getSeconds();
+        if (ttlSeconds < 1)
+            throw new IllegalArgumentException("timeToLive cannot be less than 1");
+        if (getTransport() == null || getTransport().getLocalDevice() == null)
+            throw new IllegalArgumentException(
+                    "Network must be used within a local device before foreign device registration can be performed.");
+
+        synchronized (foreignBBMDLock) {
+            if (foreignBBMD != null)
+                throw new IllegalStateException("Already registered as a foreign device");
+
+            foreignBBMD = addr;
+            foreignTTL = ttlSeconds;
+
+            ForeignDeviceRegistrant registrant = new ForeignDeviceRegistrant(retryDelayProvider);
+
+            // Initially schedule to run immediately.
+            foreignRegistrationMaintenance =
+                    getTransport().getLocalDevice().schedule(registrant, 0, TimeUnit.SECONDS);
+        }
+    }
+
+    class ForeignDeviceRegistrant implements Runnable {
+        private final ForeignDeviceRegistrationRetryDelayProvider retryDelayProvider;
+
+        ForeignDeviceRegistrant(ForeignDeviceRegistrationRetryDelayProvider retryDelayProvider) {
+            this.retryDelayProvider = retryDelayProvider;
+        }
+
+        public void run() {
+            synchronized (foreignBBMDLock) {
+                // Ensure expected state.
+                if (foreignRegistrationMaintenance == null || foreignRegistrationMaintenance.isCancelled()) {
+                    // Abort
+                    return;
+                }
+
+                int delay;
+                try {
+                    sendForeignDeviceRegistration();
+                    LOG.info("Successfully registered as foreign device");
+                    retryDelayProvider.registrationSucceeded();
+
+                    // Successful registration. Schedule the next re-registration for 30 seconds before the timeout.
+                    int interval = foreignTTL - 30;
+                    // ... but since the ttl can be less than 30, we need to correct.
+                    if (interval < 15) {
+                        // Minimum of 15s.
+                        interval = 15;
+                    }
+                    delay = interval;
+                } catch (final BACnetException e) {
+                    LOG.warn("Failed to register foreign device", e);
+                    // Failure. Ask the retry provider what to do.
+                    delay = (int) retryDelayProvider.registrationFailed(e).toSeconds();
+                    if (delay < 0) {
+                        delay = 0;
+                    }
+                }
+
+                foreignRegistrationMaintenance =
+                        getTransport().getLocalDevice().schedule(this, delay, TimeUnit.SECONDS);
+            }
         }
     }
 

--- a/src/main/java/com/serotonin/bacnet4j/npdu/ip/IpNetwork.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/ip/IpNetwork.java
@@ -305,19 +305,24 @@ public class IpNetwork extends Network {
     }
 
     /**
-     * The provider that tells the foreign device registration process how long to wait before a retry is attempted
-     * after a registration failure.
+     * The policy that tells the foreign device registration process how long to wait before a retry is attempted
+     * after a registration failure. It also allows the specification of the renewal margin, or the time before a lease
+     * ends to attempt a re-registration.
      * <p>
      * Default methods are an example of how it can work. More sophisticated implementations might provide exponential
      * backoff or different results based upon the given exception.
      */
-    public interface ForeignDeviceRegistrationRetryDelayProvider {
+    public interface ForeignDeviceRegistrationRetryDelayPolicy {
         default void registrationSucceeded() {
             // Allows implementations to reset after a series of failures.
         }
 
         default Duration registrationFailed(BACnetException e) {
             return Duration.ofSeconds(10);
+        }
+
+        default Duration renewalMargin(Duration timeToLive) {
+            return Duration.ofSeconds(30);
         }
     }
 
@@ -326,17 +331,18 @@ public class IpNetwork extends Network {
      * is non-blocking.
      * <p>
      * If a registration attempt succeeds, a re-registration will be scheduled for just before the current registration
-     * times out. If the registration attempt fails, the `retryDelayProvider` will be asked for the delay before a
+     * times out. If the registration attempt fails, the `retryDelayPolicy` will be asked for the delay before a
      * retry. This process will not end until the unregisterAsForeignDevice method is called.
      * <p>
      * The unregisterAsForeignDevice method will be called automatically if the local device is terminated.
      *
-     * @param addr               The address of the BBMD where our device wants to be registered
-     * @param timeToLive         The time in seconds until we are automatically removed out of the FDT
-     * @param retryDelayProvider provides the amount of
+     * @param addr             The address of the BBMD where our device wants to be registered
+     * @param timeToLive       The time in seconds until we are automatically removed out of the FDT
+     * @param retryDelayPolicy Provides the amount of time to delay before attempting another registration after a
+     *                         failure.
      */
     public void registerAsForeignDevice(InetSocketAddress addr, Duration timeToLive,
-            ForeignDeviceRegistrationRetryDelayProvider retryDelayProvider) {
+            ForeignDeviceRegistrationRetryDelayPolicy retryDelayPolicy) {
         int ttlSeconds = (int) timeToLive.getSeconds();
         if (ttlSeconds < 1)
             throw new IllegalArgumentException("timeToLive cannot be less than 1");
@@ -351,7 +357,7 @@ public class IpNetwork extends Network {
             foreignBBMD = addr;
             foreignTTL = ttlSeconds;
 
-            ForeignDeviceRegistrant registrant = new ForeignDeviceRegistrant(retryDelayProvider);
+            ForeignDeviceRegistrant registrant = new ForeignDeviceRegistrant(retryDelayPolicy);
 
             // Initially schedule to run immediately.
             foreignRegistrationMaintenance =
@@ -360,10 +366,10 @@ public class IpNetwork extends Network {
     }
 
     class ForeignDeviceRegistrant implements Runnable {
-        private final ForeignDeviceRegistrationRetryDelayProvider retryDelayProvider;
+        private final ForeignDeviceRegistrationRetryDelayPolicy retryDelayPolicy;
 
-        ForeignDeviceRegistrant(ForeignDeviceRegistrationRetryDelayProvider retryDelayProvider) {
-            this.retryDelayProvider = retryDelayProvider;
+        ForeignDeviceRegistrant(ForeignDeviceRegistrationRetryDelayPolicy retryDelayPolicy) {
+            this.retryDelayPolicy = retryDelayPolicy;
         }
 
         public void run() {
@@ -378,11 +384,11 @@ public class IpNetwork extends Network {
                 try {
                     sendForeignDeviceRegistration();
                     LOG.info("Successfully registered as foreign device");
-                    retryDelayProvider.registrationSucceeded();
+                    retryDelayPolicy.registrationSucceeded();
 
-                    // Successful registration. Schedule the next re-registration for 30 seconds before the timeout.
-                    int interval = foreignTTL - 30;
-                    // ... but since the ttl can be less than 30, we need to correct.
+                    // Successful registration. Schedule the next re-registration.
+                    int interval = foreignTTL -
+                            (int) retryDelayPolicy.renewalMargin(Duration.ofSeconds(foreignTTL)).getSeconds();
                     if (interval < 15) {
                         // Minimum of 15s.
                         interval = 15;
@@ -391,7 +397,7 @@ public class IpNetwork extends Network {
                 } catch (final BACnetException e) {
                     LOG.warn("Failed to register foreign device", e);
                     // Failure. Ask the retry provider what to do.
-                    delay = (int) retryDelayProvider.registrationFailed(e).toSeconds();
+                    delay = (int) retryDelayPolicy.registrationFailed(e).toSeconds();
                     if (delay < 0) {
                         delay = 0;
                     }

--- a/src/main/java/com/serotonin/bacnet4j/npdu/ip/IpNetwork.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/ip/IpNetwork.java
@@ -248,8 +248,8 @@ public class IpNetwork extends Network {
      * If the device is successfully registered (ACK), regular re-registration requests will be sent to maintain the
      * registration. If any of these requests fail, the local device's exception dispatcher will be notified.
      * <p>
-     * If the device is to be un-registered, the unregisterAsForeignDevice method should be called. This will be done
-     * automatically if the local device is terminated.
+     * If the device is to be un-registered, the {@link #unregisterAsForeignDevice} method should be called. This will
+     * be done automatically if the local device is terminated.
      *
      * @param addr       The address of the BBMD where our device wants to be registered
      * @param timeToLive The time until we are automatically removed out of the FDT
@@ -306,21 +306,35 @@ public class IpNetwork extends Network {
 
     /**
      * The policy that tells the foreign device registration process how long to wait before a retry is attempted
-     * after a registration failure. It also allows the specification of the renewal margin, or the time before a lease
-     * ends to attempt a re-registration.
+     * after a registration failure. It also allows the specification of the renewal margin, or the amount of time
+     * before a lease ends to attempt a re-registration.
      * <p>
      * Default methods are an example of how it can work. More sophisticated implementations might provide exponential
      * backoff or different results based upon the given exception.
      */
     public interface ForeignDeviceRegistrationRetryDelayPolicy {
+        /**
+         * Notifies this policy that a (re)registration has succeeded. This provides the policy an opportunity to reset,
+         * or perhaps to dismiss an error condition.
+         */
         default void registrationSucceeded() {
             // Allows implementations to reset after a series of failures.
         }
 
+        /**
+         * @param e the exception that caused the registration to fail.
+         * @return the amount of time to wait before attempting the registration again.
+         */
         default Duration registrationFailed(BACnetException e) {
             return Duration.ofSeconds(10);
         }
 
+        /**
+         * Provides the renewal margin, or the amount of time before a lease ends to attempt a re-registration.
+         *
+         * @param timeToLive the original TTL given for the registration.
+         * @return the amount of time before the end of the lease to attempt a re-registration
+         */
         default Duration renewalMargin(Duration timeToLive) {
             return Duration.ofSeconds(30);
         }
@@ -332,9 +346,9 @@ public class IpNetwork extends Network {
      * <p>
      * If a registration attempt succeeds, a re-registration will be scheduled for just before the current registration
      * times out. If the registration attempt fails, the `retryDelayPolicy` will be asked for the delay before a
-     * retry. This process will not end until the unregisterAsForeignDevice method is called.
+     * retry. This process will not end until the {@link #unregisterAsForeignDevice} method is called.
      * <p>
-     * The unregisterAsForeignDevice method will be called automatically if the local device is terminated.
+     * The {@link #unregisterAsForeignDevice} method will be called automatically if the local device is terminated.
      *
      * @param addr             The address of the BBMD where our device wants to be registered
      * @param timeToLive       The time in seconds until we are automatically removed out of the FDT
@@ -1131,7 +1145,7 @@ public class IpNetwork extends Network {
 
     /**
      * Utility method that allows the de-registration of an arbitrary foreign device in a BBMD. If the intention is
-     * to unregister this device, the unregisterAsForeignDevice method should be used instead.
+     * to unregister this device, the {@link #unregisterAsForeignDevice} method should be used instead.
      *
      * @param addr     the address at which to find the FDT
      * @param fdtEntry the entry to remove

--- a/src/test/java/com/serotonin/bacnet4j/npdu/ip/IpNetworkTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/npdu/ip/IpNetworkTest.java
@@ -203,9 +203,12 @@ public class IpNetworkTest extends AbstractTest {
     public void registerAsForeignDevice() throws Exception {
         IpNetwork network = spy(new IpNetworkBuilder().withBroadcast("1.2.3.255", 24).build());
 
+        var ttl = Duration.ofHours(12);
+        var renewal = Duration.ofHours(6);
+
         var totalSuccesses = new AtomicInteger(0);
         var totalFailures = new AtomicInteger(0);
-        var retryDelayProvider = new IpNetwork.ForeignDeviceRegistrationRetryDelayProvider() {
+        var retryDelayProvider = new IpNetwork.ForeignDeviceRegistrationRetryDelayPolicy() {
             int failures = 0;
 
             @Override
@@ -224,7 +227,15 @@ public class IpNetworkTest extends AbstractTest {
                 }
                 return Duration.ofSeconds(30);
             }
+
+            @Override
+            public Duration renewalMargin(Duration timeToLive) {
+                // Attempt re-registration after half of the lease time has expired.
+                return Duration.ofSeconds(timeToLive.getSeconds() / 2);
+            }
         };
+
+        assertEquals(Duration.ofSeconds(60 * 60 * 6), Duration.ofHours(6));
 
         var future = mock(ScheduledFuture.class);
         doReturn(false).when(future).isCancelled();
@@ -249,7 +260,7 @@ public class IpNetworkTest extends AbstractTest {
                 .when(network).sendForeignDeviceRegistration();
 
         network.registerAsForeignDevice(InetSocketAddress.createUnresolved("1.2.3.4", IpNetwork.DEFAULT_PORT),
-                Duration.ofHours(12), retryDelayProvider);
+                ttl, retryDelayProvider);
         assertEquals(0, totalSuccesses.get());
         assertEquals(0, totalFailures.get());
         verify(localDevice, times(1)).schedule(any(), eq(0L), eq(TimeUnit.SECONDS));
@@ -264,7 +275,7 @@ public class IpNetworkTest extends AbstractTest {
         task.get().run();
         assertEquals(1, totalSuccesses.get());
         assertEquals(1, totalFailures.get());
-        verify(localDevice, times(1)).schedule(any(), anyLong(), any());
+        verify(localDevice, times(1)).schedule(any(), eq(renewal.getSeconds()), eq(TimeUnit.SECONDS));
         clearInvocations(localDevice);
 
         task.get().run();
@@ -282,7 +293,7 @@ public class IpNetworkTest extends AbstractTest {
         task.get().run();
         assertEquals(2, totalSuccesses.get());
         assertEquals(3, totalFailures.get());
-        verify(localDevice, times(1)).schedule(any(), anyLong(), any());
+        verify(localDevice, times(1)).schedule(any(), eq(renewal.getSeconds()), eq(TimeUnit.SECONDS));
         clearInvocations(localDevice);
 
         network.unregisterAsForeignDevice();

--- a/src/test/java/com/serotonin/bacnet4j/npdu/ip/IpNetworkTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/npdu/ip/IpNetworkTest.java
@@ -32,17 +32,31 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.net.InetSocketAddress;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
 
+import com.serotonin.bacnet4j.AbstractTest;
 import com.serotonin.bacnet4j.LocalDevice;
 import com.serotonin.bacnet4j.RemoteDevice;
 import com.serotonin.bacnet4j.RemoteObject;
@@ -50,6 +64,7 @@ import com.serotonin.bacnet4j.TestUtils;
 import com.serotonin.bacnet4j.docker.DockerRemoteDevice;
 import com.serotonin.bacnet4j.event.DefaultDeviceEventListener;
 import com.serotonin.bacnet4j.event.DeviceEventListener;
+import com.serotonin.bacnet4j.exception.BACnetException;
 import com.serotonin.bacnet4j.transport.DefaultTransport;
 import com.serotonin.bacnet4j.transport.Transport;
 import com.serotonin.bacnet4j.type.constructed.Address;
@@ -60,7 +75,7 @@ import com.serotonin.bacnet4j.util.sero.IpAddressUtils;
  * executed in a docker environment. See @{@link DockerRemoteDevice}, which sends both broadcast and unicast
  * messages every second.
  */
-public class IpNetworkTest {
+public class IpNetworkTest extends AbstractTest {
     @Test
     public void receiveUnicastAndBroadcast() throws Exception {
         assumeTrue(TestUtils.isDockerEnv());
@@ -182,5 +197,102 @@ public class IpNetworkTest {
         InetSocketAddress addr = network.getLocalAddress();
         assertArrayEquals(IpAddressUtils.toIpAddress("1.2.3.4"), addr.getAddress().getAddress());
         assertEquals(port, addr.getPort());
+    }
+
+    @Test
+    public void registerAsForeignDevice() throws Exception {
+        IpNetwork network = spy(new IpNetworkBuilder().withBroadcast("1.2.3.255", 24).build());
+
+        var totalSuccesses = new AtomicInteger(0);
+        var totalFailures = new AtomicInteger(0);
+        var retryDelayProvider = new IpNetwork.ForeignDeviceRegistrationRetryDelayProvider() {
+            int failures = 0;
+
+            @Override
+            public void registrationSucceeded() {
+                totalSuccesses.incrementAndGet();
+                failures = 0;
+            }
+
+            @Override
+            public Duration registrationFailed(BACnetException e) {
+                totalFailures.incrementAndGet();
+                failures++;
+
+                if (failures <= 1) {
+                    return Duration.ofSeconds(10);
+                }
+                return Duration.ofSeconds(30);
+            }
+        };
+
+        var future = mock(ScheduledFuture.class);
+        doReturn(false).when(future).isCancelled();
+
+        var transport = mock(Transport.class);
+        var localDevice = mock(LocalDevice.class);
+        doReturn(localDevice).when(transport).getLocalDevice();
+        var task = new AtomicReference<Runnable>();
+        when(localDevice.schedule(any(), anyLong(), any())).thenAnswer(invocation -> {
+            Runnable r = invocation.getArgument(0);
+            task.set(r);
+            return future;
+        });
+
+        network.initialize(transport);
+
+        doThrow(new BACnetException()) // Fail the initial registration...
+                .doNothing() // ... but succeed the second try.
+                .doThrow(new BACnetException()) // Fail once...
+                .doThrow(new BACnetException()) // ... and twice on re-registration
+                .doNothing() // ... and then succeed.
+                .when(network).sendForeignDeviceRegistration();
+
+        network.registerAsForeignDevice(InetSocketAddress.createUnresolved("1.2.3.4", IpNetwork.DEFAULT_PORT),
+                Duration.ofHours(12), retryDelayProvider);
+        assertEquals(0, totalSuccesses.get());
+        assertEquals(0, totalFailures.get());
+        verify(localDevice, times(1)).schedule(any(), eq(0L), eq(TimeUnit.SECONDS));
+        clearInvocations(localDevice);
+
+        task.get().run();
+        assertEquals(0, totalSuccesses.get());
+        assertEquals(1, totalFailures.get());
+        verify(localDevice, times(1)).schedule(any(), eq(10L), eq(TimeUnit.SECONDS));
+        clearInvocations(localDevice);
+
+        task.get().run();
+        assertEquals(1, totalSuccesses.get());
+        assertEquals(1, totalFailures.get());
+        verify(localDevice, times(1)).schedule(any(), anyLong(), any());
+        clearInvocations(localDevice);
+
+        task.get().run();
+        assertEquals(1, totalSuccesses.get());
+        assertEquals(2, totalFailures.get());
+        verify(localDevice, times(1)).schedule(any(), eq(10L), eq(TimeUnit.SECONDS));
+        clearInvocations(localDevice);
+
+        task.get().run();
+        assertEquals(1, totalSuccesses.get());
+        assertEquals(3, totalFailures.get());
+        verify(localDevice, times(1)).schedule(any(), eq(30L), eq(TimeUnit.SECONDS));
+        clearInvocations(localDevice);
+
+        task.get().run();
+        assertEquals(2, totalSuccesses.get());
+        assertEquals(3, totalFailures.get());
+        verify(localDevice, times(1)).schedule(any(), anyLong(), any());
+        clearInvocations(localDevice);
+
+        network.unregisterAsForeignDevice();
+
+        task.get().run();
+        assertEquals(2, totalSuccesses.get());
+        assertEquals(3, totalFailures.get());
+        verify(localDevice, never()).schedule(any(), anyLong(), any());
+        verify(network, times(5)).sendForeignDeviceRegistration();
+
+        network.terminate();
     }
 }


### PR DESCRIPTION
https://radixiot.atlassian.net/browse/MANGO-2732

Creates a new foreign device registration process that is failure-tolerant, allowing user code to determine the amount of time to delay before retrying a registration request after a failure. This differs from the original in that initial registration failures needed to be handled differently from re-registration failures.
