### PR TITLE
MANGO-2833 Support adding and removing cached remote devices

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <url>https://www.infiniteautomation.com/</url>
     </organization>
     <properties>
-        <revision>6.1.0-SNAPSHOT</revision>
+        <revision>6.2.0-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <additionalDeploymentRepositoryId>additional-deployment-repository</additionalDeploymentRepositoryId>
         <maven.compiler.release>17</maven.compiler.release>
@@ -212,7 +212,7 @@
             <version>1.1.1</version>
             <scope>test</scope>
         </dependency>
-        
+
     </dependencies>
     <issueManagement>
         <url>https://github.com/infiniteautomation/BACnet4J/issues</url>

--- a/src/main/java/com/serotonin/bacnet4j/LocalDevice.java
+++ b/src/main/java/com/serotonin/bacnet4j/LocalDevice.java
@@ -1019,12 +1019,10 @@ public class LocalDevice implements AutoCloseable {
 
     public void setCachedRemoteProperty(final int did, final ObjectIdentifier oid, final PropertyIdentifier pid,
             final UnsignedInteger pin, final Encodable value) {
-        if (value instanceof ErrorClassAndCode e) {
-            if (ErrorClass.device.equals(e.getErrorClass())) {
-                // Don't cache devices if the error is about the device. In fact, delete the cached device.
-                remoteDeviceCache.removeEntity(did);
-                return;
-            }
+        if (value instanceof ErrorClassAndCode e && ErrorClass.device.equals(e.getErrorClass())) {
+            // Don't cache devices if the error is about the device. In fact, delete the cached device.
+            remoteDeviceCache.removeEntity(did);
+            return;
         }
 
         final RemoteDevice rd = getCachedRemoteDevice(did);

--- a/src/main/java/com/serotonin/bacnet4j/LocalDevice.java
+++ b/src/main/java/com/serotonin/bacnet4j/LocalDevice.java
@@ -53,6 +53,7 @@ import org.slf4j.LoggerFactory;
 
 import com.serotonin.bacnet4j.cache.CachePolicies;
 import com.serotonin.bacnet4j.cache.RemoteEntityCache;
+import com.serotonin.bacnet4j.cache.RemoteEntityCachePolicy;
 import com.serotonin.bacnet4j.enums.MaxApduLength;
 import com.serotonin.bacnet4j.event.DefaultReinitializeDeviceHandler;
 import com.serotonin.bacnet4j.event.DeviceEventAdapter;
@@ -94,6 +95,7 @@ import com.serotonin.bacnet4j.type.enumerated.Segmentation;
 import com.serotonin.bacnet4j.type.error.ErrorClassAndCode;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
+import com.serotonin.bacnet4j.util.DiscoveryUtils;
 import com.serotonin.bacnet4j.util.RemoteDeviceDiscoverer;
 import com.serotonin.bacnet4j.util.RemoteDeviceFinder;
 import com.serotonin.bacnet4j.util.RemoteDeviceFinder.RemoteDeviceFuture;
@@ -430,31 +432,36 @@ public class LocalDevice implements AutoCloseable {
     /**
      * Schedules the given command for later execution.
      */
-    public ScheduledFuture<?> schedule(final Runnable command, final long period, final TimeUnit unit) {
-        return timer.schedule(command, period, unit);
+    @SuppressWarnings("unchecked")
+    public <T> ScheduledFuture<T> schedule(final Runnable command, final long period, final TimeUnit unit) {
+        return (ScheduledFuture<T>) timer.schedule(command, period, unit);
     }
 
     /**
      * Schedules the given command for later execution.
      */
-    public ScheduledFuture<?> scheduleAtFixedRate(final Runnable command, final long initialDelay, final long period,
-            final TimeUnit unit) {
-        return timer.scheduleAtFixedRate(command, initialDelay, period, unit);
+    @SuppressWarnings("unchecked")
+    public <T> ScheduledFuture<T> scheduleAtFixedRate(final Runnable command, final long initialDelay,
+            final long period, final TimeUnit unit) {
+        return (ScheduledFuture<T>) timer.scheduleAtFixedRate(command, initialDelay, period, unit);
     }
 
     /**
      * Schedules the given command for later execution.
      */
-    public ScheduledFuture<?> scheduleWithFixedDelay(final Runnable command, final long initialDelay, final long delay,
+    @SuppressWarnings("unchecked")
+    public <T> ScheduledFuture<T> scheduleWithFixedDelay(final Runnable command, final long initialDelay,
+            final long delay,
             final TimeUnit unit) {
-        return timer.scheduleWithFixedDelay(command, initialDelay, delay, unit);
+        return (ScheduledFuture<T>) timer.scheduleWithFixedDelay(command, initialDelay, delay, unit);
     }
 
     /**
      * Submits the given task for immediate execution.
      */
-    public Future<?> submit(final Runnable task) {
-        return timer.submit(task);
+    @SuppressWarnings("unchecked")
+    public <T> Future<T> submit(final Runnable task) {
+        return (Future<T>) timer.submit(task);
     }
 
     /**
@@ -767,10 +774,10 @@ public class LocalDevice implements AutoCloseable {
     /**
      * Returns the remote device for the given instanceNumber. If a cached instance is not found the finder will be used
      * to try and find it. A timeout exception is thrown if it can't be found.
-     *
+     * <p/>
      * The benefits of this method are: 1) It will cache the remote device if it is found. 2) Multiple threads that
      * request the same remote device around the same time will be joined on the same request
-     *
+     * <p/>
      * If you require the ability to cancel a request, use the non-blocking method above.
      *
      * @param instanceNumber the instance number of the desired device
@@ -835,6 +842,18 @@ public class LocalDevice implements AutoCloseable {
         }
 
         return rd;
+    }
+
+    public void addRemoteDevice(RemoteDevice rd) throws BACnetException {
+        // Ensure that the remote device has all the required properties. Is a no op if it has already been fully
+        // configured.
+        DiscoveryUtils.getExtendedDeviceInformation(this, rd);
+        // Add to cache with a policy to never expire because this was not automatically discovered.
+        remoteDeviceCache.putEntity(rd.getInstanceNumber(), rd, RemoteEntityCachePolicy.NEVER_EXPIRE);
+    }
+
+    public void removeRemoteDevice(int deviceId) {
+        remoteDeviceCache.removeEntity(deviceId);
     }
 
     @Override

--- a/src/main/java/com/serotonin/bacnet4j/RemoteDevice.java
+++ b/src/main/java/com/serotonin/bacnet4j/RemoteDevice.java
@@ -27,6 +27,7 @@
 
 package com.serotonin.bacnet4j;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 import com.serotonin.bacnet4j.cache.RemoteEntityCache;
@@ -43,14 +44,15 @@ import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
 public class RemoteDevice implements Serializable {
+    @Serial
     private static final long serialVersionUID = 6338537708566242078L;
 
-    private final LocalDevice localDevice;
-    private final ObjectIdentifier deviceOid;
-    private Address address;
-    private Object userData;
+    private final transient LocalDevice localDevice;
+    private final transient ObjectIdentifier deviceOid;
+    private transient Address address;
+    private transient Object userData;
     private int maxReadMultipleReferences = -1;
-    private final RemoteEntityCache<ObjectIdentifier, RemoteObject> remoteObjectCache;
+    private final transient RemoteEntityCache<ObjectIdentifier, RemoteObject> remoteObjectCache;
 
     public RemoteDevice(final LocalDevice localDevice, final int instanceNumber) {
         this.localDevice = localDevice;
@@ -69,30 +71,6 @@ public class RemoteDevice implements Serializable {
         this.address = address;
     }
 
-    /**
-     * Add properties that are in 'that' if they are not already in 'this'.
-     *
-     * @param that
-     */
-    //    public void merge(final RemoteDevice that) {
-    //        synchronized (objects) {
-    //            for (final Map.Entry<ObjectIdentifier, RemoteObject> e : that.objects.entrySet()) {
-    //                if (e.getValue() != null) {
-    //                    final RemoteObject o = objects.get(e.getKey());
-    //                    if (o == null) {
-    //                        objects.put(e.getKey(), e.getValue());
-    //                    } else {
-    //                        o.merge(e.getValue());
-    //                    }
-    //                }
-    //            }
-    //        }
-    //
-    //        if (userData != null)
-    //            userData = that.userData;
-    //        if (maxReadMultipleReferences != -1)
-    //            maxReadMultipleReferences = that.maxReadMultipleReferences;
-    //    }
     public int getInstanceNumber() {
         return deviceOid.getInstanceNumber();
     }
@@ -153,16 +131,13 @@ public class RemoteDevice implements Serializable {
 
     public void setObjectProperty(final ObjectIdentifier oid, final PropertyIdentifier pid, final UnsignedInteger pin,
             final Encodable value) {
-        if (value instanceof ErrorClassAndCode) {
-            final ErrorClassAndCode e = (ErrorClassAndCode) value;
-            if (ErrorClass.object.equals(e.getErrorClass())) {
-                // Don't create objects if the error is about the object.
-                // But don't remove the object because it is possible to get error responses on objects that
-                // didn't cause the error. For example, a read multiple request can contain requests for properties
-                // of multiple objects. But if only one of these objects doesn't exist, an error is returned for the
-                // whole request, and this error can be assigned to the objects that do exist.
-                return;
-            }
+        if (value instanceof ErrorClassAndCode e && ErrorClass.object.equals(e.getErrorClass())) {
+            // Don't create objects if the error is about the object.
+            // But don't remove the object because it is possible to get error responses on objects that
+            // didn't cause the error. For example, a read multiple request can contain requests for properties
+            // of multiple objects. But if only one of these objects doesn't exist, an error is returned for the
+            // whole request, and this error can be assigned to the objects that do exist.
+            return;
         }
 
         synchronized (remoteObjectCache) {
@@ -214,7 +189,7 @@ public class RemoteDevice implements Serializable {
     }
 
     public Segmentation getSegmentationSupported() {
-        return (Segmentation) getDeviceProperty(PropertyIdentifier.segmentationSupported);
+        return getDeviceProperty(PropertyIdentifier.segmentationSupported);
     }
 
     public int getVendorIdentifier() {
@@ -234,18 +209,18 @@ public class RemoteDevice implements Serializable {
     }
 
     public ServicesSupported getServicesSupported() {
-        return (ServicesSupported) getDeviceProperty(PropertyIdentifier.protocolServicesSupported);
+        return getDeviceProperty(PropertyIdentifier.protocolServicesSupported);
     }
 
     public int getUnsignedIntegerProperty(final PropertyIdentifier pid) {
-        final UnsignedInteger p = (UnsignedInteger) getDeviceProperty(pid);
+        final UnsignedInteger p = getDeviceProperty(pid);
         if (p == null)
             return -1;
         return p.intValue();
     }
 
     public String getCharacterStringProperty(final PropertyIdentifier pid) {
-        final CharacterString p = (CharacterString) getDeviceProperty(pid);
+        final CharacterString p = getDeviceProperty(pid);
         if (p == null)
             return null;
         return p.getValue();

--- a/src/main/java/com/serotonin/bacnet4j/npdu/ip/IpNetwork.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/ip/IpNetwork.java
@@ -812,7 +812,7 @@ public class IpNetwork extends Network {
                 response.pushU2B(0x10); // NAK
             }
         } else {
-            response.pushU2B(0x10); // NAK  
+            response.pushU2B(0x10); // NAK
         }
         sendPacket(IpNetworkUtils.getInetSocketAddress(origin), response.popAll());
     }

--- a/src/main/java/com/serotonin/bacnet4j/transport/DefaultTransport.java
+++ b/src/main/java/com/serotonin/bacnet4j/transport/DefaultTransport.java
@@ -49,6 +49,7 @@ import com.serotonin.bacnet4j.apdu.SegmentACK;
 import com.serotonin.bacnet4j.apdu.Segmentable;
 import com.serotonin.bacnet4j.apdu.SimpleACK;
 import com.serotonin.bacnet4j.apdu.UnconfirmedRequest;
+import com.serotonin.bacnet4j.enums.MaxApduLength;
 import com.serotonin.bacnet4j.enums.MaxSegments;
 import com.serotonin.bacnet4j.exception.BACnetAbortException;
 import com.serotonin.bacnet4j.exception.BACnetErrorException;
@@ -301,6 +302,19 @@ public class DefaultTransport implements Transport, Runnable {
     @Override
     public void send(final Address address, final int maxAPDULengthAccepted, final Segmentation segmentationSupported,
             final ConfirmedRequestService service, final ResponseConsumer consumer) {
+        if (address == null) {
+            throw new IllegalArgumentException("address cannot be null");
+        }
+        if (maxAPDULengthAccepted < MaxApduLength.UP_TO_50.getMaxLengthInt()) {
+            throw new IllegalArgumentException("invalid maxAPDULengthAccepted: " + maxAPDULengthAccepted);
+        }
+        if (segmentationSupported == null) {
+            throw new IllegalArgumentException("segmentation supported cannot be null");
+        }
+        if (service == null) {
+            throw new IllegalArgumentException("service cannot be null");
+        }
+
         // 16.1.2
         if (EnableDisable.enable.equals(localDevice.getCommunicationControlState())) {
             var out = new OutgoingConfirmed(
@@ -537,6 +551,7 @@ public class DefaultTransport implements Transport, Runnable {
                 } catch (final Exception e) {
                     LOG.error("Error during send: {}", out, e);
                     LOG.error("Original send stack", out.stack);
+                    out.handleException(new BACnetException("Error during send", e));
                 }
                 pause = false;
             }

--- a/src/main/java/com/serotonin/bacnet4j/type/constructed/ServicesSupported.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/constructed/ServicesSupported.java
@@ -27,8 +27,13 @@
 
 package com.serotonin.bacnet4j.type.constructed;
 
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 
 import com.serotonin.bacnet4j.exception.BACnetErrorException;
 import com.serotonin.bacnet4j.type.primitive.BitString;
@@ -371,30 +376,32 @@ public class ServicesSupported extends BitString {
         getValue()[43] = confirmedCovNotificationMultiple;
     }
 
-    @Override
-    public String toString() {
+    @FunctionalInterface
+    public interface ServiceIteratorConsumer {
+        void accept(PropertyDescriptor serviceProperty) throws IllegalAccessException, InvocationTargetException;
+    }
+
+    public void iterateProperties(ServiceIteratorConsumer consumer) {
         try {
-            StringBuilder result = new StringBuilder("ServicesSupported[");
-            Method[] methods = this.getClass().getDeclaredMethods();
-            boolean first = true;
-            for (Method method : methods) {
-                if (method.getReturnType() == boolean.class) {
-                    if (first) {
-                        first = false;
-                    } else {
-                        result.append(", ");
-                    }
-                    result.append(method.getName().substring(2));
-                    result.append('=');
-                    result.append(method.invoke(this));
-                }
-            }
-            result.append(']');
-            return result.toString();
-        } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
-            //Should never happen
+            Arrays.stream(Introspector.getBeanInfo(getClass(), BitString.class).getPropertyDescriptors())
+                    .sorted(Comparator.comparing(PropertyDescriptor::getName))
+                    .forEach(pd -> {
+                        try {
+                            consumer.accept(pd);
+                        } catch (IllegalAccessException | InvocationTargetException ex) {
+                            throw new RuntimeException(ex.getMessage(), ex);
+                        }
+
+                    });
+        } catch (IntrospectionException ex) {
             throw new RuntimeException(ex.getMessage(), ex);
         }
     }
 
+    @Override
+    public String toString() {
+        var props = new ArrayList<String>();
+        iterateProperties(prop -> props.add(prop.getName() + "=" + prop.getReadMethod().invoke(this)));
+        return "ServicesSupported[" + String.join(", ", props) + "]";
+    }
 }

--- a/src/main/java/com/serotonin/bacnet4j/util/DiscoveryUtils.java
+++ b/src/main/java/com/serotonin/bacnet4j/util/DiscoveryUtils.java
@@ -32,24 +32,31 @@ import com.serotonin.bacnet4j.RemoteDevice;
 import com.serotonin.bacnet4j.exception.BACnetException;
 import com.serotonin.bacnet4j.service.acknowledgement.ReadPropertyAck;
 import com.serotonin.bacnet4j.service.confirmed.ReadPropertyRequest;
-import com.serotonin.bacnet4j.type.Encodable;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
 
 public class DiscoveryUtils {
+    private DiscoveryUtils() {
+    }
+
     public static void getExtendedDeviceInformation(final LocalDevice localDevice, final RemoteDevice d)
             throws BACnetException {
-        final ObjectIdentifier oid = d.getObjectIdentifier();
+        var oid = d.getObjectIdentifier();
 
-        // Get the device's supported services
+        // maxApduLengthAccepted and segmentationSupported need to be known to make requests to the device without
+        // having to use hopeful defaults.
+        ensurePropertyKnown(localDevice, d, oid, PropertyIdentifier.maxApduLengthAccepted);
+        ensurePropertyKnown(localDevice, d, oid, PropertyIdentifier.segmentationSupported);
+
+        // Ensure the device's supported services are known so we know if we can use read property multiple or not.
         if (d.getServicesSupported() == null) {
-            final ReadPropertyAck supportedServicesAck = (ReadPropertyAck) localDevice
+            ReadPropertyAck ack = localDevice
                     .send(d, new ReadPropertyRequest(oid, PropertyIdentifier.protocolServicesSupported)).get();
-            d.setDeviceProperty(PropertyIdentifier.protocolServicesSupported, supportedServicesAck.getValue());
+            d.setDeviceProperty(PropertyIdentifier.protocolServicesSupported, ack.getValue());
         }
 
         // Uses the readProperties method here because this list will probably be extended.
-        final PropertyReferences properties = new PropertyReferences();
+        var properties = new PropertyReferences();
         addIfMissing(d, properties, PropertyIdentifier.objectName);
         addIfMissing(d, properties, PropertyIdentifier.protocolVersion);
         addIfMissing(d, properties, PropertyIdentifier.vendorIdentifier);
@@ -58,10 +65,10 @@ public class DiscoveryUtils {
 
         if (properties.size() > 0) {
             // Only send a request if we have to.
-            final PropertyValues values = RequestUtils.readProperties(localDevice, d, properties, false, null);
+            var values = RequestUtils.readProperties(localDevice, d, properties, false, null);
 
-            values.forEach((opr) -> {
-                final Encodable value = values.getNullOnError(oid, opr.getPropertyIdentifier());
+            values.forEach(opr -> {
+                var value = values.getNullOnError(oid, opr.getPropertyIdentifier());
                 d.setDeviceProperty(opr.getPropertyIdentifier(), value);
             });
         }
@@ -71,5 +78,13 @@ public class DiscoveryUtils {
             final PropertyIdentifier pid) {
         if (d.getDeviceProperty(pid) == null)
             properties.add(d.getObjectIdentifier(), pid);
+    }
+
+    private static void ensurePropertyKnown(LocalDevice localDevice, RemoteDevice d, ObjectIdentifier oid,
+            PropertyIdentifier pid) throws BACnetException {
+        if (d.getDeviceProperty(pid) == null) {
+            ReadPropertyAck ack = localDevice.send(d.getAddress(), new ReadPropertyRequest(oid, pid)).get();
+            d.setDeviceProperty(pid, ack.getValue());
+        }
     }
 }

--- a/src/test/java/com/serotonin/bacnet4j/transport/DefaultTransportTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/transport/DefaultTransportTest.java
@@ -212,7 +212,7 @@ public class DefaultTransportTest {
         final Address to = new Address(0, new byte[] {1});
 
         sut.terminate();
-        ServiceFuture result = sut.send(to, 20, Segmentation.segmentedBoth, mock(ConfirmedRequestService.class));
+        ServiceFuture result = sut.send(to, 50, Segmentation.segmentedBoth, mock(ConfirmedRequestService.class));
 
         BACnetException e = Assert.assertThrows(BACnetException.class, result::get);
         Assert.assertTrue(e.getMessage().contains("not running"));

--- a/src/test/java/com/serotonin/bacnet4j/type/constructed/ServicesSupportedTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/type/constructed/ServicesSupportedTest.java
@@ -1,0 +1,47 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2026 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
+package com.serotonin.bacnet4j.type.constructed;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class ServicesSupportedTest {
+    @Test
+    public void toStringTest() {
+        var ss = new ServicesSupported();
+        ss.setAcknowledgeAlarm(true);
+        ss.setCreateObject(true);
+        ss.setTimeSynchronization(true);
+        ss.setUnconfirmedTextMessage(true);
+
+        assertEquals(
+                "ServicesSupported[IAm=false, IHave=false, acknowledgeAlarm=true, addListElement=false, atomicReadFile=false, atomicWriteFile=false, confirmedCovNotification=false, confirmedCovNotificationMultiple=false, confirmedEventNotification=false, confirmedPrivateTransfer=false, confirmedTextMessage=false, createObject=true, deleteObject=false, deviceCommunicationControl=false, getAlarmSummary=false, getEnrollmentSummary=false, getEventInformation=false, lifeSafetyOperation=false, readProperty=false, readPropertyMultiple=false, readRange=false, reinitializeDevice=false, removeListElement=false, subscribeCov=false, subscribeCovProperty=false, subscribeCovPropertyMultiple=false, timeSynchronization=true, unconfirmedCovNotification=false, unconfirmedCovNotificationMultiple=false, unconfirmedEventNotification=false, unconfirmedPrivateTransfer=false, unconfirmedTextMessage=true, utcTimeSynchronization=false, vtClose=false, vtData=false, vtOpen=false, whoHas=false, whoIs=false, writeGroup=false, writeProperty=false, writePropertyMultiple=false]",
+                ss.toString());
+    }
+}

--- a/src/test/java/com/serotonin/bacnet4j/util/DiscoveryUtilsTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/util/DiscoveryUtilsTest.java
@@ -1,0 +1,79 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2026 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
+package com.serotonin.bacnet4j.util;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test;
+
+import com.serotonin.bacnet4j.LocalDevice;
+import com.serotonin.bacnet4j.RemoteDevice;
+import com.serotonin.bacnet4j.cache.CachePolicies;
+import com.serotonin.bacnet4j.cache.RemoteEntityCachePolicy;
+import com.serotonin.bacnet4j.exception.BACnetException;
+import com.serotonin.bacnet4j.service.confirmed.ConfirmedRequestService;
+import com.serotonin.bacnet4j.type.constructed.Address;
+import com.serotonin.bacnet4j.type.constructed.ServicesSupported;
+import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
+import com.serotonin.bacnet4j.type.enumerated.Segmentation;
+import com.serotonin.bacnet4j.type.primitive.CharacterString;
+import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
+
+public class DiscoveryUtilsTest {
+    @Test
+    public void noUnnecessaryNetworkCalls() throws BACnetException {
+        var cachePolicies = mock(CachePolicies.class);
+        doReturn(RemoteEntityCachePolicy.NEVER_EXPIRE).when(cachePolicies).getObjectPolicy(anyInt(), any());
+        doReturn(RemoteEntityCachePolicy.NEVER_EXPIRE).when(cachePolicies).getPropertyPolicy(anyInt(), any(), any());
+
+        var localDevice = mock(LocalDevice.class);
+        doReturn(cachePolicies).when(localDevice).getCachePolicies();
+
+        var remoteDevice = new RemoteDevice(localDevice, 123, new Address(new byte[] {0}));
+        remoteDevice.setDeviceProperty(PropertyIdentifier.maxApduLengthAccepted, new UnsignedInteger(50));
+        remoteDevice.setDeviceProperty(PropertyIdentifier.segmentationSupported, Segmentation.segmentedBoth);
+        remoteDevice.setDeviceProperty(PropertyIdentifier.protocolServicesSupported, new ServicesSupported());
+        remoteDevice.setDeviceProperty(PropertyIdentifier.objectName, new CharacterString("name"));
+        remoteDevice.setDeviceProperty(PropertyIdentifier.protocolVersion, new UnsignedInteger(1));
+        remoteDevice.setDeviceProperty(PropertyIdentifier.vendorIdentifier, new UnsignedInteger(165));
+        remoteDevice.setDeviceProperty(PropertyIdentifier.modelName, new CharacterString("model"));
+        remoteDevice.setDeviceProperty(PropertyIdentifier.maxSegmentsAccepted, new UnsignedInteger(500));
+
+        var remoteDeviceSpy = spy(remoteDevice);
+        DiscoveryUtils.getExtendedDeviceInformation(localDevice, remoteDeviceSpy);
+
+        verify(localDevice, never()).send(any(RemoteDevice.class), any(ConfirmedRequestService.class));
+        verify(remoteDeviceSpy, never()).setDeviceProperty(any(PropertyIdentifier.class), any());
+    }
+}


### PR DESCRIPTION
This commit adds `LocalDevice.addRemoteDevice(RemoteDevice)` and `removeRemoteDevice(int)` to allow callers to manually manage the remote device cache — useful when a device address is known in advance rather than discovered via broadcast, in particular when devices cannot communicate via broadcast (i.e. WhoIs and IAm). Devices added this way are cached with NEVER_EXPIRE and have their extended properties fetched utomatically via `DiscoveryUtils.getExtendedDeviceInformation` if the required properties are not already present in the remote device..

Notable supporting changes:

- `DiscoveryUtils: getExtendedDeviceInformation` now eagerly fetches `maxApduLengthAccepted` and `segmentationSupported` upfront (via the new `ensurePropertyKnown` helper) before attempting any higher-level reads. This is important for the unicast/manual-add path where these cannot be assumed.
- `DefaultTransport.send()`: Added null/invalid-argument validation with a clear `IllegalArgumentException`. Also fixed a silent failure in the send loop — exceptions are now propagated to the caller via handleException instead of just being logged.
- `ServicesSupported`: Replaced raw reflection with `Introspector.getBeanInfo`, extracted a reusable `iterateProperties(ServiceIteratorConsumer)` method, and sorted output alphabetically. The old `toString` relied on `getDeclaredMethods` ordering.
- `RemoteDevice`: Fields that shouldn't survive serialization are now properly marked transient. Removed a large commented-out `merge()` block and modernized several unchecked casts using pattern matching and generics.
- `LocalDevice` scheduler methods: Made generic (Future<T>) to eliminate unchecked cast warnings at call sites.

Tests added: `ServicesSupportedTest` (verifies sorted alphabetical output) and `DiscoveryUtilsTest` (verifies no network calls are made when all required properties are already cached).

Version bumped to 6.2.0-SNAPSHOT.