### PR TITLE
MANGO-5921 Do not add objects to device in constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ Releases
   initialization problems. Instead, objects need to be explicitly added to the local device after instantiation. Many
   examples can be found in the unit tests, but e.g.:
 
-```java
+```
 // Old code
-var av = new AnalogValueObject(localDevice, ...)
+var av = new AnalogValueObject(localDevice, ...);
 // New code
-var av = localDevice.addObject(new AnalogVAlueObject(localDevice, ...))
+var av = localDevice.addObject(new AnalogValueObject(localDevice, ...));
 ```
 
 *Version 6.2.0*

--- a/README.md
+++ b/README.md
@@ -63,6 +63,19 @@ The dependency information is BACnet4J pre 5.0 is:
 
 Releases
 ========
+*Version 7.0.0*
+
+- Breaking change: BACnet objects are no longer added to the local device in their constructors because of
+  initialization problems. Instead, objects need to be explicitly added to the local device after instantiation. Many
+  examples can be found in the unit tests, but e.g.:
+
+```java
+// Old code
+var av = new AnalogValueObject(localDevice, ...)
+// New code
+var av = localDevice.addObject(new AnalogVAlueObject(localDevice, ...))
+```
+
 *Version 6.2.0*
 
 - Methods `LocalDevice.addRemoteDevice(RemoteDevice)` and `LocalDevice.removeRemoteDevice(int)` have been added to allow

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <url>https://www.infiniteautomation.com/</url>
     </organization>
     <properties>
-        <revision>6.2.0-SNAPSHOT</revision>
+        <revision>7.0.0-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <additionalDeploymentRepositoryId>additional-deployment-repository</additionalDeploymentRepositoryId>
         <maven.compiler.release>17</maven.compiler.release>

--- a/src/main/java/com/serotonin/bacnet4j/LocalDevice.java
+++ b/src/main/java/com/serotonin/bacnet4j/LocalDevice.java
@@ -196,7 +196,7 @@ public class LocalDevice implements AutoCloseable {
     private void afterInstantiation(final int deviceNumber) {
         try {
             // Initialize the device object.
-            new DeviceObject(this, deviceNumber);
+            addObject(new DeviceObject(this, deviceNumber));
         } catch (final BACnetServiceException e) {
             // Should not happen
             throw new RuntimeException(e);
@@ -551,7 +551,7 @@ public class LocalDevice implements AutoCloseable {
         return null;
     }
 
-    public void addObject(final BACnetObject obj) throws BACnetServiceException {
+    public <T extends BACnetObject> T addObject(final T obj) throws BACnetServiceException {
         if (obj.getId().getObjectType().equals(ObjectType.device)) {
             if (deviceObject == null) {
                 deviceObject = (DeviceObject) obj;
@@ -565,12 +565,17 @@ public class LocalDevice implements AutoCloseable {
         if (getObject(obj.getObjectName()) != null)
             throw new BACnetServiceException(ErrorClass.object, ErrorCode.duplicateName);
 
+        if (obj.getLocalDevice() != this) {
+            throw new IllegalArgumentException("Cannot add an object not created with this local device");
+        }
         localObjects.add(obj);
 
         if (initialized) {
             // If the local device is already initialized, initialize the object.
             obj.initialize();
         }
+
+        return obj;
     }
 
     public ObjectIdentifier getNextInstanceObjectIdentifier(final ObjectType objectType) {

--- a/src/main/java/com/serotonin/bacnet4j/event/DefaultReinitializeDeviceHandler.java
+++ b/src/main/java/com/serotonin/bacnet4j/event/DefaultReinitializeDeviceHandler.java
@@ -105,10 +105,6 @@ public class DefaultReinitializeDeviceHandler implements ReinitializeDeviceHandl
 
     /**
      * Override as required.
-     *
-     * @param localDevice
-     * @param from
-     * @throws BACnetErrorException
      */
     protected void coldstart(final LocalDevice localDevice, final Address from) throws BACnetErrorException {
         throw new BACnetErrorException(ErrorClass.device, ErrorCode.notConfigured);
@@ -116,10 +112,6 @@ public class DefaultReinitializeDeviceHandler implements ReinitializeDeviceHandl
 
     /**
      * Override as required.
-     *
-     * @param localDevice
-     * @param from
-     * @throws BACnetErrorException
      */
     protected void warmstart(final LocalDevice localDevice, final Address from) throws BACnetErrorException {
         throw new BACnetErrorException(ErrorClass.device, ErrorCode.notConfigured);
@@ -127,10 +119,6 @@ public class DefaultReinitializeDeviceHandler implements ReinitializeDeviceHandl
 
     /**
      * Override as required.
-     *
-     * @param localDevice
-     * @param from
-     * @throws BACnetErrorException
      */
     protected void startBackup(final LocalDevice localDevice, final Address from) throws BACnetErrorException {
         LOG.info("Starting backup");
@@ -178,8 +166,8 @@ public class DefaultReinitializeDeviceHandler implements ReinitializeDeviceHandl
                 Files.copy(file.toPath(), copy.toPath());
 
                 final int instanceNumber = localDevice.getNextInstanceObjectNumber(ObjectType.file);
-                final FileObject fo = new FileObject(localDevice, instanceNumber, "configurationFile",
-                        new StreamAccess(copy));
+                final FileObject fo = localDevice.addObject(new FileObject(localDevice, instanceNumber,
+                        "configurationFile", new StreamAccess(copy)));
                 fileOids.add(fo.getId());
             }
             configurationFiles = new BACnetArray<>(fileOids);
@@ -191,10 +179,6 @@ public class DefaultReinitializeDeviceHandler implements ReinitializeDeviceHandl
 
     /**
      * Override as required.
-     *
-     * @param localDevice
-     * @param from
-     * @throws BACnetErrorException
      */
     protected void endBackup(final LocalDevice localDevice, final Address from) throws BACnetErrorException {
         LOG.info("Ending backup");
@@ -213,7 +197,7 @@ public class DefaultReinitializeDeviceHandler implements ReinitializeDeviceHandl
         final UnsignedInteger backupFailureTimeout = localDevice.getDeviceObject()
                 .get(PropertyIdentifier.backupFailureTimeout);
         if (backupFailureTimeout.intValue() > 0) {
-            backupStateMonitor = new BackupStateMonitor(localDevice, from, backupFailureTimeout.intValue() * 1000);
+            backupStateMonitor = new BackupStateMonitor(localDevice, from, backupFailureTimeout.intValue() * 1000L);
         }
     }
 
@@ -313,7 +297,7 @@ public class DefaultReinitializeDeviceHandler implements ReinitializeDeviceHandl
             try {
                 final FileObject fo = (FileObject) localDevice.removeObject(fileOid);
                 if (!fo.getFileAccess().delete()) {
-                    LOG.warn("Failed to delete configuration file " + fo.getFileAccess().getName());
+                    LOG.warn("Failed to delete configuration file {}", fo.getFileAccess().getName());
                 }
             } catch (final BACnetServiceException e) {
                 LOG.error("Error while trying to remove configuration file", e);
@@ -326,10 +310,6 @@ public class DefaultReinitializeDeviceHandler implements ReinitializeDeviceHandl
 
     /**
      * Override as required.
-     *
-     * @param localDevice
-     * @param from
-     * @throws BACnetErrorException
      */
     protected void startRestore(final LocalDevice localDevice, final Address from) throws BACnetErrorException {
         LOG.info("Starting restore");
@@ -392,7 +372,7 @@ public class DefaultReinitializeDeviceHandler implements ReinitializeDeviceHandl
 
     /**
      * This method should be overridden to properly validate and implement the files that were restored. Since not all
-     * of the configuration files were necessarily written, and since new file objects may have been created for new
+     * the configuration files were necessarily written, and since new file objects may have been created for new
      * files, the list of files should be derived from the existing file objects. Also, file objects that are detected
      * as being new should be removed as required, since this handler will only remove file objects that it created, as
      * given by the configurationFiles property.

--- a/src/main/java/com/serotonin/bacnet4j/obj/AccumulatorObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/AccumulatorObject.java
@@ -84,8 +84,7 @@ public class AccumulatorObject extends BACnetObject {
 
     public AccumulatorObject(final LocalDevice localDevice, final int instanceNumber, final String name,
             final long presentValue, final long accumulation, final EngineeringUnits units, final boolean outOfService,
-            final Scale scale, final Prescale prescale, final long maxPresValue, final int limitMonitoringInterval)
-            throws BACnetServiceException {
+            final Scale scale, final Prescale prescale, final long maxPresValue, final int limitMonitoringInterval) {
         super(localDevice, ObjectType.accumulator, instanceNumber, name);
 
         Objects.requireNonNull(units);
@@ -124,12 +123,6 @@ public class AccumulatorObject extends BACnetObject {
                 pulseCount = 0;
             }
         }, limitMonitoringInterval, limitMonitoringInterval, TimeUnit.SECONDS);
-
-        // TODO
-        // ?? Logging_Record
-        // ?? Logging_Object -> not currently possible to know what is making a request to read a property.
-
-        localDevice.addObject(this);
     }
 
     public AccumulatorObject supportIntrinsicReporting(final int highLimit, final int lowLimit,

--- a/src/main/java/com/serotonin/bacnet4j/obj/AlertEnrollmentObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/AlertEnrollmentObject.java
@@ -31,7 +31,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.serotonin.bacnet4j.LocalDevice;
-import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.obj.mixin.ReadOnlyPropertyMixin;
 import com.serotonin.bacnet4j.obj.mixin.event.AlertReportingMixin;
 import com.serotonin.bacnet4j.type.constructed.EventTransitionBits;
@@ -51,7 +50,7 @@ public class AlertEnrollmentObject extends BACnetObject {
     private final UnsignedInteger defaultVendorId;
 
     public AlertEnrollmentObject(final LocalDevice localDevice, final int instanceNumber, final String name,
-            final int notificationClass, final NotifyType notifyType) throws BACnetServiceException {
+            final int notificationClass, final NotifyType notifyType) {
         super(localDevice, ObjectType.alertEnrollment, instanceNumber, name);
 
         defaultVendorId = localDevice.get(PropertyIdentifier.vendorIdentifier);
@@ -68,8 +67,6 @@ public class AlertEnrollmentObject extends BACnetObject {
 
         alertReporting = new AlertReportingMixin(this);
         addMixin(alertReporting);
-
-        localDevice.addObject(this);
     }
 
     public void issueAlert(final ObjectIdentifier alertSource, final int extendedEventType,

--- a/src/main/java/com/serotonin/bacnet4j/obj/AnalogInputObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/AnalogInputObject.java
@@ -28,7 +28,6 @@
 package com.serotonin.bacnet4j.obj;
 
 import com.serotonin.bacnet4j.LocalDevice;
-import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.obj.mixin.HasStatusFlagsMixin;
 import com.serotonin.bacnet4j.obj.mixin.ReadOnlyPropertyMixin;
 import com.serotonin.bacnet4j.obj.mixin.WritablePropertyOutOfServiceMixin;
@@ -50,8 +49,7 @@ import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
 public class AnalogInputObject extends BACnetObject {
     public AnalogInputObject(final LocalDevice localDevice, final int instanceNumber, final String name,
-            final float presentValue, final EngineeringUnits units, final boolean outOfService)
-            throws BACnetServiceException {
+            final float presentValue, final EngineeringUnits units, final boolean outOfService) {
         super(localDevice, ObjectType.analogInput, instanceNumber, name);
 
         writePropertyInternal(PropertyIdentifier.eventState, EventState.normal);
@@ -68,8 +66,6 @@ public class AnalogInputObject extends BACnetObject {
         addMixin(new ReadOnlyPropertyMixin(this, PropertyIdentifier.eventMessageTexts, PropertyIdentifier.resolution,
                 PropertyIdentifier.ackedTransitions, PropertyIdentifier.eventTimeStamps,
                 PropertyIdentifier.interfaceValue));
-
-        localDevice.addObject(this);
     }
 
     public AnalogInputObject supportIntrinsicReporting(final int timeDelay, final int notificationClass,

--- a/src/main/java/com/serotonin/bacnet4j/obj/AnalogOutputObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/AnalogOutputObject.java
@@ -30,7 +30,6 @@ package com.serotonin.bacnet4j.obj;
 import java.util.Objects;
 
 import com.serotonin.bacnet4j.LocalDevice;
-import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.obj.mixin.CommandableMixin;
 import com.serotonin.bacnet4j.obj.mixin.HasStatusFlagsMixin;
 import com.serotonin.bacnet4j.obj.mixin.ReadOnlyPropertyMixin;
@@ -54,7 +53,7 @@ import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 public class AnalogOutputObject extends BACnetObject {
     public AnalogOutputObject(final LocalDevice localDevice, final int instanceNumber, final String name,
             final float presentValue, final EngineeringUnits units, final boolean outOfService,
-            final float relinquishDefault) throws BACnetServiceException {
+            final float relinquishDefault) {
         super(localDevice, ObjectType.analogOutput, instanceNumber, name);
 
         Objects.requireNonNull(units);
@@ -77,8 +76,6 @@ public class AnalogOutputObject extends BACnetObject {
 
         _supportCommandable(new Real(relinquishDefault));
         _supportValueSource();
-
-        localDevice.addObject(this);
     }
 
     public AnalogOutputObject supportCovReporting(final float covIncrement) {

--- a/src/main/java/com/serotonin/bacnet4j/obj/AnalogValueObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/AnalogValueObject.java
@@ -30,7 +30,6 @@ package com.serotonin.bacnet4j.obj;
 import java.util.Objects;
 
 import com.serotonin.bacnet4j.LocalDevice;
-import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.obj.mixin.CommandableMixin;
 import com.serotonin.bacnet4j.obj.mixin.HasStatusFlagsMixin;
 import com.serotonin.bacnet4j.obj.mixin.ReadOnlyPropertyMixin;
@@ -53,8 +52,7 @@ import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
 public class AnalogValueObject extends BACnetObject {
     public AnalogValueObject(final LocalDevice localDevice, final int instanceNumber, final String name,
-            final float presentValue, final EngineeringUnits units, final boolean outOfService)
-            throws BACnetServiceException {
+            final float presentValue, final EngineeringUnits units, final boolean outOfService) {
         super(localDevice, ObjectType.analogValue, instanceNumber, name);
 
         Objects.requireNonNull(units);
@@ -73,8 +71,6 @@ public class AnalogValueObject extends BACnetObject {
         addMixin(
                 new ReadOnlyPropertyMixin(this, PropertyIdentifier.ackedTransitions, PropertyIdentifier.eventTimeStamps,
                         PropertyIdentifier.eventMessageTexts, PropertyIdentifier.resolution));
-
-        localDevice.addObject(this);
     }
 
     public AnalogValueObject supportIntrinsicReporting(final int timeDelay, final int notificationClass,

--- a/src/main/java/com/serotonin/bacnet4j/obj/AveragingObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/AveragingObject.java
@@ -71,7 +71,7 @@ public class AveragingObject extends BACnetObject {
 
     public AveragingObject(final LocalDevice localDevice, final int instanceNumber, final String name,
             final DeviceObjectPropertyReference objectPropertyReference, final int windowInterval,
-            final int windowSamples) throws BACnetServiceException {
+            final int windowSamples) {
         super(localDevice, ObjectType.averaging, instanceNumber, name);
 
         Objects.requireNonNull(objectPropertyReference);
@@ -95,8 +95,6 @@ public class AveragingObject extends BACnetObject {
 
         updateMonitoredProperty();
         reinitializePolling();
-
-        localDevice.addObject(this);
     }
 
     private void reset() {

--- a/src/main/java/com/serotonin/bacnet4j/obj/BinaryInputObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/BinaryInputObject.java
@@ -30,7 +30,6 @@ package com.serotonin.bacnet4j.obj;
 import java.util.Objects;
 
 import com.serotonin.bacnet4j.LocalDevice;
-import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.obj.mixin.ActiveTimeMixin;
 import com.serotonin.bacnet4j.obj.mixin.HasStatusFlagsMixin;
 import com.serotonin.bacnet4j.obj.mixin.ReadOnlyPropertyMixin;
@@ -54,8 +53,7 @@ import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
 public class BinaryInputObject extends BACnetObject {
     public BinaryInputObject(final LocalDevice localDevice, final int instanceNumber, final String name,
-            final BinaryPV presentValue, final boolean outOfService, final Polarity polarity)
-            throws BACnetServiceException {
+            final BinaryPV presentValue, final boolean outOfService, final Polarity polarity) {
         super(localDevice, ObjectType.binaryInput, instanceNumber, name);
 
         Objects.requireNonNull(presentValue);
@@ -79,8 +77,6 @@ public class BinaryInputObject extends BACnetObject {
         writePropertyInternal(PropertyIdentifier.interfaceValue, new OptionalBinaryPV());
 
         addMixin(new StateChangeMixin(this));
-
-        localDevice.addObject(this);
     }
 
     public BinaryInputObject supportStateText(final String inactive, final String active) {

--- a/src/main/java/com/serotonin/bacnet4j/obj/BinaryOutputObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/BinaryOutputObject.java
@@ -30,7 +30,6 @@ package com.serotonin.bacnet4j.obj;
 import java.util.Objects;
 
 import com.serotonin.bacnet4j.LocalDevice;
-import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.obj.mixin.ActiveTimeMixin;
 import com.serotonin.bacnet4j.obj.mixin.CommandableMixin;
 import com.serotonin.bacnet4j.obj.mixin.HasStatusFlagsMixin;
@@ -56,7 +55,7 @@ import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 public class BinaryOutputObject extends BACnetObject {
     public BinaryOutputObject(final LocalDevice localDevice, final int instanceNumber, final String name,
             final BinaryPV presentValue, final boolean outOfService, final Polarity polarity,
-            final BinaryPV relinquishDefault) throws BACnetServiceException {
+            final BinaryPV relinquishDefault) {
         super(localDevice, ObjectType.binaryOutput, instanceNumber, name);
 
         Objects.requireNonNull(presentValue);
@@ -84,8 +83,6 @@ public class BinaryOutputObject extends BACnetObject {
         writePropertyInternal(PropertyIdentifier.interfaceValue, new OptionalBinaryPV());
 
         addMixin(new StateChangeMixin(this));
-
-        localDevice.addObject(this);
     }
 
     public BinaryOutputObject supportIntrinsicReporting(final int timeDelay, final int notificationClass,

--- a/src/main/java/com/serotonin/bacnet4j/obj/BinaryValueObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/BinaryValueObject.java
@@ -30,7 +30,6 @@ package com.serotonin.bacnet4j.obj;
 import java.util.Objects;
 
 import com.serotonin.bacnet4j.LocalDevice;
-import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.obj.mixin.ActiveTimeMixin;
 import com.serotonin.bacnet4j.obj.mixin.CommandableMixin;
 import com.serotonin.bacnet4j.obj.mixin.HasStatusFlagsMixin;
@@ -53,7 +52,7 @@ import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
 public class BinaryValueObject extends BACnetObject {
     public BinaryValueObject(final LocalDevice localDevice, final int instanceNumber, final String name,
-            final BinaryPV presentValue, final boolean outOfService) throws BACnetServiceException {
+            final BinaryPV presentValue, final boolean outOfService) {
         super(localDevice, ObjectType.binaryValue, instanceNumber, name);
 
         Objects.requireNonNull(presentValue);
@@ -73,8 +72,6 @@ public class BinaryValueObject extends BACnetObject {
         writePropertyInternal(PropertyIdentifier.presentValue, presentValue);
 
         addMixin(new StateChangeMixin(this));
-
-        localDevice.addObject(this);
     }
 
     public BinaryValueObject supportStateText(final String inactive, final String active) {

--- a/src/main/java/com/serotonin/bacnet4j/obj/CalendarObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/CalendarObject.java
@@ -54,8 +54,7 @@ public class CalendarObject extends BACnetObject {
     static final Logger LOG = LoggerFactory.getLogger(CalendarObject.class);
 
     // CreateObject constructor
-    public static CalendarObject create(final LocalDevice localDevice, final int instanceNumber)
-            throws BACnetServiceException {
+    public static CalendarObject create(final LocalDevice localDevice, final int instanceNumber) {
         return new CalendarObject(localDevice, instanceNumber, ObjectType.calendar.toString() + " " + instanceNumber,
                 new SequenceOf<>());
     }

--- a/src/main/java/com/serotonin/bacnet4j/obj/CalendarObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/CalendarObject.java
@@ -67,7 +67,7 @@ public class CalendarObject extends BACnetObject {
     private ScheduledFuture<?> presentValueRefresher;
 
     public CalendarObject(final LocalDevice localDevice, final int instanceNumber, final String name,
-            final SequenceOf<CalendarEntry> dateList) throws BACnetServiceException {
+            final SequenceOf<CalendarEntry> dateList) {
         super(localDevice, ObjectType.calendar, instanceNumber, name);
 
         writePropertyInternal(PropertyIdentifier.dateList, dateList);
@@ -87,10 +87,8 @@ public class CalendarObject extends BACnetObject {
         final long delay = hour - elapsed + 10; // Add a few milliseconds for fun.
 
         // Delay until the top of the next hour, and then run every hour.
-        presentValueRefresher = getLocalDevice().scheduleAtFixedRate(() -> updatePresentValue(), delay, hour,
+        presentValueRefresher = getLocalDevice().scheduleAtFixedRate(this::updatePresentValue, delay, hour,
                 TimeUnit.MILLISECONDS);
-
-        localDevice.addObject(this);
     }
 
     public int getTimeTolerance() {

--- a/src/main/java/com/serotonin/bacnet4j/obj/CharacterStringObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/CharacterStringObject.java
@@ -30,7 +30,6 @@ package com.serotonin.bacnet4j.obj;
 import java.util.Objects;
 
 import com.serotonin.bacnet4j.LocalDevice;
-import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.obj.mixin.CommandableMixin;
 import com.serotonin.bacnet4j.obj.mixin.HasStatusFlagsMixin;
 import com.serotonin.bacnet4j.obj.mixin.ReadOnlyPropertyMixin;
@@ -47,17 +46,8 @@ import com.serotonin.bacnet4j.type.primitive.CharacterString;
  * @author Phillip Dunlap, based on BinaryValueObject
  */
 public class CharacterStringObject extends BACnetObject {
-
-    /**
-     * @param localDevice
-     * @param instanceNumber
-     * @param name
-     * @param presentValue
-     * @param outOfService
-     * @throws BACnetServiceException
-     */
     public CharacterStringObject(LocalDevice localDevice, int instanceNumber,
-            String name, final CharacterString presentValue, final boolean outOfService) throws BACnetServiceException {
+            String name, final CharacterString presentValue, final boolean outOfService) {
         super(localDevice, ObjectType.characterstringValue, instanceNumber, name);
 
 
@@ -74,8 +64,6 @@ public class CharacterStringObject extends BACnetObject {
                 PropertyIdentifier.eventTimeStamps, PropertyIdentifier.eventMessageTexts));
 
         writePropertyInternal(PropertyIdentifier.presentValue, presentValue);
-
-        localDevice.addObject(this);
     }
 
     public CharacterStringObject supportCommandable(final CharacterString relinquishDefault) {
@@ -88,7 +76,4 @@ public class CharacterStringObject extends BACnetObject {
         _supportCovReporting(null, null);
         return this;
     }
-
-
-
 }

--- a/src/main/java/com/serotonin/bacnet4j/obj/DeviceObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/DeviceObject.java
@@ -81,7 +81,7 @@ import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 public class DeviceObject extends BACnetObject {
     private static final int VENDOR_ID = 865; //Infinite Automation Systems, Inc.
 
-    public DeviceObject(final LocalDevice localDevice, final int instanceNumber) throws BACnetServiceException {
+    public DeviceObject(final LocalDevice localDevice, final int instanceNumber) {
         super(localDevice, ObjectType.device, instanceNumber, "BACnet4J device " + instanceNumber);
 
         writePropertyInternal(PropertyIdentifier.maxApduLengthAccepted,
@@ -246,8 +246,6 @@ public class DeviceObject extends BACnetObject {
         addMixin(new ReadOnlyPropertyMixin(this, PropertyIdentifier.activeCovSubscriptions,
                 PropertyIdentifier.localTime, PropertyIdentifier.localDate, PropertyIdentifier.deviceAddressBinding));
         addMixin(new ObjectListMixin(this));
-
-        localDevice.addObject(this);
     }
 
     public DeviceObject supportTimeSynchronization(final SequenceOf<Recipient> timeSynchronizationRecipients,

--- a/src/main/java/com/serotonin/bacnet4j/obj/DeviceObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/DeviceObject.java
@@ -337,10 +337,10 @@ public class DeviceObject extends BACnetObject {
 
     private MasterNode getMasterNode() {
         final Network network = getLocalDevice().getNetwork();
-        if (network instanceof MstpNetwork) {
-            final MstpNode node = ((MstpNetwork) network).getNode();
-            if (node instanceof MasterNode) {
-                return (MasterNode) node;
+        if (network instanceof MstpNetwork mstp) {
+            final MstpNode node = mstp.getNode();
+            if (node instanceof MasterNode manager) {
+                return manager;
             }
         }
         return null;

--- a/src/main/java/com/serotonin/bacnet4j/obj/EventEnrollmentObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/EventEnrollmentObject.java
@@ -86,8 +86,7 @@ public class EventEnrollmentObject extends BACnetObject {
     public EventEnrollmentObject(final LocalDevice localDevice, final int instanceNumber, final String name,
             final DeviceObjectPropertyReference objectPropertyReference, final NotifyType notifyType,
             final EventParameter eventParameter, final EventTransitionBits eventEnable, final int notificationClass,
-            final int pollDelayMillis, final UnsignedInteger timeDelayNormal, final FaultParameter faultParameter)
-            throws BACnetServiceException {
+            final int pollDelayMillis, final UnsignedInteger timeDelayNormal, final FaultParameter faultParameter) {
         super(localDevice, ObjectType.eventEnrollment, instanceNumber, name);
 
         // Validation
@@ -210,10 +209,8 @@ public class EventEnrollmentObject extends BACnetObject {
 
         //
         // Start polling
-        pollingFuture = localDevice.scheduleWithFixedDelay(() -> doPoll(), pollDelayMillis, pollDelayMillis,
+        pollingFuture = localDevice.scheduleWithFixedDelay(this::doPoll, pollDelayMillis, pollDelayMillis,
                 TimeUnit.MILLISECONDS);
-
-        localDevice.addObject(this);
     }
 
     @Override

--- a/src/main/java/com/serotonin/bacnet4j/obj/EventLogObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/EventLogObject.java
@@ -77,8 +77,7 @@ public class EventLogObject extends BACnetObject {
     static final Logger LOG = LoggerFactory.getLogger(EventLogObject.class);
 
     // CreateObject constructor
-    public static EventLogObject create(final LocalDevice localDevice, final int instanceNumber)
-            throws BACnetServiceException {
+    public static EventLogObject create(final LocalDevice localDevice, final int instanceNumber) {
         return new EventLogObject(localDevice, instanceNumber, ObjectType.eventLog.toString() + " " + instanceNumber,
                 new LinkedListLogBuffer<>(), false, DateTime.UNSPECIFIED, DateTime.UNSPECIFIED, false, 100) //
                 .supportIntrinsicReporting(20, 0, new EventTransitionBits(false, false, false),
@@ -171,7 +170,7 @@ public class EventLogObject extends BACnetObject {
 
         // Now add the mixin.
         addMixin(new IntrinsicReportingMixin(this, algo, null, PropertyIdentifier.totalRecordCount, triggerProps)
-                .withPostNotificationAction((notifParams) -> {
+                .withPostNotificationAction(notifParams -> {
                     // After a notification has been sent, a couple values need to be updated.
                     final BufferReadyNotif brn = (BufferReadyNotif) notifParams.getParameter();
                     writePropertyInternal(PropertyIdentifier.lastNotifyRecord, brn.getCurrentNotification());
@@ -293,7 +292,7 @@ public class EventLogObject extends BACnetObject {
             final DateTime now = getNow();
             final long diff = startTime.getGC().getTimeInMillis() - now.getGC().getTimeInMillis();
             if (diff > 0) {
-                startTimeFuture = getLocalDevice().schedule(() -> evaluateLogDisabled(), diff, TimeUnit.MILLISECONDS);
+                startTimeFuture = getLocalDevice().schedule(this::evaluateLogDisabled, diff, TimeUnit.MILLISECONDS);
             }
         }
         evaluateLogDisabled();
@@ -305,7 +304,7 @@ public class EventLogObject extends BACnetObject {
             final DateTime now = getNow();
             final long diff = stopTime.getGC().getTimeInMillis() - now.getGC().getTimeInMillis();
             if (diff > 0) {
-                stopTimeFuture = getLocalDevice().schedule(() -> evaluateLogDisabled(), diff, TimeUnit.MILLISECONDS);
+                stopTimeFuture = getLocalDevice().schedule(this::evaluateLogDisabled, diff, TimeUnit.MILLISECONDS);
             }
         }
         evaluateLogDisabled();
@@ -323,13 +322,13 @@ public class EventLogObject extends BACnetObject {
             future.cancel(false);
     }
 
-    private synchronized void addLogRecord(final EventLogRecord record) {
+    private synchronized void addLogRecord(final EventLogRecord rec) {
         // Check if logging is allowed.
         if (logDisabled)
             return;
 
         // Add the new record.
-        addLogRecordImpl(record);
+        addLogRecordImpl(rec);
 
         fullCheck();
     }
@@ -343,7 +342,7 @@ public class EventLogObject extends BACnetObject {
         }
     }
 
-    private void addLogRecordImpl(final EventLogRecord record) {
+    private void addLogRecordImpl(final EventLogRecord rec) {
         final UnsignedInteger bufferSize = get(PropertyIdentifier.bufferSize);
 
         synchronized (buffer) {
@@ -353,7 +352,7 @@ public class EventLogObject extends BACnetObject {
                 buffer.remove();
             }
 
-            buffer.add(record);
+            buffer.add(rec);
         }
 
         updateRecordCount();
@@ -369,7 +368,7 @@ public class EventLogObject extends BACnetObject {
         if (totalRecordCount.longValue() == 0)
             // Value overflowed. As per 12.27.15 set to 1.
             totalRecordCount = new UnsignedInteger(1);
-        record.setSequenceNumber(totalRecordCount.longValue());
+        rec.setSequenceNumber(totalRecordCount.longValue());
         writePropertyInternal(PropertyIdentifier.totalRecordCount, totalRecordCount);
     }
 

--- a/src/main/java/com/serotonin/bacnet4j/obj/EventLogObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/EventLogObject.java
@@ -97,7 +97,7 @@ public class EventLogObject extends BACnetObject {
      */
     public EventLogObject(final LocalDevice localDevice, final int instanceNumber, final String name,
             final LogBuffer<EventLogRecord> buffer, final boolean enable, final DateTime startTime,
-            final DateTime stopTime, final boolean stopWhenFull, final int bufferSize) throws BACnetServiceException {
+            final DateTime stopTime, final boolean stopWhenFull, final int bufferSize) {
         super(localDevice, ObjectType.eventLog, instanceNumber, name);
 
         Objects.requireNonNull(localDevice);
@@ -142,8 +142,6 @@ public class EventLogObject extends BACnetObject {
             }
         };
         localDevice.getEventHandler().addListener(eventListener);
-
-        localDevice.addObject(this);
     }
 
     public EventLogObject supportIntrinsicReporting(final int notificationThreshold, final int notificationClass,

--- a/src/main/java/com/serotonin/bacnet4j/obj/FileObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/FileObject.java
@@ -62,7 +62,7 @@ public class FileObject extends BACnetObject {
     private final ReentrantLock lock = new ReentrantLock();
 
     public FileObject(final LocalDevice localDevice, final int instanceNumber, final String fileType,
-            final FileAccess fileAccess) throws BACnetServiceException {
+            final FileAccess fileAccess) {
         super(localDevice, ObjectType.file, instanceNumber, fileAccess.getName());
         this.fileAccess = fileAccess;
 
@@ -77,8 +77,6 @@ public class FileObject extends BACnetObject {
         writePropertyInternal(PropertyIdentifier.fileType, new CharacterString(fileType));
         writePropertyInternal(PropertyIdentifier.fileAccessMethod, fileAccess.getAccessMethod());
         writePropertyInternal(PropertyIdentifier.archive, Boolean.FALSE);
-
-        localDevice.addObject(this);
     }
 
     public ReentrantLock getLock() {

--- a/src/main/java/com/serotonin/bacnet4j/obj/GroupObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/GroupObject.java
@@ -29,9 +29,6 @@ package com.serotonin.bacnet4j.obj;
 
 import java.util.Objects;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.serotonin.bacnet4j.LocalDevice;
 import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.obj.mixin.ReadOnlyPropertyMixin;
@@ -51,17 +48,14 @@ import com.serotonin.bacnet4j.type.error.ErrorClassAndCode;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
 
 public class GroupObject extends BACnetObject {
-    static final Logger LOG = LoggerFactory.getLogger(GroupObject.class);
-
     // CreateObject constructor
-    public static GroupObject create(final LocalDevice localDevice, final int instanceNumber)
-            throws BACnetServiceException {
+    public static GroupObject create(final LocalDevice localDevice, final int instanceNumber) {
         return new GroupObject(localDevice, instanceNumber, ObjectType.group.toString() + " " + instanceNumber,
                 new SequenceOf<>());
     }
 
     public GroupObject(final LocalDevice localDevice, final int instanceNumber, final String name,
-            final SequenceOf<ReadAccessSpecification> listOfGroupMembers) throws BACnetServiceException {
+            final SequenceOf<ReadAccessSpecification> listOfGroupMembers) {
         super(localDevice, ObjectType.group, instanceNumber, name);
 
         Objects.requireNonNull(listOfGroupMembers);
@@ -70,8 +64,6 @@ public class GroupObject extends BACnetObject {
         writePropertyInternal(PropertyIdentifier.listOfGroupMembers, listOfGroupMembers);
 
         addMixin(new ReadOnlyPropertyMixin(this, PropertyIdentifier.presentValue));
-
-        localDevice.addObject(this);
     }
 
     @Override

--- a/src/main/java/com/serotonin/bacnet4j/obj/LifeSafetyPointObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/LifeSafetyPointObject.java
@@ -88,8 +88,6 @@ public class LifeSafetyPointObject extends BACnetObject implements LifeSafety {
         addMixin(new LifeSafetyMixin(this));
         addMixin(new ReadOnlyPropertyMixin(this, PropertyIdentifier.acceptedModes, PropertyIdentifier.ackedTransitions,
                 PropertyIdentifier.eventTimeStamps, PropertyIdentifier.eventMessageTexts));
-
-        localDevice.addObject(this);
     }
 
     public LifeSafetyPointObject supportIntrinsicReporting(final int timeDelay, final int notificationClass,

--- a/src/main/java/com/serotonin/bacnet4j/obj/LifeSafetyZoneObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/LifeSafetyZoneObject.java
@@ -89,8 +89,6 @@ public class LifeSafetyZoneObject extends BACnetObject implements LifeSafety {
         addMixin(new LifeSafetyMixin(this));
         addMixin(new ReadOnlyPropertyMixin(this, PropertyIdentifier.acceptedModes, PropertyIdentifier.ackedTransitions,
                 PropertyIdentifier.eventTimeStamps, PropertyIdentifier.eventMessageTexts));
-
-        localDevice.addObject(this);
     }
 
     public LifeSafetyZoneObject supportIntrinsicReporting(final int timeDelay, final int notificationClass,

--- a/src/main/java/com/serotonin/bacnet4j/obj/MultistateInputObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/MultistateInputObject.java
@@ -88,8 +88,6 @@ public class MultistateInputObject extends BACnetObject {
         addMixin(
                 new ReadOnlyPropertyMixin(this, PropertyIdentifier.ackedTransitions, PropertyIdentifier.eventTimeStamps,
                         PropertyIdentifier.eventMessageTexts, PropertyIdentifier.interfaceValue));
-
-        localDevice.addObject(this);
     }
 
     public MultistateInputObject supportCovReporting() {

--- a/src/main/java/com/serotonin/bacnet4j/obj/MultistateOutputObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/MultistateOutputObject.java
@@ -95,8 +95,6 @@ public class MultistateOutputObject extends BACnetObject {
 
         _supportCommandable(new UnsignedInteger(relinquishDefaultBase1));
         _supportValueSource();
-
-        localDevice.addObject(this);
     }
 
     public MultistateOutputObject supportCovReporting() {

--- a/src/main/java/com/serotonin/bacnet4j/obj/MultistateValueObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/MultistateValueObject.java
@@ -85,14 +85,12 @@ public class MultistateValueObject extends BACnetObject {
         if (!outOfService) {
             writePropertyInternal(PropertyIdentifier.outOfService, Boolean.valueOf(outOfService));
         }
-
-        localDevice.addObject(this);
     }
 
     public MultistateValueObject supportIntrinsicReporting(final int timeDelay, final int notificationClass,
             final BACnetArray<UnsignedInteger> alarmValues, final BACnetArray<UnsignedInteger> faultValues,
             final EventTransitionBits eventEnable, final NotifyType notifyType, final int timeDelayNormal) {
-        // Prepare the object with all of the properties that intrinsic reporting will need.
+        // Prepare the object with all the properties that intrinsic reporting will need.
         // User-defined properties
         writePropertyInternal(PropertyIdentifier.timeDelay, new UnsignedInteger(timeDelay));
         writePropertyInternal(PropertyIdentifier.notificationClass, new UnsignedInteger(notificationClass));

--- a/src/main/java/com/serotonin/bacnet4j/obj/NotificationClassObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/NotificationClassObject.java
@@ -60,8 +60,7 @@ import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
 public class NotificationClassObject extends BACnetObject {
     // CreateObject constructor
-    public static NotificationClassObject create(final LocalDevice localDevice, final int instanceNumber)
-            throws BACnetServiceException {
+    public static NotificationClassObject create(final LocalDevice localDevice, final int instanceNumber) {
         return new NotificationClassObject(localDevice, instanceNumber,
                 ObjectType.notificationClass + " " + instanceNumber, 20, 10, 30,
                 new EventTransitionBits(false, false, false))
@@ -72,7 +71,7 @@ public class NotificationClassObject extends BACnetObject {
 
     public NotificationClassObject(final LocalDevice localDevice, final int instanceNumber, final String name,
             final int toOffnormalPriority, final int toFaultPriority, final int toNormalPriority,
-            final EventTransitionBits ackRequired) throws BACnetServiceException {
+            final EventTransitionBits ackRequired) {
         this(localDevice, instanceNumber, name, new BACnetArray<>(new UnsignedInteger(toOffnormalPriority),
                 new UnsignedInteger(toFaultPriority), new UnsignedInteger(toNormalPriority)), ackRequired);
 

--- a/src/main/java/com/serotonin/bacnet4j/obj/NotificationClassObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/NotificationClassObject.java
@@ -63,7 +63,7 @@ public class NotificationClassObject extends BACnetObject {
     public static NotificationClassObject create(final LocalDevice localDevice, final int instanceNumber)
             throws BACnetServiceException {
         return new NotificationClassObject(localDevice, instanceNumber,
-                ObjectType.notificationClass.toString() + " " + instanceNumber, 20, 10, 30,
+                ObjectType.notificationClass + " " + instanceNumber, 20, 10, 30,
                 new EventTransitionBits(false, false, false))
                 .supportIntrinsicReporting(new EventTransitionBits(false, false, false), NotifyType.event);
     }
@@ -80,8 +80,7 @@ public class NotificationClassObject extends BACnetObject {
     }
 
     public NotificationClassObject(final LocalDevice localDevice, final int instanceNumber, final String name,
-            final BACnetArray<UnsignedInteger> priority, final EventTransitionBits ackRequired)
-            throws BACnetServiceException {
+            final BACnetArray<UnsignedInteger> priority, final EventTransitionBits ackRequired) {
         super(localDevice, ObjectType.notificationClass, instanceNumber, name);
 
         writePropertyInternal(PropertyIdentifier.notificationClass, new UnsignedInteger(instanceNumber));
@@ -91,13 +90,11 @@ public class NotificationClassObject extends BACnetObject {
         writePropertyInternal(PropertyIdentifier.statusFlags, new StatusFlags(false, false, false, false));
 
         addMixin(new HasStatusFlagsMixin(this));
-
-        localDevice.addObject(this);
     }
 
     public NotificationClassObject supportIntrinsicReporting(final EventTransitionBits eventEnable,
             final NotifyType notifyType) {
-        // Prepare the object with all of the properties that intrinsic reporting will need.
+        // Prepare the object with all the properties that intrinsic reporting will need.
         // User-defined properties
         writePropertyInternal(PropertyIdentifier.eventEnable, eventEnable);
         writePropertyInternal(PropertyIdentifier.eventState, EventState.normal);

--- a/src/main/java/com/serotonin/bacnet4j/obj/NotificationForwarderObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/NotificationForwarderObject.java
@@ -211,7 +211,6 @@ public class NotificationForwarderObject extends BACnetObject {
         };
 
         localDevice.getEventHandler().addListener(eventListener);
-        localDevice.addObject(this);
     }
 
     private void sendNotification(final UnsignedInteger processIdentifier,

--- a/src/main/java/com/serotonin/bacnet4j/obj/NotificationForwarderObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/NotificationForwarderObject.java
@@ -192,7 +192,7 @@ public class NotificationForwarderObject extends BACnetObject {
                 }
 
                 // Send to subscribers
-                forEachSubscriber((subscription) -> {
+                forEachSubscriber(subscription -> {
                     Address address;
                     try {
                         address = subscription.getRecipient().toAddress(getLocalDevice());
@@ -312,7 +312,7 @@ public class NotificationForwarderObject extends BACnetObject {
                             }
                             // Update the subscription with the new values.
                             subscription.setIssueConfirmedNotifications(ens.getIssueConfirmedNotifications());
-                            subscription.setExpiryMillis(now + ens.getTimeRemaining().intValue() * 1000);
+                            subscription.setExpiryMillis(now + ens.getTimeRemaining().intValue() * 1000L);
                         }
                     }
 
@@ -361,7 +361,7 @@ public class NotificationForwarderObject extends BACnetObject {
         // Dynamically construct the list of subscribers.
         final SequenceOf<EventNotificationSubscription> subscribedRecipients = new SequenceOf<>(subscriptions.size());
         final long now = getLocalDevice().getClock().millis();
-        forEachSubscriber((subscription) -> {
+        forEachSubscriber(subscription -> {
             // Convert to seconds, using a ceiling.
             int timeRemaining = (int) ((subscription.getExpiryMillis() - now + 999) / 1000);
             // The forEachSubscriber method should ensure that no expired subscriptions appear here, but just make

--- a/src/main/java/com/serotonin/bacnet4j/obj/PulseConverterObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/PulseConverterObject.java
@@ -109,7 +109,7 @@ public class PulseConverterObject extends BACnetObject {
         Objects.requireNonNull(eventEnable);
         Objects.requireNonNull(notifyType);
 
-        // Prepare the object with all of the properties that intrinsic reporting will need.
+        // Prepare the object with all the properties that intrinsic reporting will need.
         writePropertyInternal(PropertyIdentifier.timeDelay, new UnsignedInteger(timeDelay));
         writePropertyInternal(PropertyIdentifier.notificationClass, new UnsignedInteger(notificationClass));
         writePropertyInternal(PropertyIdentifier.highLimit, new Real(highLimit));
@@ -159,10 +159,10 @@ public class PulseConverterObject extends BACnetObject {
                     long newValue = 0;
                     if (value == null) {
                         pollingError = "Unknown property " + ref;
-                    } else if (value instanceof UnsignedInteger) {
-                        newValue = ((UnsignedInteger) value).longValue();
-                    } else if (value instanceof SignedInteger) {
-                        newValue = ((SignedInteger) value).longValue();
+                    } else if (value instanceof UnsignedInteger ui) {
+                        newValue = ui.longValue();
+                    } else if (value instanceof SignedInteger si) {
+                        newValue = si.longValue();
                     } else {
                         pollingError = "Invalid input reference data type: " + value.getClass();
                     }
@@ -187,7 +187,7 @@ public class PulseConverterObject extends BACnetObject {
                     LOG.info("Poll succeeded");
                     writePropertyInternal(PropertyIdentifier.reliability, Reliability.noFaultDetected);
                 } else {
-                    LOG.warn("Polling error: " + pollingError);
+                    LOG.warn("Polling error: {}", pollingError);
                     writePropertyInternal(PropertyIdentifier.reliability, Reliability.configurationError);
                 }
                 lastPollingError = pollingError;

--- a/src/main/java/com/serotonin/bacnet4j/obj/PulseConverterObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/PulseConverterObject.java
@@ -76,8 +76,7 @@ public class PulseConverterObject extends BACnetObject {
     private long lastPollingValue = Long.MAX_VALUE;
 
     public PulseConverterObject(final LocalDevice localDevice, final int instanceNumber, final String name,
-            final long count, final float scaleFactor, final EngineeringUnits units, final boolean outOfService)
-            throws BACnetServiceException {
+            final long count, final float scaleFactor, final EngineeringUnits units, final boolean outOfService) {
         super(localDevice, ObjectType.pulseConverter, instanceNumber, name);
 
         Objects.requireNonNull(units);
@@ -99,8 +98,6 @@ public class PulseConverterObject extends BACnetObject {
                 PropertyIdentifier.reliability));
         addMixin(new ReadOnlyPropertyMixin(this, PropertyIdentifier.count, PropertyIdentifier.updateTime,
                 PropertyIdentifier.ackedTransitions, PropertyIdentifier.eventMessageTexts));
-
-        localDevice.addObject(this);
     }
 
     public PulseConverterObject supportIntrinsicReporting(final float highLimit, final float lowLimit,

--- a/src/main/java/com/serotonin/bacnet4j/obj/ScheduleObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/ScheduleObject.java
@@ -103,7 +103,7 @@ public class ScheduleObject extends BACnetObject {
      * failures, restarts, and the like.
      */
     private ScheduledFuture<?> periodicWriter;
-    private volatile DateTime lastUpdateTime;
+    private DateTime lastUpdateTime;
 
     public ScheduleObject(final LocalDevice localDevice, final int instanceNumber, final String name,
             final DateRange effectivePeriod, final BACnetArray<DailySchedule> weeklySchedule,

--- a/src/main/java/com/serotonin/bacnet4j/obj/ScheduleObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/ScheduleObject.java
@@ -148,8 +148,6 @@ public class ScheduleObject extends BACnetObject {
         // initialization of the objects in the list, force a write.
         if (Objects.equals(oldValue, newValue))
             doWrites(newValue);
-
-        localDevice.addObject(this);
     }
 
     public void supportIntrinsicReporting(final int notificationClass, final EventTransitionBits eventEnable,

--- a/src/main/java/com/serotonin/bacnet4j/obj/TrendLogBase.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/TrendLogBase.java
@@ -1,0 +1,358 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2026 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
+package com.serotonin.bacnet4j.obj;
+
+import java.util.Objects;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import com.serotonin.bacnet4j.LocalDevice;
+import com.serotonin.bacnet4j.exception.BACnetServiceException;
+import com.serotonin.bacnet4j.obj.mixin.HasStatusFlagsMixin;
+import com.serotonin.bacnet4j.obj.mixin.PollingDelegate;
+import com.serotonin.bacnet4j.obj.mixin.ReadOnlyPropertyMixin;
+import com.serotonin.bacnet4j.obj.mixin.event.IntrinsicReportingMixin;
+import com.serotonin.bacnet4j.obj.mixin.event.eventAlgo.BufferReadyAlgo;
+import com.serotonin.bacnet4j.type.Encodable;
+import com.serotonin.bacnet4j.type.constructed.DateTime;
+import com.serotonin.bacnet4j.type.constructed.DeviceObjectPropertyReference;
+import com.serotonin.bacnet4j.type.constructed.EventTransitionBits;
+import com.serotonin.bacnet4j.type.constructed.PropertyValue;
+import com.serotonin.bacnet4j.type.constructed.StatusFlags;
+import com.serotonin.bacnet4j.type.constructed.ValueSource;
+import com.serotonin.bacnet4j.type.enumerated.ErrorClass;
+import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
+import com.serotonin.bacnet4j.type.enumerated.EventState;
+import com.serotonin.bacnet4j.type.enumerated.LoggingType;
+import com.serotonin.bacnet4j.type.enumerated.NotifyType;
+import com.serotonin.bacnet4j.type.enumerated.ObjectType;
+import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
+import com.serotonin.bacnet4j.type.enumerated.Reliability;
+import com.serotonin.bacnet4j.type.notificationParameters.BufferReadyNotif;
+import com.serotonin.bacnet4j.type.primitive.Boolean;
+import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
+
+abstract class TrendLogBase extends BACnetObject {
+    protected boolean logDisabled;
+    protected ScheduledFuture<?> startTimeFuture;
+    protected ScheduledFuture<?> stopTimeFuture;
+
+    protected PollingDelegate pollingDelegate;
+    protected ScheduledFuture<?> pollingFuture;
+
+    protected TrendLogBase(LocalDevice localDevice, ObjectType type, int instanceNumber, String name, boolean enable,
+            DateTime startTime, DateTime stopTime, int logInterval, boolean stopWhenFull, int bufferSize) {
+        super(localDevice, type, instanceNumber, name);
+
+        Objects.requireNonNull(localDevice);
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(startTime);
+        Objects.requireNonNull(stopTime);
+
+        set(PropertyIdentifier.enable, Boolean.valueOf(enable));
+        set(PropertyIdentifier.startTime, startTime);
+        set(PropertyIdentifier.stopTime, stopTime);
+        set(PropertyIdentifier.logInterval, new UnsignedInteger(logInterval));
+        set(PropertyIdentifier.stopWhenFull, Boolean.valueOf(stopWhenFull));
+        set(PropertyIdentifier.bufferSize, new UnsignedInteger(bufferSize));
+        set(PropertyIdentifier.recordCount, UnsignedInteger.ZERO);
+        set(PropertyIdentifier.totalRecordCount, UnsignedInteger.ZERO);
+        set(PropertyIdentifier.alignIntervals, Boolean.TRUE);
+        set(PropertyIdentifier.intervalOffset, UnsignedInteger.ZERO);
+        set(PropertyIdentifier.trigger, Boolean.FALSE);
+        set(PropertyIdentifier.statusFlags, new StatusFlags(false, false, false, false));
+        set(PropertyIdentifier.reliability, Reliability.noFaultDetected);
+    }
+
+    protected void postInitialize() {
+        updateMonitoredProperty();
+        updateStartTime(get(PropertyIdentifier.startTime));
+        updateStopTime(get(PropertyIdentifier.stopTime));
+        withTriggered();
+
+        // Mixins
+        addMixin(new HasStatusFlagsMixin(this));
+        addMixin(new ReadOnlyPropertyMixin(this, PropertyIdentifier.logBuffer, PropertyIdentifier.reliability,
+                PropertyIdentifier.totalRecordCount));
+    }
+
+    protected void baseWithPolled(int logInterval, TimeUnit logIntervalUnit, boolean alignIntervals,
+            int intervalOffset, TimeUnit offsetUnit) {
+        set(PropertyIdentifier.logInterval, new UnsignedInteger(logIntervalUnit.toMillis(logInterval) / 10));
+        set(PropertyIdentifier.alignIntervals, Boolean.valueOf(alignIntervals));
+        set(PropertyIdentifier.intervalOffset, new UnsignedInteger(offsetUnit.toMillis(intervalOffset) / 10));
+        set(PropertyIdentifier.loggingType, LoggingType.polled);
+        updateLoggingType();
+    }
+
+    protected void baseSupportIntrinsicReporting(int notificationThreshold, int notificationClass,
+            EventTransitionBits eventEnable, NotifyType notifyType) {
+        Objects.requireNonNull(eventEnable);
+        Objects.requireNonNull(notifyType);
+
+        // Prepare the object with all the properties that intrinsic reporting will need.
+        // User-defined properties
+        writePropertyInternal(PropertyIdentifier.notificationThreshold, new UnsignedInteger(notificationThreshold));
+        writePropertyInternal(PropertyIdentifier.recordsSinceNotification, UnsignedInteger.ZERO);
+        writePropertyInternal(PropertyIdentifier.lastNotifyRecord, UnsignedInteger.ZERO);
+        writePropertyInternal(PropertyIdentifier.eventState, EventState.normal);
+        writePropertyInternal(PropertyIdentifier.notificationClass, new UnsignedInteger(notificationClass));
+        writePropertyInternal(PropertyIdentifier.eventEnable, eventEnable);
+        writePropertyInternal(PropertyIdentifier.notifyType, notifyType);
+        writePropertyInternal(PropertyIdentifier.eventDetectionEnable, Boolean.TRUE);
+
+        BufferReadyAlgo algo = new BufferReadyAlgo(PropertyIdentifier.totalRecordCount,
+                new DeviceObjectPropertyReference(getId(), PropertyIdentifier.logBuffer, null,
+                        getLocalDevice().getId()),
+                PropertyIdentifier.notificationThreshold, PropertyIdentifier.lastNotifyRecord);
+
+        PropertyIdentifier[] triggerProps = new PropertyIdentifier[] { //
+                PropertyIdentifier.totalRecordCount, //
+                PropertyIdentifier.notificationThreshold};
+
+        // Now add the mixin.
+        addMixin(new IntrinsicReportingMixin(this, algo, null, PropertyIdentifier.totalRecordCount, triggerProps)
+                .withPostNotificationAction(notifParams -> {
+                    if (notifParams.getParameter() instanceof BufferReadyNotif brn) {
+                        // After a notification has been sent, a couple values need to be updated.
+                        writePropertyInternal(PropertyIdentifier.lastNotifyRecord, brn.getCurrentNotification());
+                        writePropertyInternal(PropertyIdentifier.recordsSinceNotification, UnsignedInteger.ZERO);
+                    }
+                }));
+
+        updateMonitoredProperty();
+    }
+
+    public boolean isLogDisabled() {
+        return logDisabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        writePropertyInternal(PropertyIdentifier.enable, Boolean.valueOf(enabled));
+    }
+
+    protected abstract void updateMonitoredProperty();
+
+    protected void updateStartTime(DateTime startTime) {
+        cancelFuture(startTimeFuture);
+        if (!startTime.equals(DateTime.UNSPECIFIED)) {
+            DateTime now = getNow();
+            long diff = startTime.getGC().getTimeInMillis() - now.getGC().getTimeInMillis();
+            if (diff > 0) {
+                startTimeFuture = getLocalDevice().schedule(this::evaluateLogDisabled, diff, TimeUnit.MILLISECONDS);
+            }
+        }
+        evaluateLogDisabled();
+    }
+
+    protected void updateStopTime(DateTime stopTime) {
+        cancelFuture(stopTimeFuture);
+        if (!stopTime.equals(DateTime.UNSPECIFIED)) {
+            DateTime now = getNow();
+            long diff = stopTime.getGC().getTimeInMillis() - now.getGC().getTimeInMillis();
+            if (diff > 0) {
+                stopTimeFuture = getLocalDevice().schedule(this::evaluateLogDisabled, diff, TimeUnit.MILLISECONDS);
+            }
+        }
+        evaluateLogDisabled();
+    }
+
+    protected void withTriggered() {
+        set(PropertyIdentifier.loggingType, LoggingType.triggered);
+        updateLoggingType();
+    }
+
+    protected static void cancelFuture(ScheduledFuture<?> future) {
+        if (future != null)
+            future.cancel(false);
+    }
+
+    protected DateTime getNow() {
+        return new DateTime(getLocalDevice().getClock().millis());
+    }
+
+    protected abstract void evaluateLogDisabled();
+
+    protected abstract void updateLoggingType();
+
+    protected abstract int bufferSize();
+
+
+    /**
+     * Locally trigger a poll.
+     *
+     * @return true if the trigger was done, false if the trigger value was already true, indicating that a trigger
+     * was already in progress.
+     */
+    public synchronized boolean trigger() {
+        Boolean trigger = get(PropertyIdentifier.trigger);
+        if (trigger.booleanValue()) {
+            return false;
+        }
+        set(PropertyIdentifier.trigger, Boolean.TRUE);
+        doTrigger();
+        return true;
+    }
+
+    @Override
+    protected void beforeReadProperty(PropertyIdentifier pid) throws BACnetServiceException {
+        if (PropertyIdentifier.logBuffer.equals(pid)) {
+            throw new BACnetServiceException(ErrorClass.property, ErrorCode.readAccessDenied);
+        }
+    }
+
+    @Override
+    protected boolean validateProperty(ValueSource valueSource, PropertyValue value)
+            throws BACnetServiceException {
+        if (PropertyIdentifier.enable.equals(value.getPropertyIdentifier())) {
+            Boolean enable = value.getValue();
+            Boolean stopWhenFull = get(PropertyIdentifier.stopWhenFull);
+            UnsignedInteger bufferSize = get(PropertyIdentifier.bufferSize);
+
+            if (enable.booleanValue() && stopWhenFull.booleanValue() && bufferSize.intValue() == bufferSize()) {
+                throw new BACnetServiceException(ErrorClass.object, ErrorCode.logBufferFull);
+            }
+        } else if (PropertyIdentifier.startTime.equals(value.getPropertyIdentifier()) //
+                || PropertyIdentifier.stopTime.equals(value.getPropertyIdentifier())) {
+            // Ensure that the date time is either entirely unspecified or entirely specified.
+            DateTime dt = value.getValue();
+            if (dt.equals(DateTime.UNSPECIFIED))
+                return false;
+
+            if (!dt.isFullySpecified())
+                throw new BACnetServiceException(ErrorClass.property, ErrorCode.parameterOutOfRange);
+        } else if (PropertyIdentifier.bufferSize.equals(value.getPropertyIdentifier())) {
+            Boolean enable = get(PropertyIdentifier.enable);
+            if (enable.booleanValue()) {
+                throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
+            }
+        } else if (PropertyIdentifier.recordCount.equals(value.getPropertyIdentifier())) {
+            // Only allowed to write a zero to this record. What would any other value do?
+            UnsignedInteger recordCount = value.getValue();
+            if (recordCount.intValue() != 0)
+                throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
+        }
+        return false;
+    }
+
+    @Override
+    protected void afterWriteProperty(PropertyIdentifier pid, Encodable oldValue, Encodable newValue) {
+        if (PropertyIdentifier.enable.equals(pid)) {
+            evaluateLogDisabled();
+        } else if (PropertyIdentifier.startTime.equals(pid)) {
+            updateStartTime((DateTime) newValue);
+        } else if (PropertyIdentifier.stopTime.equals(pid)) {
+            updateStopTime((DateTime) newValue);
+        } else if (PropertyIdentifier.logDeviceObjectProperty.equals(pid)) {
+            purge();
+            updateMonitoredProperty();
+        } else if (PropertyIdentifier.recordCount.equals(pid)) {
+            UnsignedInteger recordCount = (UnsignedInteger) newValue;
+            if (recordCount.intValue() == 0)
+                purge();
+        } else if (PropertyIdentifier.loggingType.equals(pid)) {
+            updateLoggingType();
+        } else if (pid.isOneOf(PropertyIdentifier.alignIntervals, PropertyIdentifier.intervalOffset)) {
+            LoggingType loggingType = get(PropertyIdentifier.loggingType);
+            if (loggingType.equals(LoggingType.polled)) {
+                updateLoggingType();
+            }
+        } else if (PropertyIdentifier.trigger.equals(pid)) {
+            // If the value has changed from false to true.
+            if (((Boolean) newValue).booleanValue() && !((Boolean) oldValue).booleanValue()) {
+                doTrigger();
+            }
+        }
+    }
+
+    protected void doTrigger() {
+        // Perform the trigger asynchronously
+        getLocalDevice().execute(() -> {
+            try {
+                // Do the poll.
+                doPoll();
+                LOG.debug("Trigger complete");
+            } finally {
+                // Set the trigger value back to false.
+                writePropertyInternal(PropertyIdentifier.trigger, Boolean.FALSE);
+            }
+        });
+    }
+
+    protected abstract void purge();
+
+    protected abstract void doPoll();
+
+    @Override
+    protected void terminateImpl() {
+        super.terminate();
+        cancelFuture(startTimeFuture);
+        cancelFuture(stopTimeFuture);
+        cancelFuture(pollingFuture);
+    }
+
+    protected void fullCheck() {
+        Boolean stopWhenFull = get(PropertyIdentifier.stopWhenFull);
+        UnsignedInteger bufferSize = get(PropertyIdentifier.bufferSize);
+        if (stopWhenFull.booleanValue() && bufferSize() == bufferSize.intValue() - 1) {
+            // There is only one spot left in the buffer, and StopWhenFull is true. Set Enable to false.
+            writePropertyInternal(PropertyIdentifier.enable, Boolean.FALSE);
+        }
+    }
+
+
+    /**
+     * Determines whether logging should be performed based upon Enable, StartTime, and StopTime.
+     */
+    protected boolean allowLogging(DateTime now) {
+        Boolean enabled = get(PropertyIdentifier.enable);
+        if (!enabled.booleanValue())
+            return false;
+
+        DateTime start = get(PropertyIdentifier.startTime);
+        DateTime stop = get(PropertyIdentifier.stopTime);
+
+        if (!start.equals(DateTime.UNSPECIFIED)) {
+            LOG.debug("Checking start time");
+            if (now.compareTo(start) < 0)
+                return false;
+        }
+
+        if (!stop.equals(DateTime.UNSPECIFIED)) {
+            LOG.debug("Checking stop time, now={}, stop={}", now, stop);
+            if (now.compareTo(stop) >= 0)
+                return false;
+        }
+
+        return true;
+    }
+
+    protected void updateRecordCount() {
+        writePropertyInternal(PropertyIdentifier.recordCount, new UnsignedInteger(bufferSize()));
+    }
+}

--- a/src/main/java/com/serotonin/bacnet4j/obj/TrendLogMultipleObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/TrendLogMultipleObject.java
@@ -162,7 +162,7 @@ public class TrendLogMultipleObject extends BACnetObject {
         Objects.requireNonNull(eventEnable);
         Objects.requireNonNull(notifyType);
 
-        // Prepare the object with all of the properties that intrinsic reporting will need.
+        // Prepare the object with all the properties that intrinsic reporting will need.
         // User-defined properties
         writePropertyInternal(PropertyIdentifier.notificationThreshold, new UnsignedInteger(notificationThreshold));
         writePropertyInternal(PropertyIdentifier.recordsSinceNotification, UnsignedInteger.ZERO);

--- a/src/main/java/com/serotonin/bacnet4j/obj/TrendLogMultipleObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/TrendLogMultipleObject.java
@@ -30,7 +30,6 @@ package com.serotonin.bacnet4j.obj;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
@@ -41,11 +40,7 @@ import com.serotonin.bacnet4j.LocalDevice;
 import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.obj.logBuffer.LinkedListLogBuffer;
 import com.serotonin.bacnet4j.obj.logBuffer.LogBuffer;
-import com.serotonin.bacnet4j.obj.mixin.HasStatusFlagsMixin;
 import com.serotonin.bacnet4j.obj.mixin.PollingDelegate;
-import com.serotonin.bacnet4j.obj.mixin.ReadOnlyPropertyMixin;
-import com.serotonin.bacnet4j.obj.mixin.event.IntrinsicReportingMixin;
-import com.serotonin.bacnet4j.obj.mixin.event.eventAlgo.BufferReadyAlgo;
 import com.serotonin.bacnet4j.type.Encodable;
 import com.serotonin.bacnet4j.type.constructed.BACnetArray;
 import com.serotonin.bacnet4j.type.constructed.DateTime;
@@ -58,25 +53,21 @@ import com.serotonin.bacnet4j.type.constructed.LogStatus;
 import com.serotonin.bacnet4j.type.constructed.PropertyReference;
 import com.serotonin.bacnet4j.type.constructed.PropertyValue;
 import com.serotonin.bacnet4j.type.constructed.SequenceOf;
-import com.serotonin.bacnet4j.type.constructed.StatusFlags;
 import com.serotonin.bacnet4j.type.constructed.ValueSource;
 import com.serotonin.bacnet4j.type.enumerated.ErrorClass;
 import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
-import com.serotonin.bacnet4j.type.enumerated.EventState;
 import com.serotonin.bacnet4j.type.enumerated.LoggingType;
 import com.serotonin.bacnet4j.type.enumerated.NotifyType;
 import com.serotonin.bacnet4j.type.enumerated.ObjectType;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
-import com.serotonin.bacnet4j.type.enumerated.Reliability;
 import com.serotonin.bacnet4j.type.error.ErrorClassAndCode;
-import com.serotonin.bacnet4j.type.notificationParameters.BufferReadyNotif;
 import com.serotonin.bacnet4j.type.primitive.Boolean;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 import com.serotonin.bacnet4j.util.DeviceObjectPropertyReferences;
 import com.serotonin.bacnet4j.util.DeviceObjectPropertyValues;
 import com.serotonin.bacnet4j.util.PropertyValues;
 
-public class TrendLogMultipleObject extends BACnetObject {
+public class TrendLogMultipleObject extends TrendLogBase {
     static final Logger LOG = LoggerFactory.getLogger(TrendLogMultipleObject.class);
 
     // CreateObject constructor
@@ -90,114 +81,34 @@ public class TrendLogMultipleObject extends BACnetObject {
 
     private final LogBuffer<LogMultipleRecord> buffer;
 
-    private boolean logDisabled;
-    private ScheduledFuture<?> startTimeFuture;
-    private ScheduledFuture<?> stopTimeFuture;
-
-    private PollingDelegate pollingDelegate;
-    private ScheduledFuture<?> pollingFuture;
-
     public TrendLogMultipleObject(final LocalDevice localDevice, final int instanceNumber, final String name,
             final LogBuffer<LogMultipleRecord> buffer, final boolean enable, final DateTime startTime,
             final DateTime stopTime, final BACnetArray<DeviceObjectPropertyReference> logDeviceObjectProperty,
             final int logInterval, final boolean stopWhenFull, final int bufferSize) {
-        super(localDevice, ObjectType.trendLogMultiple, instanceNumber, name);
+        super(localDevice, ObjectType.trendLogMultiple, instanceNumber, name, enable, startTime, stopTime, logInterval,
+                stopWhenFull, bufferSize);
 
-        Objects.requireNonNull(localDevice);
-        Objects.requireNonNull(name);
-        Objects.requireNonNull(startTime);
-        Objects.requireNonNull(stopTime);
         Objects.requireNonNull(logDeviceObjectProperty);
 
-        set(PropertyIdentifier.enable, Boolean.valueOf(enable));
-        set(PropertyIdentifier.startTime, startTime);
-        set(PropertyIdentifier.stopTime, stopTime);
         set(PropertyIdentifier.logDeviceObjectProperty, logDeviceObjectProperty);
-        set(PropertyIdentifier.logInterval, new UnsignedInteger(logInterval));
-        set(PropertyIdentifier.stopWhenFull, Boolean.valueOf(stopWhenFull));
-        set(PropertyIdentifier.bufferSize, new UnsignedInteger(bufferSize));
         set(PropertyIdentifier.logBuffer, buffer);
-        set(PropertyIdentifier.recordCount, UnsignedInteger.ZERO);
-        set(PropertyIdentifier.totalRecordCount, UnsignedInteger.ZERO);
-        set(PropertyIdentifier.alignIntervals, Boolean.TRUE);
-        set(PropertyIdentifier.intervalOffset, UnsignedInteger.ZERO);
-        set(PropertyIdentifier.trigger, Boolean.FALSE);
-        set(PropertyIdentifier.statusFlags, new StatusFlags(false, false, false, false));
-        set(PropertyIdentifier.reliability, Reliability.noFaultDetected);
 
-        updateMonitoredProperty();
-        updateStartTime(startTime);
-        updateStopTime(stopTime);
-        withTriggered();
-
-        // Mixins
-        addMixin(new HasStatusFlagsMixin(this));
-        addMixin(new ReadOnlyPropertyMixin(this, PropertyIdentifier.logBuffer, PropertyIdentifier.reliability,
-                PropertyIdentifier.totalRecordCount));
+        postInitialize();
 
         this.buffer = buffer;
         logDisabled = !allowLogging(getNow());
     }
 
-    public TrendLogMultipleObject withPolled(final int logInterval, final TimeUnit logIntervalUnit,
-            final boolean alignIntervals, final int intervalOffset, final TimeUnit offsetUnit) {
-        set(PropertyIdentifier.logInterval, new UnsignedInteger(logIntervalUnit.toMillis(logInterval) / 10));
-        set(PropertyIdentifier.alignIntervals, Boolean.valueOf(alignIntervals));
-        set(PropertyIdentifier.intervalOffset, new UnsignedInteger(offsetUnit.toMillis(intervalOffset) / 10));
-        set(PropertyIdentifier.loggingType, LoggingType.polled);
-        updateLoggingType();
-
+    public TrendLogMultipleObject withPolled(int logInterval, TimeUnit logIntervalUnit, boolean alignIntervals,
+            int intervalOffset, TimeUnit offsetUnit) {
+        baseWithPolled(logInterval, logIntervalUnit, alignIntervals, intervalOffset, offsetUnit);
         return this;
     }
 
-    public TrendLogMultipleObject withTriggered() {
-        set(PropertyIdentifier.loggingType, LoggingType.triggered);
-        updateLoggingType();
-
+    public TrendLogMultipleObject supportIntrinsicReporting(int notificationThreshold, int notificationClass,
+            EventTransitionBits eventEnable, NotifyType notifyType) {
+        baseSupportIntrinsicReporting(notificationThreshold, notificationClass, eventEnable, notifyType);
         return this;
-    }
-
-    public TrendLogMultipleObject supportIntrinsicReporting(final int notificationThreshold,
-            final int notificationClass, final EventTransitionBits eventEnable, final NotifyType notifyType) {
-        Objects.requireNonNull(eventEnable);
-        Objects.requireNonNull(notifyType);
-
-        // Prepare the object with all the properties that intrinsic reporting will need.
-        // User-defined properties
-        writePropertyInternal(PropertyIdentifier.notificationThreshold, new UnsignedInteger(notificationThreshold));
-        writePropertyInternal(PropertyIdentifier.recordsSinceNotification, UnsignedInteger.ZERO);
-        writePropertyInternal(PropertyIdentifier.lastNotifyRecord, UnsignedInteger.ZERO);
-        writePropertyInternal(PropertyIdentifier.eventState, EventState.normal);
-        writePropertyInternal(PropertyIdentifier.notificationClass, new UnsignedInteger(notificationClass));
-        writePropertyInternal(PropertyIdentifier.eventEnable, eventEnable);
-        writePropertyInternal(PropertyIdentifier.notifyType, notifyType);
-        writePropertyInternal(PropertyIdentifier.eventDetectionEnable, Boolean.TRUE);
-
-        final BufferReadyAlgo algo = new BufferReadyAlgo(PropertyIdentifier.totalRecordCount,
-                new DeviceObjectPropertyReference(getId(), PropertyIdentifier.logBuffer, null,
-                        getLocalDevice().getId()),
-                PropertyIdentifier.notificationThreshold, PropertyIdentifier.lastNotifyRecord);
-
-        final PropertyIdentifier[] triggerProps = new PropertyIdentifier[] { //
-                PropertyIdentifier.totalRecordCount, //
-                PropertyIdentifier.notificationThreshold};
-
-        // Now add the mixin.
-        addMixin(new IntrinsicReportingMixin(this, algo, null, PropertyIdentifier.totalRecordCount, triggerProps)
-                .withPostNotificationAction(notifParams -> {
-                    // After a notification has been sent, a couple values need to be updated.
-                    final BufferReadyNotif brn = (BufferReadyNotif) notifParams.getParameter();
-                    writePropertyInternal(PropertyIdentifier.lastNotifyRecord, brn.getCurrentNotification());
-                    writePropertyInternal(PropertyIdentifier.recordsSinceNotification, UnsignedInteger.ZERO);
-                }));
-
-        updateMonitoredProperty();
-
-        return this;
-    }
-
-    public boolean isLogDisabled() {
-        return logDisabled;
     }
 
     /**
@@ -233,59 +144,21 @@ public class TrendLogMultipleObject extends BACnetObject {
         }
     }
 
-    public void setEnabled(final boolean enabled) {
-        writePropertyInternal(PropertyIdentifier.enable, Boolean.valueOf(enabled));
-    }
-
-    /**
-     * Locally trigger a poll.
-     *
-     * @return true if the trigger was done, false if the trigger value was already true, indicating that a trigger
-     * was already in progress.
-     */
-    public synchronized boolean trigger() {
-        final Boolean trigger = get(PropertyIdentifier.trigger);
-        if (trigger.booleanValue()) {
-            return false;
-        }
-        set(PropertyIdentifier.trigger, Boolean.TRUE);
-        doTrigger();
-        return true;
-    }
-
     @Override
-    protected void beforeReadProperty(final PropertyIdentifier pid) throws BACnetServiceException {
-        if (PropertyIdentifier.logBuffer.equals(pid)) {
-            throw new BACnetServiceException(ErrorClass.property, ErrorCode.readAccessDenied);
+    protected int bufferSize() {
+        synchronized (buffer) {
+            return buffer.size();
         }
     }
 
     @Override
     protected boolean validateProperty(final ValueSource valueSource, final PropertyValue value)
             throws BACnetServiceException {
-        if (PropertyIdentifier.enable.equals(value.getPropertyIdentifier())) {
-            final Boolean enable = value.getValue();
-            final Boolean stopWhenFull = get(PropertyIdentifier.stopWhenFull);
-            final UnsignedInteger bufferSize = get(PropertyIdentifier.bufferSize);
-
-            if (enable.booleanValue() && stopWhenFull.booleanValue() && bufferSize.intValue() == buffer.size()) {
-                throw new BACnetServiceException(ErrorClass.object, ErrorCode.logBufferFull);
-            }
-        } else if (PropertyIdentifier.loggingType.equals(value.getPropertyIdentifier())) {
+        super.validateProperty(valueSource, value);
+        if (PropertyIdentifier.loggingType.equals(value.getPropertyIdentifier())) {
             final LoggingType loggingType = value.getValue();
             if (loggingType.equals(LoggingType.cov))
                 throw new BACnetServiceException(ErrorClass.property, ErrorCode.valueOutOfRange);
-
-        } else if (PropertyIdentifier.startTime.equals(value.getPropertyIdentifier()) //
-                || PropertyIdentifier.stopTime.equals(value.getPropertyIdentifier())) {
-            // Ensure that the date time is either entirely unspecified or entirely specified.
-            final DateTime dt = value.getValue();
-            if (dt.equals(DateTime.UNSPECIFIED))
-                return false;
-
-            if (!dt.isFullySpecified())
-                throw new BACnetServiceException(ErrorClass.property, ErrorCode.parameterOutOfRange);
-
         } else if (PropertyIdentifier.logDeviceObjectProperty.equals(value.getPropertyIdentifier())) {
             final BACnetArray<DeviceObjectPropertyReference> refs = value.getValue();
             for (final DeviceObjectPropertyReference ref : refs) {
@@ -294,42 +167,21 @@ public class TrendLogMultipleObject extends BACnetObject {
                     throw new BACnetServiceException(ErrorClass.property, ErrorCode.parameterOutOfRange);
                 }
             }
-
         } else if (PropertyIdentifier.logInterval.equals(value.getPropertyIdentifier())) {
             final LoggingType loggingType = get(PropertyIdentifier.loggingType);
             if (!loggingType.equals(LoggingType.polled)) {
                 throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
             }
-        } else if (PropertyIdentifier.bufferSize.equals(value.getPropertyIdentifier())) {
-            final Boolean enable = get(PropertyIdentifier.enable);
-            if (enable.booleanValue()) {
-                throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
-            }
-        } else if (PropertyIdentifier.recordCount.equals(value.getPropertyIdentifier())) {
-            // Only allowed to write a zero to this record. What would any other value do?
-            final UnsignedInteger recordCount = value.getValue();
-            if (recordCount.intValue() != 0)
-                throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
         }
         return false;
     }
 
     @Override
-    protected void afterWriteProperty(final PropertyIdentifier pid, final Encodable oldValue,
-            final Encodable newValue) {
-        if (PropertyIdentifier.enable.equals(pid)) {
-            evaluateLogDisabled();
-        } else if (PropertyIdentifier.startTime.equals(pid)) {
-            updateStartTime((DateTime) newValue);
-        } else if (PropertyIdentifier.stopTime.equals(pid)) {
-            updateStopTime((DateTime) newValue);
-        } else if (PropertyIdentifier.logDeviceObjectProperty.equals(pid)) {
-            purge();
-            updateMonitoredProperty();
+    protected void afterWriteProperty(PropertyIdentifier pid, Encodable oldValue, Encodable newValue) {
+        super.afterWriteProperty(pid, oldValue, newValue);
 
-        } else if (PropertyIdentifier.logInterval.equals(pid)) {
+        if (PropertyIdentifier.logInterval.equals(pid)) {
             updateLoggingType();
-
         } else if (PropertyIdentifier.stopWhenFull.equals(pid)) {
             final Boolean oldStopWhenFull = (Boolean) oldValue;
             final Boolean stopWhenFull = (Boolean) newValue;
@@ -345,7 +197,6 @@ public class TrendLogMultipleObject extends BACnetObject {
                     writePropertyInternal(PropertyIdentifier.enable, Boolean.FALSE);
                 }
             }
-
         } else if (PropertyIdentifier.bufferSize.equals(pid)) {
             final UnsignedInteger bufferSize = (UnsignedInteger) newValue;
             // In case the buffer size was reduced, remove extra entries in the buffer.
@@ -354,30 +205,11 @@ public class TrendLogMultipleObject extends BACnetObject {
                     buffer.remove();
             }
             updateRecordCount();
-
-        } else if (PropertyIdentifier.recordCount.equals(pid)) {
-            final UnsignedInteger recordCount = (UnsignedInteger) newValue;
-            if (recordCount.intValue() == 0)
-                purge();
-
-        } else if (PropertyIdentifier.loggingType.equals(pid)) {
-            updateLoggingType();
-
-        } else if (pid.isOneOf(PropertyIdentifier.alignIntervals, PropertyIdentifier.intervalOffset)) {
-            final LoggingType loggingType = get(PropertyIdentifier.loggingType);
-            if (loggingType.equals(LoggingType.polled)) {
-                updateLoggingType();
-            }
-
-        } else if (PropertyIdentifier.trigger.equals(pid)) {
-            // If the value has changed from false to true.
-            if (((Boolean) newValue).booleanValue() && !((Boolean) oldValue).booleanValue()) {
-                doTrigger();
-            }
         }
     }
 
-    private void purge() {
+    @Override
+    protected void purge() {
         synchronized (buffer) {
             buffer.clear();
         }
@@ -385,44 +217,8 @@ public class TrendLogMultipleObject extends BACnetObject {
         addLogRecordImpl(new LogMultipleRecord(getNow(), new LogData(new LogStatus(logDisabled, true, false))));
     }
 
-    private void updateStartTime(final DateTime startTime) {
-        cancelFuture(startTimeFuture);
-        if (!startTime.equals(DateTime.UNSPECIFIED)) {
-            final DateTime now = getNow();
-            final long diff = startTime.getGC().getTimeInMillis() - now.getGC().getTimeInMillis();
-            if (diff > 0) {
-                startTimeFuture = getLocalDevice().schedule(this::evaluateLogDisabled, diff, TimeUnit.MILLISECONDS);
-            }
-        }
-        evaluateLogDisabled();
-    }
-
-    private void updateStopTime(final DateTime stopTime) {
-        cancelFuture(stopTimeFuture);
-        if (!stopTime.equals(DateTime.UNSPECIFIED)) {
-            final DateTime now = getNow();
-            final long diff = stopTime.getGC().getTimeInMillis() - now.getGC().getTimeInMillis();
-            if (diff > 0) {
-                stopTimeFuture = getLocalDevice().schedule(this::evaluateLogDisabled, diff, TimeUnit.MILLISECONDS);
-            }
-        }
-        evaluateLogDisabled();
-    }
-
     @Override
-    protected void terminateImpl() {
-        super.terminate();
-        cancelFuture(startTimeFuture);
-        cancelFuture(stopTimeFuture);
-        cancelFuture(pollingFuture);
-    }
-
-    private static void cancelFuture(final ScheduledFuture<?> future) {
-        if (future != null)
-            future.cancel(false);
-    }
-
-    private void updateMonitoredProperty() {
+    protected void updateMonitoredProperty() {
         final BACnetArray<DeviceObjectPropertyReference> props = get(PropertyIdentifier.logDeviceObjectProperty);
 
         // Add the monitored property.
@@ -442,7 +238,8 @@ public class TrendLogMultipleObject extends BACnetObject {
     /**
      * This method reinitializes all data retrieval.
      */
-    private void updateLoggingType() {
+    @Override
+    protected void updateLoggingType() {
         final LoggingType loggingType = get(PropertyIdentifier.loggingType);
 
         cancelFuture(pollingFuture);
@@ -488,21 +285,8 @@ public class TrendLogMultipleObject extends BACnetObject {
         }
     }
 
-    private void doTrigger() {
-        // Perform the trigger asynchronously
-        getLocalDevice().execute(() -> {
-            try {
-                // Do the poll.
-                doPoll();
-                LOG.debug("Trigger complete");
-            } finally {
-                // Set the trigger value back to false.
-                writePropertyInternal(PropertyIdentifier.trigger, Boolean.FALSE);
-            }
-        });
-    }
-
-    private synchronized void doPoll() {
+    @Override
+    protected synchronized void doPoll() {
         // The spec says that no *logging* should occur if the log is disabled, but there doesn't seem to be much
         // point in polling at all if this is the case, so we check here and abort accordingly.
         if (logDisabled)
@@ -550,15 +334,6 @@ public class TrendLogMultipleObject extends BACnetObject {
         fullCheck();
     }
 
-    private void fullCheck() {
-        final Boolean stopWhenFull = get(PropertyIdentifier.stopWhenFull);
-        final UnsignedInteger bufferSize = get(PropertyIdentifier.bufferSize);
-        if (stopWhenFull.booleanValue() && buffer.size() == bufferSize.intValue() - 1) {
-            // There is only one spot left in the buffer, and StopWhenFull is true. Set Enable to false.
-            writePropertyInternal(PropertyIdentifier.enable, Boolean.FALSE);
-        }
-    }
-
     private void addLogRecordImpl(final LogMultipleRecord rec) {
         final UnsignedInteger bufferSize = get(PropertyIdentifier.bufferSize);
 
@@ -589,37 +364,8 @@ public class TrendLogMultipleObject extends BACnetObject {
         writePropertyInternal(PropertyIdentifier.totalRecordCount, totalRecordCount);
     }
 
-    /**
-     * Determines whether logging should be performed based upon Enable, StartTime, and StopTime.
-     */
-    private boolean allowLogging(final DateTime now) {
-        final Boolean enabled = get(PropertyIdentifier.enable);
-        if (!enabled.booleanValue())
-            return false;
-
-        final DateTime start = get(PropertyIdentifier.startTime);
-        final DateTime stop = get(PropertyIdentifier.stopTime);
-
-        if (!start.equals(DateTime.UNSPECIFIED)) {
-            LOG.info("Checking start time");
-            if (now.compareTo(start) < 0)
-                return false;
-        }
-
-        if (!stop.equals(DateTime.UNSPECIFIED)) {
-            LOG.info("Checking stop time");
-            if (now.compareTo(stop) >= 0)
-                return false;
-        }
-
-        return true;
-    }
-
-    private void updateRecordCount() {
-        writePropertyInternal(PropertyIdentifier.recordCount, new UnsignedInteger(buffer.size()));
-    }
-
-    private void evaluateLogDisabled() {
+    @Override
+    protected void evaluateLogDisabled() {
         // Don't evaluate until instantiation is complete.
         if (buffer != null) {
             final DateTime now = getNow();
@@ -631,9 +377,5 @@ public class TrendLogMultipleObject extends BACnetObject {
                     addLogRecordImpl(new LogMultipleRecord(now, new LogData(new LogStatus(logDisabled, false, false))));
             }
         }
-    }
-
-    private DateTime getNow() {
-        return new DateTime(getLocalDevice().getClock().millis());
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/obj/TrendLogMultipleObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/TrendLogMultipleObject.java
@@ -80,10 +80,9 @@ public class TrendLogMultipleObject extends BACnetObject {
     static final Logger LOG = LoggerFactory.getLogger(TrendLogMultipleObject.class);
 
     // CreateObject constructor
-    public static TrendLogMultipleObject create(final LocalDevice localDevice, final int instanceNumber)
-            throws BACnetServiceException {
+    public static TrendLogMultipleObject create(final LocalDevice localDevice, final int instanceNumber) {
         return new TrendLogMultipleObject(localDevice, instanceNumber,
-                ObjectType.trendLogMultiple.toString() + " " + instanceNumber, new LinkedListLogBuffer<>(), false,
+                ObjectType.trendLogMultiple + " " + instanceNumber, new LinkedListLogBuffer<>(), false,
                 DateTime.UNSPECIFIED, DateTime.UNSPECIFIED, new BACnetArray<>(), 60, false, 100) //
                 .supportIntrinsicReporting(20, 0, new EventTransitionBits(false, false, false),
                         NotifyType.event);
@@ -101,7 +100,7 @@ public class TrendLogMultipleObject extends BACnetObject {
     public TrendLogMultipleObject(final LocalDevice localDevice, final int instanceNumber, final String name,
             final LogBuffer<LogMultipleRecord> buffer, final boolean enable, final DateTime startTime,
             final DateTime stopTime, final BACnetArray<DeviceObjectPropertyReference> logDeviceObjectProperty,
-            final int logInterval, final boolean stopWhenFull, final int bufferSize) throws BACnetServiceException {
+            final int logInterval, final boolean stopWhenFull, final int bufferSize) {
         super(localDevice, ObjectType.trendLogMultiple, instanceNumber, name);
 
         Objects.requireNonNull(localDevice);
@@ -138,8 +137,6 @@ public class TrendLogMultipleObject extends BACnetObject {
 
         this.buffer = buffer;
         logDisabled = !allowLogging(getNow());
-
-        localDevice.addObject(this);
     }
 
     public TrendLogMultipleObject withPolled(final int logInterval, final TimeUnit logIntervalUnit,
@@ -477,13 +474,13 @@ public class TrendLogMultipleObject extends BACnetObject {
                 }
 
                 offsetToUse = intervalOffset.intValue() * 10;
-                offsetToUse %= period;
+                offsetToUse %= (int) period;
             }
 
             initialDelay += offsetToUse;
             initialDelay %= period;
 
-            pollingFuture = getLocalDevice().scheduleAtFixedRate(() -> doPoll(), initialDelay, period,
+            pollingFuture = getLocalDevice().scheduleAtFixedRate(this::doPoll, initialDelay, period,
                     TimeUnit.MILLISECONDS);
 
         } else if (loggingType.equals(LoggingType.triggered)) {

--- a/src/main/java/com/serotonin/bacnet4j/obj/TrendLogMultipleObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/TrendLogMultipleObject.java
@@ -184,7 +184,7 @@ public class TrendLogMultipleObject extends BACnetObject {
 
         // Now add the mixin.
         addMixin(new IntrinsicReportingMixin(this, algo, null, PropertyIdentifier.totalRecordCount, triggerProps)
-                .withPostNotificationAction((notifParams) -> {
+                .withPostNotificationAction(notifParams -> {
                     // After a notification has been sent, a couple values need to be updated.
                     final BufferReadyNotif brn = (BufferReadyNotif) notifParams.getParameter();
                     writePropertyInternal(PropertyIdentifier.lastNotifyRecord, brn.getCurrentNotification());
@@ -391,7 +391,7 @@ public class TrendLogMultipleObject extends BACnetObject {
             final DateTime now = getNow();
             final long diff = startTime.getGC().getTimeInMillis() - now.getGC().getTimeInMillis();
             if (diff > 0) {
-                startTimeFuture = getLocalDevice().schedule(() -> evaluateLogDisabled(), diff, TimeUnit.MILLISECONDS);
+                startTimeFuture = getLocalDevice().schedule(this::evaluateLogDisabled, diff, TimeUnit.MILLISECONDS);
             }
         }
         evaluateLogDisabled();
@@ -403,7 +403,7 @@ public class TrendLogMultipleObject extends BACnetObject {
             final DateTime now = getNow();
             final long diff = stopTime.getGC().getTimeInMillis() - now.getGC().getTimeInMillis();
             if (diff > 0) {
-                stopTimeFuture = getLocalDevice().schedule(() -> evaluateLogDisabled(), diff, TimeUnit.MILLISECONDS);
+                stopTimeFuture = getLocalDevice().schedule(this::evaluateLogDisabled, diff, TimeUnit.MILLISECONDS);
             }
         }
         evaluateLogDisabled();
@@ -535,17 +535,17 @@ public class TrendLogMultipleObject extends BACnetObject {
             elements.add(element);
         }
 
-        final LogMultipleRecord record = new LogMultipleRecord(now, new LogData(new SequenceOf<>(elements)));
-        addLogRecord(record);
+        final LogMultipleRecord rec = new LogMultipleRecord(now, new LogData(new SequenceOf<>(elements)));
+        addLogRecord(rec);
     }
 
-    private synchronized void addLogRecord(final LogMultipleRecord record) {
+    private synchronized void addLogRecord(final LogMultipleRecord rec) {
         // Check if logging is allowed.
         if (logDisabled)
             return;
 
         // Add the new record.
-        addLogRecordImpl(record);
+        addLogRecordImpl(rec);
 
         fullCheck();
     }
@@ -559,7 +559,7 @@ public class TrendLogMultipleObject extends BACnetObject {
         }
     }
 
-    private void addLogRecordImpl(final LogMultipleRecord record) {
+    private void addLogRecordImpl(final LogMultipleRecord rec) {
         final UnsignedInteger bufferSize = get(PropertyIdentifier.bufferSize);
 
         synchronized (buffer) {
@@ -569,7 +569,7 @@ public class TrendLogMultipleObject extends BACnetObject {
                 buffer.remove();
             }
 
-            buffer.add(record);
+            buffer.add(rec);
         }
 
         updateRecordCount();
@@ -585,7 +585,7 @@ public class TrendLogMultipleObject extends BACnetObject {
         if (totalRecordCount.longValue() == 0)
             // Value overflowed. As per 12.30.21 set to 1.
             totalRecordCount = new UnsignedInteger(1);
-        record.setSequenceNumber(totalRecordCount.longValue());
+        rec.setSequenceNumber(totalRecordCount.longValue());
         writePropertyInternal(PropertyIdentifier.totalRecordCount, totalRecordCount);
     }
 

--- a/src/main/java/com/serotonin/bacnet4j/obj/TrendLogObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/TrendLogObject.java
@@ -211,7 +211,7 @@ public class TrendLogObject extends BACnetObject {
 
         // Now add the mixin.
         addMixin(new IntrinsicReportingMixin(this, algo, null, PropertyIdentifier.totalRecordCount, triggerProps)
-                .withPostNotificationAction((notifParams) -> {
+                .withPostNotificationAction(notifParams -> {
                     if (notifParams.getParameter() instanceof BufferReadyNotif brn) {
                         // After a notification has been sent, a couple values need to be updated.
                         writePropertyInternal(PropertyIdentifier.lastNotifyRecord, brn.getCurrentNotification());

--- a/src/main/java/com/serotonin/bacnet4j/obj/TrendLogObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/TrendLogObject.java
@@ -42,11 +42,7 @@ import com.serotonin.bacnet4j.exception.BACnetException;
 import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.obj.logBuffer.LinkedListLogBuffer;
 import com.serotonin.bacnet4j.obj.logBuffer.LogBuffer;
-import com.serotonin.bacnet4j.obj.mixin.HasStatusFlagsMixin;
 import com.serotonin.bacnet4j.obj.mixin.PollingDelegate;
-import com.serotonin.bacnet4j.obj.mixin.ReadOnlyPropertyMixin;
-import com.serotonin.bacnet4j.obj.mixin.event.IntrinsicReportingMixin;
-import com.serotonin.bacnet4j.obj.mixin.event.eventAlgo.BufferReadyAlgo;
 import com.serotonin.bacnet4j.service.confirmed.SubscribeCOVPropertyRequest;
 import com.serotonin.bacnet4j.type.Encodable;
 import com.serotonin.bacnet4j.type.constructed.ClientCov;
@@ -62,14 +58,12 @@ import com.serotonin.bacnet4j.type.constructed.StatusFlags;
 import com.serotonin.bacnet4j.type.constructed.ValueSource;
 import com.serotonin.bacnet4j.type.enumerated.ErrorClass;
 import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
-import com.serotonin.bacnet4j.type.enumerated.EventState;
 import com.serotonin.bacnet4j.type.enumerated.LoggingType;
 import com.serotonin.bacnet4j.type.enumerated.NotifyType;
 import com.serotonin.bacnet4j.type.enumerated.ObjectType;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
 import com.serotonin.bacnet4j.type.enumerated.Reliability;
 import com.serotonin.bacnet4j.type.error.ErrorClassAndCode;
-import com.serotonin.bacnet4j.type.notificationParameters.BufferReadyNotif;
 import com.serotonin.bacnet4j.type.primitive.Boolean;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
@@ -84,7 +78,7 @@ import com.serotonin.bacnet4j.util.PropertyValues;
  * - Align intervals considering daylight savings time.
  * - What if a device doesn't support SubscribeCOVPropertyRequest?
  */
-public class TrendLogObject extends BACnetObject {
+public class TrendLogObject extends TrendLogBase {
     static final Logger LOG = LoggerFactory.getLogger(TrendLogObject.class);
 
     // CreateObject constructor
@@ -100,12 +94,6 @@ public class TrendLogObject extends BACnetObject {
 
     private final LogBuffer<LogRecord> buffer;
 
-    private boolean logDisabled;
-    private ScheduledFuture<?> startTimeFuture;
-    private ScheduledFuture<?> stopTimeFuture;
-
-    private PollingDelegate pollingDelegate;
-    private ScheduledFuture<?> pollingFuture;
     private SubscribeCOVPropertyRequest covSubscription;
     private DeviceEventAdapter covListener;
     private ScheduledFuture<?> resubscriptionFuture;
@@ -119,50 +107,29 @@ public class TrendLogObject extends BACnetObject {
             final LogBuffer<LogRecord> buffer, final boolean enable, final DateTime startTime, final DateTime stopTime,
             final DeviceObjectPropertyReference logDeviceObjectProperty, final int logInterval,
             final boolean stopWhenFull, final int bufferSize) {
-        super(localDevice, ObjectType.trendLog, instanceNumber, name);
+        super(localDevice, ObjectType.trendLog, instanceNumber, name, enable, startTime, stopTime, logInterval,
+                stopWhenFull, bufferSize);
 
-        Objects.requireNonNull(startTime);
-        Objects.requireNonNull(stopTime);
         Objects.requireNonNull(logDeviceObjectProperty);
 
-        set(PropertyIdentifier.enable, Boolean.valueOf(enable));
-        set(PropertyIdentifier.startTime, startTime);
-        set(PropertyIdentifier.stopTime, stopTime);
         set(PropertyIdentifier.logDeviceObjectProperty, logDeviceObjectProperty);
-        set(PropertyIdentifier.logInterval, new UnsignedInteger(logInterval));
-        set(PropertyIdentifier.stopWhenFull, Boolean.valueOf(stopWhenFull));
-        set(PropertyIdentifier.bufferSize, new UnsignedInteger(bufferSize));
         set(PropertyIdentifier.logBuffer, buffer);
-        set(PropertyIdentifier.recordCount, UnsignedInteger.ZERO);
-        set(PropertyIdentifier.totalRecordCount, UnsignedInteger.ZERO);
-        set(PropertyIdentifier.alignIntervals, Boolean.TRUE);
-        set(PropertyIdentifier.intervalOffset, UnsignedInteger.ZERO);
-        set(PropertyIdentifier.trigger, Boolean.FALSE);
-        set(PropertyIdentifier.statusFlags, new StatusFlags(false, false, false, false));
-        set(PropertyIdentifier.reliability, Reliability.noFaultDetected);
 
-        updateMonitoredProperty();
-        updateStartTime(startTime);
-        updateStopTime(stopTime);
-        withTriggered();
-
-        // Mixins
-        addMixin(new HasStatusFlagsMixin(this));
-        addMixin(new ReadOnlyPropertyMixin(this, PropertyIdentifier.logBuffer, PropertyIdentifier.reliability,
-                PropertyIdentifier.totalRecordCount));
+        postInitialize();
 
         this.buffer = buffer;
         logDisabled = !allowLogging(getNow());
     }
 
-    public TrendLogObject withPolled(final int logInterval, final TimeUnit logIntervalUnit,
-            final boolean alignIntervals, final int intervalOffset, final TimeUnit offsetUnit) {
-        set(PropertyIdentifier.logInterval, new UnsignedInteger(logIntervalUnit.toMillis(logInterval) / 10));
-        set(PropertyIdentifier.alignIntervals, Boolean.valueOf(alignIntervals));
-        set(PropertyIdentifier.intervalOffset, new UnsignedInteger(offsetUnit.toMillis(intervalOffset) / 10));
-        set(PropertyIdentifier.loggingType, LoggingType.polled);
-        updateLoggingType();
+    public TrendLogObject withPolled(int logInterval, TimeUnit logIntervalUnit, boolean alignIntervals,
+            int intervalOffset, TimeUnit offsetUnit) {
+        baseWithPolled(logInterval, logIntervalUnit, alignIntervals, intervalOffset, offsetUnit);
+        return this;
+    }
 
+    public TrendLogObject supportIntrinsicReporting(int notificationThreshold, int notificationClass,
+            EventTransitionBits eventEnable, NotifyType notifyType) {
+        baseSupportIntrinsicReporting(notificationThreshold, notificationClass, eventEnable, notifyType);
         return this;
     }
 
@@ -175,57 +142,6 @@ public class TrendLogObject extends BACnetObject {
         updateLoggingType();
 
         return this;
-    }
-
-    public TrendLogObject withTriggered() {
-        set(PropertyIdentifier.loggingType, LoggingType.triggered);
-        updateLoggingType();
-
-        return this;
-    }
-
-    public TrendLogObject supportIntrinsicReporting(final int notificationThreshold, final int notificationClass,
-            final EventTransitionBits eventEnable, final NotifyType notifyType) {
-        Objects.requireNonNull(eventEnable);
-        Objects.requireNonNull(notifyType);
-
-        // Prepare the object with all the properties that intrinsic reporting will need.
-        // User-defined properties
-        writePropertyInternal(PropertyIdentifier.notificationThreshold, new UnsignedInteger(notificationThreshold));
-        writePropertyInternal(PropertyIdentifier.recordsSinceNotification, UnsignedInteger.ZERO);
-        writePropertyInternal(PropertyIdentifier.lastNotifyRecord, UnsignedInteger.ZERO);
-        writePropertyInternal(PropertyIdentifier.eventState, EventState.normal);
-        writePropertyInternal(PropertyIdentifier.notificationClass, new UnsignedInteger(notificationClass));
-        writePropertyInternal(PropertyIdentifier.eventEnable, eventEnable);
-        writePropertyInternal(PropertyIdentifier.notifyType, notifyType);
-        writePropertyInternal(PropertyIdentifier.eventDetectionEnable, Boolean.TRUE);
-
-        final BufferReadyAlgo algo = new BufferReadyAlgo(PropertyIdentifier.totalRecordCount,
-                new DeviceObjectPropertyReference(getId(), PropertyIdentifier.logBuffer, null,
-                        getLocalDevice().getId()),
-                PropertyIdentifier.notificationThreshold, PropertyIdentifier.lastNotifyRecord);
-
-        final PropertyIdentifier[] triggerProps = new PropertyIdentifier[] { //
-                PropertyIdentifier.totalRecordCount, //
-                PropertyIdentifier.notificationThreshold};
-
-        // Now add the mixin.
-        addMixin(new IntrinsicReportingMixin(this, algo, null, PropertyIdentifier.totalRecordCount, triggerProps)
-                .withPostNotificationAction(notifParams -> {
-                    if (notifParams.getParameter() instanceof BufferReadyNotif brn) {
-                        // After a notification has been sent, a couple values need to be updated.
-                        writePropertyInternal(PropertyIdentifier.lastNotifyRecord, brn.getCurrentNotification());
-                        writePropertyInternal(PropertyIdentifier.recordsSinceNotification, UnsignedInteger.ZERO);
-                    }
-                }));
-
-        updateMonitoredProperty();
-
-        return this;
-    }
-
-    public boolean isLogDisabled() {
-        return logDisabled;
     }
 
     /**
@@ -257,56 +173,18 @@ public class TrendLogObject extends BACnetObject {
         }
     }
 
-    public void setEnabled(final boolean enabled) {
-        writePropertyInternal(PropertyIdentifier.enable, Boolean.valueOf(enabled));
-    }
-
-    /**
-     * Locally trigger a poll.
-     *
-     * @return true if the trigger was done, false if the trigger value was already true, indicating that a trigger
-     * was already in progress.
-     */
-    public synchronized boolean trigger() {
-        final Boolean trigger = get(PropertyIdentifier.trigger);
-        if (trigger.booleanValue()) {
-            return false;
-        }
-        set(PropertyIdentifier.trigger, Boolean.TRUE);
-        doTrigger();
-        return true;
-    }
-
     @Override
-    protected void beforeReadProperty(final PropertyIdentifier pid) throws BACnetServiceException {
-        if (PropertyIdentifier.logBuffer.equals(pid)) {
-            throw new BACnetServiceException(ErrorClass.property, ErrorCode.readAccessDenied);
+    protected int bufferSize() {
+        synchronized (buffer) {
+            return buffer.size();
         }
     }
 
     @Override
-    protected boolean validateProperty(final ValueSource valueSource, final PropertyValue value)
+    protected boolean validateProperty(ValueSource valueSource, PropertyValue value)
             throws BACnetServiceException {
-        if (PropertyIdentifier.enable.equals(value.getPropertyIdentifier())) {
-            final Boolean enable = value.getValue();
-            final Boolean stopWhenFull = get(PropertyIdentifier.stopWhenFull);
-            final UnsignedInteger bufferSize = get(PropertyIdentifier.bufferSize);
-
-            if (enable.booleanValue() && stopWhenFull.booleanValue() && bufferSize.intValue() == buffer.size()) {
-                throw new BACnetServiceException(ErrorClass.object, ErrorCode.logBufferFull);
-            }
-
-        } else if (PropertyIdentifier.startTime.equals(value.getPropertyIdentifier()) //
-                || PropertyIdentifier.stopTime.equals(value.getPropertyIdentifier())) {
-            // Ensure that the date time is either entirely unspecified or entirely specified.
-            final DateTime dt = value.getValue();
-            if (dt.equals(DateTime.UNSPECIFIED))
-                return false;
-
-            if (!dt.isFullySpecified())
-                throw new BACnetServiceException(ErrorClass.property, ErrorCode.parameterOutOfRange);
-
-        } else if (PropertyIdentifier.logDeviceObjectProperty.equals(value.getPropertyIdentifier())) {
+        super.validateProperty(valueSource, value);
+        if (PropertyIdentifier.logDeviceObjectProperty.equals(value.getPropertyIdentifier())) {
             final DeviceObjectPropertyReference logDeviceObjectProperty = value.getValue();
             if (logDeviceObjectProperty.getPropertyIdentifier().isOneOf(PropertyIdentifier.all,
                     PropertyIdentifier.required, PropertyIdentifier.optional)) {
@@ -317,34 +195,14 @@ public class TrendLogObject extends BACnetObject {
             if (!loggingType.isOneOf(LoggingType.polled, LoggingType.cov)) {
                 throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
             }
-        } else if (PropertyIdentifier.bufferSize.equals(value.getPropertyIdentifier())) {
-            final Boolean enable = get(PropertyIdentifier.enable);
-            if (enable.booleanValue()) {
-                throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
-            }
-        } else if (PropertyIdentifier.recordCount.equals(value.getPropertyIdentifier())) {
-            // Only allowed to write a zero to this record. What would any other value do?
-            final UnsignedInteger recordCount = value.getValue();
-            if (recordCount.intValue() != 0)
-                throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
         }
         return false;
     }
 
     @Override
-    protected void afterWriteProperty(final PropertyIdentifier pid, final Encodable oldValue,
-            final Encodable newValue) {
-        if (PropertyIdentifier.enable.equals(pid)) {
-            evaluateLogDisabled();
-        } else if (PropertyIdentifier.startTime.equals(pid)) {
-            updateStartTime((DateTime) newValue);
-        } else if (PropertyIdentifier.stopTime.equals(pid)) {
-            updateStopTime((DateTime) newValue);
-        } else if (PropertyIdentifier.logDeviceObjectProperty.equals(pid)) {
-            purge();
-            updateMonitoredProperty();
-
-        } else if (PropertyIdentifier.logInterval.equals(pid)) {
+    protected void afterWriteProperty(PropertyIdentifier pid, Encodable oldValue, Encodable newValue) {
+        super.afterWriteProperty(pid, oldValue, newValue);
+        if (PropertyIdentifier.logInterval.equals(pid)) {
             final int oldLogInterval = ((UnsignedInteger) oldValue).intValue();
             final int logInterval = ((UnsignedInteger) newValue).intValue();
             final LoggingType loggingType = get(PropertyIdentifier.loggingType);
@@ -356,13 +214,6 @@ public class TrendLogObject extends BACnetObject {
             }
 
             updateLoggingType();
-
-        } else if (pid.isOneOf(PropertyIdentifier.covResubscriptionInterval, PropertyIdentifier.clientCovIncrement)) {
-            final LoggingType loggingType = get(PropertyIdentifier.loggingType);
-            if (loggingType.equals(LoggingType.cov)) {
-                updateLoggingType();
-            }
-
         } else if (PropertyIdentifier.stopWhenFull.equals(pid)) {
             final Boolean oldStopWhenFull = (Boolean) oldValue;
             final Boolean stopWhenFull = (Boolean) newValue;
@@ -378,7 +229,6 @@ public class TrendLogObject extends BACnetObject {
                     writePropertyInternal(PropertyIdentifier.enable, Boolean.FALSE);
                 }
             }
-
         } else if (PropertyIdentifier.bufferSize.equals(pid)) {
             final UnsignedInteger bufferSize = (UnsignedInteger) newValue;
             // In case the buffer size was reduced, remove extra entries in the buffer.
@@ -387,30 +237,16 @@ public class TrendLogObject extends BACnetObject {
                     buffer.remove();
             }
             updateRecordCount();
-
-        } else if (PropertyIdentifier.recordCount.equals(pid)) {
-            final UnsignedInteger recordCount = (UnsignedInteger) newValue;
-            if (recordCount.intValue() == 0)
-                purge();
-
-        } else if (PropertyIdentifier.loggingType.equals(pid)) {
-            updateLoggingType();
-
-        } else if (pid.isOneOf(PropertyIdentifier.alignIntervals, PropertyIdentifier.intervalOffset)) {
+        } else if (pid.isOneOf(PropertyIdentifier.covResubscriptionInterval, PropertyIdentifier.clientCovIncrement)) {
             final LoggingType loggingType = get(PropertyIdentifier.loggingType);
-            if (loggingType.equals(LoggingType.polled)) {
+            if (loggingType.equals(LoggingType.cov)) {
                 updateLoggingType();
-            }
-
-        } else if (PropertyIdentifier.trigger.equals(pid)) {
-            // If the value has changed from false to true.
-            if (((Boolean) newValue).booleanValue() && !((Boolean) oldValue).booleanValue()) {
-                doTrigger();
             }
         }
     }
 
-    private void purge() {
+    @Override
+    protected void purge() {
         synchronized (buffer) {
             buffer.clear();
         }
@@ -418,42 +254,10 @@ public class TrendLogObject extends BACnetObject {
         addLogRecordImpl(new LogRecord(getNow(), new LogStatus(logDisabled, true, false), null));
     }
 
-    private void updateStartTime(final DateTime startTime) {
-        cancelFuture(startTimeFuture);
-        if (!startTime.equals(DateTime.UNSPECIFIED)) {
-            final DateTime now = getNow();
-            final long diff = startTime.getGC().getTimeInMillis() - now.getGC().getTimeInMillis();
-            if (diff > 0) {
-                startTimeFuture = getLocalDevice().schedule(this::evaluateLogDisabled, diff, TimeUnit.MILLISECONDS);
-            }
-        }
-        evaluateLogDisabled();
-    }
-
-    private void updateStopTime(final DateTime stopTime) {
-        cancelFuture(stopTimeFuture);
-        if (!stopTime.equals(DateTime.UNSPECIFIED)) {
-            final DateTime now = getNow();
-            final long diff = stopTime.getGC().getTimeInMillis() - now.getGC().getTimeInMillis();
-            if (diff > 0) {
-                stopTimeFuture = getLocalDevice().schedule(this::evaluateLogDisabled, diff, TimeUnit.MILLISECONDS);
-            }
-        }
-        evaluateLogDisabled();
-    }
-
     @Override
     protected void terminateImpl() {
         super.terminate();
-        cancelFuture(startTimeFuture);
-        cancelFuture(stopTimeFuture);
-        cancelFuture(pollingFuture);
         cancelCov();
-    }
-
-    private static void cancelFuture(final ScheduledFuture<?> future) {
-        if (future != null)
-            future.cancel(false);
     }
 
     private void cancelCov() {
@@ -491,7 +295,8 @@ public class TrendLogObject extends BACnetObject {
         cancelFuture(resubscriptionFuture);
     }
 
-    private void updateMonitoredProperty() {
+    @Override
+    protected void updateMonitoredProperty() {
         final DeviceObjectPropertyReference monitored = get(PropertyIdentifier.logDeviceObjectProperty);
 
         // Add the monitored property.
@@ -513,7 +318,8 @@ public class TrendLogObject extends BACnetObject {
     /**
      * This method reinitializes all data retrieval.
      */
-    private void updateLoggingType() {
+    @Override
+    protected void updateLoggingType() {
         final LoggingType loggingType = get(PropertyIdentifier.loggingType);
 
         cancelFuture(pollingFuture);
@@ -653,21 +459,8 @@ public class TrendLogObject extends BACnetObject {
         updateConfigurationError(false);
     }
 
-    private void doTrigger() {
-        // Perform the trigger asynchronously
-        getLocalDevice().execute(() -> {
-            try {
-                // Do the poll.
-                doPoll();
-                LOG.debug("Trigger complete");
-            } finally {
-                // Set the trigger value back to false.
-                writePropertyInternal(PropertyIdentifier.trigger, Boolean.FALSE);
-            }
-        });
-    }
-
-    private synchronized void doPoll() {
+    @Override
+    protected synchronized void doPoll() {
         // The spec says that no *logging* should occur if the log is disabled, but there doesn't seem to be much
         // point in polling at all if this is the case, so we check here and abort accordingly.
         if (logDisabled)
@@ -731,15 +524,6 @@ public class TrendLogObject extends BACnetObject {
         fullCheck();
     }
 
-    private void fullCheck() {
-        final Boolean stopWhenFull = get(PropertyIdentifier.stopWhenFull);
-        final UnsignedInteger bufferSize = get(PropertyIdentifier.bufferSize);
-        if (stopWhenFull.booleanValue() && buffer.size() == bufferSize.intValue() - 1) {
-            // There is only one spot left in the buffer, and StopWhenFull is true. Set Enable to false.
-            writePropertyInternal(PropertyIdentifier.enable, Boolean.FALSE);
-        }
-    }
-
     private void addLogRecordImpl(final LogRecord rec) {
         final UnsignedInteger bufferSize = get(PropertyIdentifier.bufferSize);
 
@@ -770,37 +554,8 @@ public class TrendLogObject extends BACnetObject {
         writePropertyInternal(PropertyIdentifier.totalRecordCount, totalRecordCount);
     }
 
-    /**
-     * Determines whether logging should be performed based upon Enable, StartTime, and StopTime.
-     */
-    private boolean allowLogging(final DateTime now) {
-        final Boolean enabled = get(PropertyIdentifier.enable);
-        if (!enabled.booleanValue())
-            return false;
-
-        final DateTime start = get(PropertyIdentifier.startTime);
-        final DateTime stop = get(PropertyIdentifier.stopTime);
-
-        if (!start.equals(DateTime.UNSPECIFIED)) {
-            LOG.debug("Checking start time");
-            if (now.compareTo(start) < 0)
-                return false;
-        }
-
-        if (!stop.equals(DateTime.UNSPECIFIED)) {
-            LOG.debug("Checking stop time, now={}, stop={}", now, stop);
-            if (now.compareTo(stop) >= 0)
-                return false;
-        }
-
-        return true;
-    }
-
-    private void updateRecordCount() {
-        writePropertyInternal(PropertyIdentifier.recordCount, new UnsignedInteger(buffer.size()));
-    }
-
-    private void evaluateLogDisabled() {
+    @Override
+    protected void evaluateLogDisabled() {
         // Don't evaluate until instantiation is complete.
         if (buffer != null) {
             final DateTime now = getNow();
@@ -812,9 +567,5 @@ public class TrendLogObject extends BACnetObject {
                     addLogRecordImpl(new LogRecord(now, new LogStatus(logDisabled, false, false), null));
             }
         }
-    }
-
-    private DateTime getNow() {
-        return new DateTime(getLocalDevice().getClock().millis());
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/obj/TrendLogObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/TrendLogObject.java
@@ -119,7 +119,7 @@ public class TrendLogObject extends BACnetObject {
     public TrendLogObject(final LocalDevice localDevice, final int instanceNumber, final String name,
             final LogBuffer<LogRecord> buffer, final boolean enable, final DateTime startTime, final DateTime stopTime,
             final DeviceObjectPropertyReference logDeviceObjectProperty, final int logInterval,
-            final boolean stopWhenFull, final int bufferSize) throws BACnetServiceException {
+            final boolean stopWhenFull, final int bufferSize) {
         super(localDevice, ObjectType.trendLog, instanceNumber, name);
 
         Objects.requireNonNull(startTime);
@@ -154,8 +154,6 @@ public class TrendLogObject extends BACnetObject {
 
         this.buffer = buffer;
         logDisabled = !allowLogging(getNow());
-
-        localDevice.addObject(this);
     }
 
     public TrendLogObject withPolled(final int logInterval, final TimeUnit logIntervalUnit,

--- a/src/main/java/com/serotonin/bacnet4j/obj/TrendLogObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/TrendLogObject.java
@@ -88,8 +88,7 @@ public class TrendLogObject extends BACnetObject {
     static final Logger LOG = LoggerFactory.getLogger(TrendLogObject.class);
 
     // CreateObject constructor
-    public static TrendLogObject create(final LocalDevice localDevice, final int instanceNumber)
-            throws BACnetServiceException {
+    public static TrendLogObject create(final LocalDevice localDevice, final int instanceNumber) {
         return new TrendLogObject(localDevice, instanceNumber, ObjectType.trendLog.toString() + " " + instanceNumber,
                 new LinkedListLogBuffer<>(), false, DateTime.UNSPECIFIED, DateTime.UNSPECIFIED,
                 new DeviceObjectPropertyReference(localDevice.getInstanceNumber(), localDevice.getId(),
@@ -190,7 +189,7 @@ public class TrendLogObject extends BACnetObject {
         Objects.requireNonNull(eventEnable);
         Objects.requireNonNull(notifyType);
 
-        // Prepare the object with all of the properties that intrinsic reporting will need.
+        // Prepare the object with all the properties that intrinsic reporting will need.
         // User-defined properties
         writePropertyInternal(PropertyIdentifier.notificationThreshold, new UnsignedInteger(notificationThreshold));
         writePropertyInternal(PropertyIdentifier.recordsSinceNotification, UnsignedInteger.ZERO);
@@ -213,9 +212,8 @@ public class TrendLogObject extends BACnetObject {
         // Now add the mixin.
         addMixin(new IntrinsicReportingMixin(this, algo, null, PropertyIdentifier.totalRecordCount, triggerProps)
                 .withPostNotificationAction((notifParams) -> {
-                    if (notifParams.getParameter() instanceof BufferReadyNotif) {
+                    if (notifParams.getParameter() instanceof BufferReadyNotif brn) {
                         // After a notification has been sent, a couple values need to be updated.
-                        final BufferReadyNotif brn = (BufferReadyNotif) notifParams.getParameter();
                         writePropertyInternal(PropertyIdentifier.lastNotifyRecord, brn.getCurrentNotification());
                         writePropertyInternal(PropertyIdentifier.recordsSinceNotification, UnsignedInteger.ZERO);
                     }
@@ -426,7 +424,7 @@ public class TrendLogObject extends BACnetObject {
             final DateTime now = getNow();
             final long diff = startTime.getGC().getTimeInMillis() - now.getGC().getTimeInMillis();
             if (diff > 0) {
-                startTimeFuture = getLocalDevice().schedule(() -> evaluateLogDisabled(), diff, TimeUnit.MILLISECONDS);
+                startTimeFuture = getLocalDevice().schedule(this::evaluateLogDisabled, diff, TimeUnit.MILLISECONDS);
             }
         }
         evaluateLogDisabled();
@@ -438,7 +436,7 @@ public class TrendLogObject extends BACnetObject {
             final DateTime now = getNow();
             final long diff = stopTime.getGC().getTimeInMillis() - now.getGC().getTimeInMillis();
             if (diff > 0) {
-                stopTimeFuture = getLocalDevice().schedule(() -> evaluateLogDisabled(), diff, TimeUnit.MILLISECONDS);
+                stopTimeFuture = getLocalDevice().schedule(this::evaluateLogDisabled, diff, TimeUnit.MILLISECONDS);
             }
         }
         evaluateLogDisabled();
@@ -548,13 +546,13 @@ public class TrendLogObject extends BACnetObject {
                 }
 
                 offsetToUse = intervalOffset.intValue() * 10;
-                offsetToUse %= period;
+                offsetToUse %= (int) period;
             }
 
             initialDelay += offsetToUse;
             initialDelay %= period;
 
-            pollingFuture = getLocalDevice().scheduleAtFixedRate(() -> doPoll(), initialDelay, period,
+            pollingFuture = getLocalDevice().scheduleAtFixedRate(this::doPoll, initialDelay, period,
                     TimeUnit.MILLISECONDS);
 
         } else if (loggingType.equals(LoggingType.cov)) {
@@ -602,7 +600,7 @@ public class TrendLogObject extends BACnetObject {
                             LOG.warn("Requested property not found in COV notification: {}", listOfValues);
                             updateConfigurationError(true);
                         } else {
-                            LOG.debug("COV update: " + value);
+                            LOG.debug("COV update: {}", value);
                             addLogRecord(LogRecord.createFromMonitoredValue(getNow(), value, statusFlags));
                         }
                     }
@@ -687,10 +685,10 @@ public class TrendLogObject extends BACnetObject {
         final Encodable value = values.getNoErrorCheck(monitored.getObjectIdentifier(),
                 new PropertyReference(monitored.getPropertyIdentifier(), monitored.getPropertyArrayIndex()));
 
-        LogRecord record;
+        LogRecord rec;
         boolean error = false;
         if (value instanceof ErrorClassAndCode) {
-            record = LogRecord.createFromMonitoredValue(now, value, null);
+            rec = LogRecord.createFromMonitoredValue(now, value, null);
             error = true;
             LOG.warn("Error returned for value from poll: {}", value);
         } else {
@@ -700,15 +698,15 @@ public class TrendLogObject extends BACnetObject {
             if (statusFlags instanceof ErrorClassAndCode) {
                 error = true;
                 LOG.warn("Error returned for statusFlags from poll: {}", value);
-                record = LogRecord.createFromMonitoredValue(now, value, null);
+                rec = LogRecord.createFromMonitoredValue(now, value, null);
             } else {
-                record = LogRecord.createFromMonitoredValue(now, value, (StatusFlags) statusFlags);
+                rec = LogRecord.createFromMonitoredValue(now, value, (StatusFlags) statusFlags);
             }
         }
 
         updateConfigurationError(error);
 
-        addLogRecord(record);
+        addLogRecord(rec);
     }
 
     private void updateConfigurationError(final boolean error) {
@@ -722,13 +720,13 @@ public class TrendLogObject extends BACnetObject {
         }
     }
 
-    private synchronized void addLogRecord(final LogRecord record) {
+    private synchronized void addLogRecord(final LogRecord rec) {
         // Check if logging is allowed.
         if (logDisabled)
             return;
 
         // Add the new record.
-        addLogRecordImpl(record);
+        addLogRecordImpl(rec);
 
         fullCheck();
     }
@@ -742,7 +740,7 @@ public class TrendLogObject extends BACnetObject {
         }
     }
 
-    private void addLogRecordImpl(final LogRecord record) {
+    private void addLogRecordImpl(final LogRecord rec) {
         final UnsignedInteger bufferSize = get(PropertyIdentifier.bufferSize);
 
         synchronized (buffer) {
@@ -752,7 +750,7 @@ public class TrendLogObject extends BACnetObject {
                 buffer.remove();
             }
 
-            buffer.add(record);
+            buffer.add(rec);
         }
 
         updateRecordCount();
@@ -768,7 +766,7 @@ public class TrendLogObject extends BACnetObject {
         if (totalRecordCount.longValue() == 0)
             // Value overflowed. As per 12.25.16 set to 1.
             totalRecordCount = new UnsignedInteger(1);
-        record.setSequenceNumber(totalRecordCount.longValue());
+        rec.setSequenceNumber(totalRecordCount.longValue());
         writePropertyInternal(PropertyIdentifier.totalRecordCount, totalRecordCount);
     }
 

--- a/src/main/java/com/serotonin/bacnet4j/service/confirmed/CreateObjectRequest.java
+++ b/src/main/java/com/serotonin/bacnet4j/service/confirmed/CreateObjectRequest.java
@@ -72,23 +72,23 @@ public class CreateObjectRequest extends ConfirmedRequestService {
 
     public static final byte TYPE_ID = 10;
 
-    private static ChoiceOptions choiceOptions = new ChoiceOptions();
+    private static final ChoiceOptions choiceOptions = new ChoiceOptions();
 
     static {
         choiceOptions.addContextual(0, ObjectType.class);
         choiceOptions.addContextual(1, ObjectIdentifier.class);
     }
 
-    private static Map<ObjectType, ObjectCreator> creators = new HashMap<>();
+    private static final Map<ObjectType, ObjectCreator> creators = new HashMap<>();
 
     static {
-        creators.put(ObjectType.calendar, (d, number) -> CalendarObject.create(d, number));
-        creators.put(ObjectType.eventLog, (d, number) -> EventLogObject.create(d, number));
-        creators.put(ObjectType.group, (d, number) -> GroupObject.create(d, number));
-        creators.put(ObjectType.notificationClass, (d, number) -> NotificationClassObject.create(d, number));
-        creators.put(ObjectType.schedule, (d, number) -> ScheduleObject.create(d, number));
-        creators.put(ObjectType.trendLog, (d, number) -> TrendLogObject.create(d, number));
-        creators.put(ObjectType.trendLogMultiple, (d, number) -> TrendLogMultipleObject.create(d, number));
+        creators.put(ObjectType.calendar, CalendarObject::create);
+        creators.put(ObjectType.eventLog, EventLogObject::create);
+        creators.put(ObjectType.group, GroupObject::create);
+        creators.put(ObjectType.notificationClass, NotificationClassObject::create);
+        creators.put(ObjectType.schedule, ScheduleObject::create);
+        creators.put(ObjectType.trendLog, TrendLogObject::create);
+        creators.put(ObjectType.trendLogMultiple, TrendLogMultipleObject::create);
     }
 
     private final Choice objectSpecifier;
@@ -169,7 +169,7 @@ public class CreateObjectRequest extends ConfirmedRequestService {
         try {
             final BACnetObject bo;
             try {
-                bo = creator.create(localDevice, instanceNumber);
+                bo = localDevice.addObject(creator.create(localDevice, instanceNumber));
             } catch (final BACnetServiceException e) {
                 throw createException(e.getErrorClass(), e.getErrorCode(), 0);
             }
@@ -243,7 +243,7 @@ public class CreateObjectRequest extends ConfirmedRequestService {
     }
 
     @FunctionalInterface
-    public static interface ObjectCreator {
+    public interface ObjectCreator {
         BACnetObject create(LocalDevice d, int instanceNumber) throws BACnetServiceException;
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/transport/DefaultTransport.java
+++ b/src/main/java/com/serotonin/bacnet4j/transport/DefaultTransport.java
@@ -27,6 +27,7 @@
 
 package com.serotonin.bacnet4j.transport;
 
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Queue;
@@ -1006,6 +1007,7 @@ public class DefaultTransport implements Transport, Runnable {
                 .entrySet().iterator();
 
         // Check for expired unacked messages
+        var toSendForResponse = new HashMap<UnackedMessageKey, UnackedMessageContext>();
         while (umIter.hasNext()) {
             final Map.Entry<UnackedMessageKey, UnackedMessageContext> e = umIter.next();
             final UnackedMessageKey key = e.getKey();
@@ -1014,7 +1016,7 @@ public class DefaultTransport implements Transport, Runnable {
                 if (ctx.hasMoreAttempts()) {
                     // Resend
                     ctx.retry(timeout);
-                    sendForResponse(key, ctx);
+                    toSendForResponse.put(key, ctx);
                 } else {
                     LOG.debug("Timeout on key {}", key);
 
@@ -1040,6 +1042,7 @@ public class DefaultTransport implements Transport, Runnable {
                 didSomething = true;
             }
         }
+        toSendForResponse.forEach(this::sendForResponse);
 
         return !didSomething;
     }

--- a/src/test/java/com/serotonin/bacnet4j/LocalDeviceTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/LocalDeviceTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -61,8 +62,10 @@ import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.exception.BACnetTimeoutException;
 import com.serotonin.bacnet4j.npdu.test.TestNetwork;
 import com.serotonin.bacnet4j.npdu.test.TestNetworkMap;
+import com.serotonin.bacnet4j.obj.AnalogInputObject;
 import com.serotonin.bacnet4j.obj.DeviceObject;
 import com.serotonin.bacnet4j.transport.DefaultTransport;
+import com.serotonin.bacnet4j.type.enumerated.EngineeringUnits;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
 import com.serotonin.bacnet4j.util.DiscoveryUtils;
@@ -123,18 +126,18 @@ public class LocalDeviceTest {
         future1.get();
         future2.get();
 
-        assertSame(rd21.getValue(), rd22.getValue());
-        assertNotNull(rd21.getValue().getDeviceProperty(PropertyIdentifier.protocolServicesSupported));
-        assertNotNull(rd21.getValue().getDeviceProperty(PropertyIdentifier.objectName));
-        assertNotNull(rd21.getValue().getDeviceProperty(PropertyIdentifier.protocolVersion));
-        assertNotNull(rd21.getValue().getDeviceProperty(PropertyIdentifier.vendorIdentifier));
-        assertNotNull(rd21.getValue().getDeviceProperty(PropertyIdentifier.modelName));
+        assertSame(rd21.get(), rd22.get());
+        assertNotNull(rd21.get().getDeviceProperty(PropertyIdentifier.protocolServicesSupported));
+        assertNotNull(rd21.get().getDeviceProperty(PropertyIdentifier.objectName));
+        assertNotNull(rd21.get().getDeviceProperty(PropertyIdentifier.protocolVersion));
+        assertNotNull(rd21.get().getDeviceProperty(PropertyIdentifier.vendorIdentifier));
+        assertNotNull(rd21.get().getDeviceProperty(PropertyIdentifier.modelName));
 
         // Ask for it again. Should be the same instance.
         final RemoteDevice rd23 = d1.getRemoteDevice(2).get();
 
         // Device is cached, so it will still be the same instance.
-        assertSame(rd21.getValue(), rd23);
+        assertSame(rd21.get(), rd23);
     }
 
     @Test(expected = BACnetTimeoutException.class)
@@ -174,12 +177,12 @@ public class LocalDeviceTest {
         final MutableObject<RemoteDevice> rd21 = new MutableObject<>();
         d1.getRemoteDevice(2, rd21::setValue, null, null, 1, TimeUnit.SECONDS);
 
-        awaitTrue(() -> rd21.getValue() != null);
-        assertSame(rd21.getValue(), d1.getCachedRemoteDevice(2));
+        awaitTrue(() -> rd21.get() != null);
+        assertSame(rd21.get(), d1.getCachedRemoteDevice(2));
     }
 
-    @Test(expected = BACnetServiceException.class)
-    public void createSecondDevice() throws BACnetServiceException {
+    @Test
+    public void createSecondDevice() {
         final LocalDevice ld = new LocalDevice(1, new DefaultTransport(new TestNetwork(map, 1, 0)));
         final DeviceObject o = new DeviceObject(ld, 2);
 
@@ -187,7 +190,17 @@ public class LocalDeviceTest {
         assertEquals(1, ld.getLocalObjects().size());
 
         // Try to add the device manually, and ensure that this fails.
-        ld.addObject(o);
+        assertThrows(BACnetServiceException.class, () -> ld.addObject(o));
+    }
+
+    @Test
+    public void wrongLocalDevice() {
+        var ld = new LocalDevice(1, new DefaultTransport(new TestNetwork(map, 1, 0)));
+        var ld2 = new LocalDevice(2, new DefaultTransport(new TestNetwork(map, 2, 0)));
+        var o = new AnalogInputObject(ld2, 3, "ai", 0, EngineeringUnits.noUnits, false);
+
+        // Try to add the object to the wrong local device.
+        assertThrows(IllegalArgumentException.class, () -> ld.addObject(o));
     }
 
     @SuppressWarnings("unused")

--- a/src/test/java/com/serotonin/bacnet4j/obj/AccumulatorObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/AccumulatorObjectTest.java
@@ -82,9 +82,11 @@ public class AccumulatorObjectTest extends AbstractTest {
 
     @Override
     public void afterInit() throws Exception {
-        a = new AccumulatorObject(d1, 0, "a0", 0, 0, EngineeringUnits.amperes, false, new Scale(new Real(1)),
-                new Prescale(new UnsignedInteger(2), new UnsignedInteger(15)), 200, 1);
-        nc = new NotificationClassObject(d1, 54, "nc54", 100, 5, 200, new EventTransitionBits(true, true, true));
+        a = d1.addObject(new AccumulatorObject(
+                d1, 0, "a0", 0, 0, EngineeringUnits.amperes, false, new Scale(new Real(1)),
+                new Prescale(new UnsignedInteger(2), new UnsignedInteger(15)), 200, 1));
+        nc = d1.addObject(new NotificationClassObject(
+                d1, 54, "nc54", 100, 5, 200, new EventTransitionBits(true, true, true)));
     }
 
     @SuppressWarnings("unchecked")
@@ -336,12 +338,13 @@ public class AccumulatorObjectTest extends AbstractTest {
 
         final DeviceObjectPropertyReference ref =
                 new DeviceObjectPropertyReference(1, a.getId(), PropertyIdentifier.pulseRate);
-        final EventEnrollmentObject ee = new EventEnrollmentObject(d1, 0, "ee", ref, NotifyType.alarm,
+        final EventEnrollmentObject ee = d1.addObject(new EventEnrollmentObject(
+                d1, 0, "ee", ref, NotifyType.alarm,
                 new EventParameter(
                         new UnsignedRange(new UnsignedInteger(3), new UnsignedInteger(30), new UnsignedInteger(50))),
                 new EventTransitionBits(true, true, true), 54, 100, null, new FaultParameter(
                 new FaultOutOfRange(new FaultNormalValue(new UnsignedInteger(20)),
-                        new FaultNormalValue(new UnsignedInteger(60)))));
+                        new FaultNormalValue(new UnsignedInteger(60))))));
 
         // Set up the notification destination
         final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
@@ -414,9 +417,9 @@ public class AccumulatorObjectTest extends AbstractTest {
 
     @Test
     public void construction() throws Exception {
-        final AccumulatorObject a1 =
-                new AccumulatorObject(d1, 1, "a1", 456, 0, EngineeringUnits.amperes, false, new Scale(new Real(1)),
-                        new Prescale(new UnsignedInteger(2), new UnsignedInteger(15)), 200, 1);
+        final AccumulatorObject a1 = d1.addObject(new AccumulatorObject(
+                d1, 1, "a1", 456, 0, EngineeringUnits.amperes, false, new Scale(new Real(1)),
+                new Prescale(new UnsignedInteger(2), new UnsignedInteger(15)), 200, 1));
         assertEquals(new UnsignedInteger(456), a1.get(PropertyIdentifier.presentValue));
     }
 

--- a/src/test/java/com/serotonin/bacnet4j/obj/AccumulatorObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/AccumulatorObjectTest.java
@@ -356,7 +356,7 @@ public class AccumulatorObjectTest extends AbstractTest {
         d2.getEventHandler().addListener(listener);
 
         // Ensure that initializing the event enrollment object didn't fire any notifications.
-        Thread.sleep(500);
+        quiesce();
         assertEquals(EventState.normal, ee.readProperty(PropertyIdentifier.eventState));
         assertEquals(0, listener.getNotifCount());
 

--- a/src/test/java/com/serotonin/bacnet4j/obj/AlertEnrollmentObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/AlertEnrollmentObjectTest.java
@@ -62,14 +62,16 @@ public class AlertEnrollmentObjectTest extends AbstractTest {
 
     @Override
     public void afterInit() throws Exception {
-        av0 = new AnalogValueObject(d1, 0, "av0", 0, EngineeringUnits.noUnits, false);
-        nc = new NotificationClassObject(d1, 55, "nc55", 101, 4, 201, new EventTransitionBits(false, false, false));
+        av0 = d1.addObject(new AnalogValueObject(
+                d1, 0, "av0", 0, EngineeringUnits.noUnits, false));
+        nc = d1.addObject(new NotificationClassObject(
+                d1, 55, "nc55", 101, 4, 201, new EventTransitionBits(false, false, false)));
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void alertReporting() throws Exception {
-        final AlertEnrollmentObject ae = new AlertEnrollmentObject(d1, 0, "ae0", 55, NotifyType.alarm);
+        final AlertEnrollmentObject ae = d1.addObject(new AlertEnrollmentObject(d1, 0, "ae0", 55, NotifyType.alarm));
 
         final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
         recipients.add(new Destination(new Recipient(rd2.getAddress()), new UnsignedInteger(10), Boolean.TRUE,

--- a/src/test/java/com/serotonin/bacnet4j/obj/AnalogInputObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/AnalogInputObjectTest.java
@@ -69,8 +69,9 @@ public class AnalogInputObjectTest extends AbstractTest {
 
     @Override
     public void afterInit() throws Exception {
-        ai = new AnalogInputObject(d1, 0, "ai0", 50, EngineeringUnits.amperes, false);
-        nc = new NotificationClassObject(d1, 17, "nc17", 100, 5, 200, new EventTransitionBits(false, false, false));
+        ai = d1.addObject(new AnalogInputObject(d1, 0, "ai0", 50, EngineeringUnits.amperes, false));
+        nc = d1.addObject(new NotificationClassObject(
+                d1, 17, "nc17", 100, 5, 200, new EventTransitionBits(false, false, false)));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/com/serotonin/bacnet4j/obj/AnalogOutputObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/AnalogOutputObjectTest.java
@@ -75,8 +75,9 @@ public class AnalogOutputObjectTest extends AbstractTest {
 
     @Override
     public void afterInit() throws Exception {
-        ao = new AnalogOutputObject(d1, 0, "ao", 50, EngineeringUnits.amperes, false, 45);
-        nc = new NotificationClassObject(d1, 17, "nc17", 100, 5, 200, new EventTransitionBits(false, false, false));
+        ao = d1.addObject(new AnalogOutputObject(d1, 0, "ao", 50, EngineeringUnits.amperes, false, 45));
+        nc = d1.addObject(new NotificationClassObject(
+                d1, 17, "nc17", 100, 5, 200, new EventTransitionBits(false, false, false)));
     }
 
     @SuppressWarnings("unchecked")
@@ -224,9 +225,10 @@ public class AnalogOutputObjectTest extends AbstractTest {
     public void algorithmicReporting() throws Exception {
         final DeviceObjectPropertyReference ref =
                 new DeviceObjectPropertyReference(1, ao.getId(), PropertyIdentifier.presentValue);
-        final EventEnrollmentObject ee = new EventEnrollmentObject(d1, 0, "ee", ref, NotifyType.alarm,
+        final EventEnrollmentObject ee = d1.addObject(new EventEnrollmentObject(
+                d1, 0, "ee", ref, NotifyType.alarm,
                 new EventParameter(new OutOfRange(new UnsignedInteger(30), new Real(40), new Real(60), new Real(2))),
-                new EventTransitionBits(true, true, true), 17, 1000, null, null);
+                new EventTransitionBits(true, true, true), 17, 1000, null, null));
 
         // Set up the notification destination
         final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);

--- a/src/test/java/com/serotonin/bacnet4j/obj/AnalogValueObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/AnalogValueObjectTest.java
@@ -65,8 +65,9 @@ public class AnalogValueObjectTest extends AbstractTest {
 
     @Override
     public void afterInit() throws Exception {
-        av = new AnalogValueObject(d1, 0, "av0", 50, EngineeringUnits.amperes, false);
-        nc = new NotificationClassObject(d1, 7, "nc7", 100, 5, 200, new EventTransitionBits(false, false, false));
+        av = d1.addObject(new AnalogValueObject(d1, 0, "av0", 50, EngineeringUnits.amperes, false));
+        nc = d1.addObject(new NotificationClassObject(
+                d1, 7, "nc7", 100, 5, 200, new EventTransitionBits(false, false, false)));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/com/serotonin/bacnet4j/obj/AveragingObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/AveragingObjectTest.java
@@ -60,16 +60,17 @@ AveragingObjectTest extends AbstractTest {
     @Override
     public void afterInit() throws Exception {
         // Poll every 5s
-        a = new AveragingObject(d1, 0, "a0",
+        a = d1.addObject(new AveragingObject(d1, 0, "a0",
                 new DeviceObjectPropertyReference(1, new ObjectIdentifier(ObjectType.device, 1),
-                        PropertyIdentifier.systemStatus), 60, 12);
+                        PropertyIdentifier.systemStatus), 60, 12));
     }
 
     @Test
     public void real() throws Exception {
         ObjectTestUtils.ObjectWriteNotifier<AveragingObject> notif = ObjectTestUtils.createObjectWriteNotifier(a);
 
-        final AnalogInputObject ai = new AnalogInputObject(d1, 0, "ai0", 0, EngineeringUnits.noUnits, false);
+        final AnalogInputObject ai = d1.addObject(new AnalogInputObject(
+                d1, 0, "ai0", 0, EngineeringUnits.noUnits, false));
 
         // Reference the present value of the analog input.
         a.writeProperty(null, PropertyIdentifier.objectPropertyReference,

--- a/src/test/java/com/serotonin/bacnet4j/obj/BACnetObjectListenerTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/BACnetObjectListenerTest.java
@@ -55,7 +55,7 @@ public class BACnetObjectListenerTest extends AbstractTest {
                 new CharacterString("Off"), //
                 new CharacterString("On"), //
                 new CharacterString("Auto"));
-        mv = new MultistateValueObject(d2, 0, "mv0", 3, stateText, 1, false);
+        mv = d2.addObject(new MultistateValueObject(d2, 0, "mv0", 3, stateText, 1, false));
         mv.supportCommandable(UnsignedInteger.ZERO);
     }
 

--- a/src/test/java/com/serotonin/bacnet4j/obj/BinaryInputObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/BinaryInputObjectTest.java
@@ -64,13 +64,14 @@ public class BinaryInputObjectTest extends AbstractTest {
 
     @Override
     public void afterInit() throws Exception {
-        bi = new BinaryInputObject(d1, 0, "bi", BinaryPV.inactive, false, Polarity.normal);
-        nc = new NotificationClassObject(d1, 17, "nc17", 100, 5, 200, new EventTransitionBits(false, false, false));
+        bi = d1.addObject(new BinaryInputObject(d1, 0, "bi", BinaryPV.inactive, false, Polarity.normal));
+        nc = d1.addObject(new NotificationClassObject(
+                d1, 17, "nc17", 100, 5, 200, new EventTransitionBits(false, false, false)));
     }
 
     @Test
     public void initialization() throws Exception {
-        new BinaryInputObject(d1, 1, "bi1", BinaryPV.inactive, true, Polarity.normal);
+        d1.addObject(new BinaryInputObject(d1, 1, "bi1", BinaryPV.inactive, true, Polarity.normal));
     }
 
     @SuppressWarnings("unchecked")
@@ -157,10 +158,11 @@ public class BinaryInputObjectTest extends AbstractTest {
     public void algorithmicReporting() throws Exception {
         final DeviceObjectPropertyReference ref =
                 new DeviceObjectPropertyReference(1, bi.getId(), PropertyIdentifier.presentValue);
-        final EventEnrollmentObject ee = new EventEnrollmentObject(d1, 0, "ee", ref, NotifyType.alarm,
+        final EventEnrollmentObject ee = d1.addObject(new EventEnrollmentObject(
+                d1, 0, "ee", ref, NotifyType.alarm,
                 new EventParameter(new ChangeOfState(new UnsignedInteger(30),
                         new SequenceOf<>(new PropertyStates(BinaryPV.active)))),
-                new EventTransitionBits(true, true, true), 17, 1000, null, null);
+                new EventTransitionBits(true, true, true), 17, 1000, null, null));
 
         // Set up the notification destination
         final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);

--- a/src/test/java/com/serotonin/bacnet4j/obj/BinaryOutputObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/BinaryOutputObjectTest.java
@@ -75,15 +75,18 @@ public class BinaryOutputObjectTest extends AbstractTest {
 
     @Override
     public void afterInit() throws Exception {
-        obj = new BinaryOutputObject(d1, 0, "boName1", BinaryPV.inactive, false, Polarity.normal, BinaryPV.inactive);
+        obj = d1.addObject(new BinaryOutputObject(
+                d1, 0, "boName1", BinaryPV.inactive, false, Polarity.normal, BinaryPV.inactive));
         obj.addListener((pid, oldValue, newValue) -> LOG.debug("{} changed from {} to {}", pid, oldValue, newValue));
 
-        nc = new NotificationClassObject(d1, 17, "nc17", 100, 5, 200, new EventTransitionBits(false, false, false));
+        nc = d1.addObject(new NotificationClassObject(
+                d1, 17, "nc17", 100, 5, 200, new EventTransitionBits(false, false, false)));
     }
 
     @Test
     public void initialization() throws Exception {
-        new BinaryOutputObject(d1, 1, "boName2", BinaryPV.inactive, true, Polarity.normal, BinaryPV.inactive);
+        d1.addObject(new BinaryOutputObject(
+                d1, 1, "boName2", BinaryPV.inactive, true, Polarity.normal, BinaryPV.inactive));
     }
 
     @Test
@@ -265,10 +268,11 @@ public class BinaryOutputObjectTest extends AbstractTest {
     public void algorithmicReporting() throws Exception {
         final DeviceObjectPropertyReference ref =
                 new DeviceObjectPropertyReference(1, obj.getId(), PropertyIdentifier.presentValue);
-        final EventEnrollmentObject ee = new EventEnrollmentObject(d1, 0, "ee", ref, NotifyType.alarm,
+        final EventEnrollmentObject ee = d1.addObject(new EventEnrollmentObject(
+                d1, 0, "ee", ref, NotifyType.alarm,
                 new EventParameter(new CommandFailure(new UnsignedInteger(30),
                         new DeviceObjectPropertyReference(1, obj.getId(), PropertyIdentifier.feedbackValue))),
-                new EventTransitionBits(true, true, true), 17, 1000, null, null);
+                new EventTransitionBits(true, true, true), 17, 1000, null, null));
 
         // Set up the notification destination
         final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);

--- a/src/test/java/com/serotonin/bacnet4j/obj/BinaryValueObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/BinaryValueObjectTest.java
@@ -69,13 +69,14 @@ public class BinaryValueObjectTest extends AbstractTest {
 
     @Override
     public void afterInit() throws Exception {
-        bv = new BinaryValueObject(d1, 0, "bv", BinaryPV.inactive, true);
-        new NotificationClassObject(d1, 17, "nc17", 100, 5, 200, new EventTransitionBits(false, false, false));
+        bv = d1.addObject(new BinaryValueObject(d1, 0, "bv", BinaryPV.inactive, true));
+        d1.addObject(new NotificationClassObject(
+                d1, 17, "nc17", 100, 5, 200, new EventTransitionBits(false, false, false)));
     }
 
     @Test
     public void initialization() throws Exception {
-        new BinaryValueObject(d1, 1, "bvName2", BinaryPV.inactive, false);
+        d1.addObject(new BinaryValueObject(d1, 1, "bvName2", BinaryPV.inactive, false));
     }
 
     @Test

--- a/src/test/java/com/serotonin/bacnet4j/obj/CalendarObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/CalendarObjectTest.java
@@ -60,7 +60,7 @@ public class CalendarObjectTest extends AbstractTest {
                 // November to February
                 ce);
 
-        final CalendarObject co = new CalendarObject(d1, 0, "cal0", dateList);
+        final CalendarObject co = d1.addObject(new CalendarObject(d1, 0, "cal0", dateList));
 
         co.updatePresentValue(); // November to February
         assertEquals(Boolean.TRUE, co.get(PropertyIdentifier.presentValue));

--- a/src/test/java/com/serotonin/bacnet4j/obj/ChangeOfValueTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/ChangeOfValueTest.java
@@ -82,7 +82,8 @@ public class ChangeOfValueTest extends AbstractTest {
             assertEquals(ErrorCode.unknownObject, e.getError().getErrorCode());
         }
 
-        final AnalogValueObject av = new AnalogValueObject(d1, 0, "av0", 10, EngineeringUnits.amperes, false);
+        final AnalogValueObject av = d1.addObject(new AnalogValueObject(
+                d1, 0, "av0", 10, EngineeringUnits.amperes, false));
 
         try {
             d2.send(rd1, new SubscribeCOVRequest(new UnsignedInteger(4), av.getId(), Boolean.TRUE,
@@ -112,7 +113,8 @@ public class ChangeOfValueTest extends AbstractTest {
             assertEquals(ErrorCode.unknownObject, e.getError().getErrorCode());
         }
 
-        final AnalogValueObject av = new AnalogValueObject(d1, 0, "av0", 10, EngineeringUnits.amperes, false);
+        final AnalogValueObject av = d1.addObject(new AnalogValueObject(
+                d1, 0, "av0", 10, EngineeringUnits.amperes, false));
 
         try {
             d2.send(rd1, new SubscribeCOVPropertyRequest(new UnsignedInteger(4),
@@ -134,7 +136,8 @@ public class ChangeOfValueTest extends AbstractTest {
 
     @Test
     public void objectCov() throws Exception {
-        final AnalogValueObject av = new AnalogValueObject(d1, 0, "av0", 10, EngineeringUnits.amperes, false);
+        final AnalogValueObject av = d1.addObject(new AnalogValueObject(
+                d1, 0, "av0", 10, EngineeringUnits.amperes, false));
         av.supportCovReporting(4);
 
         final CovNotifListener listener = new CovNotifListener();
@@ -219,7 +222,8 @@ public class ChangeOfValueTest extends AbstractTest {
 
     @Test
     public void unsubscribe() throws Exception {
-        final AnalogValueObject av = new AnalogValueObject(d1, 0, "av0", 10, EngineeringUnits.amperes, false);
+        final AnalogValueObject av = d1.addObject(new AnalogValueObject(
+                d1, 0, "av0", 10, EngineeringUnits.amperes, false));
         av.supportCovReporting(4);
 
         final CovNotifListener listener = new CovNotifListener();
@@ -251,7 +255,8 @@ public class ChangeOfValueTest extends AbstractTest {
 
     @Test
     public void propertyCov() throws Exception {
-        final AnalogValueObject av = new AnalogValueObject(d1, 0, "av0", 10, EngineeringUnits.amperes, false);
+        final AnalogValueObject av = d1.addObject(new AnalogValueObject(
+                d1, 0, "av0", 10, EngineeringUnits.amperes, false));
         av.supportCovReporting(4);
 
         final CovNotifListener listener = new CovNotifListener();
@@ -317,10 +322,10 @@ public class ChangeOfValueTest extends AbstractTest {
     @SuppressWarnings("unchecked")
     @Test
     public void multipleClients() throws Exception {
-        final AnalogValueObject av0 = new AnalogValueObject(d1, 0, "av0", 10, EngineeringUnits.amperes, false) //
-                .supportCovReporting(0);
-        final AnalogValueObject av1 = new AnalogValueObject(d1, 1, "av1", 10, EngineeringUnits.amperes, true) //
-                .supportCovReporting(0);
+        final AnalogValueObject av0 = d1.addObject(new AnalogValueObject(
+                d1, 0, "av0", 10, EngineeringUnits.amperes, false).supportCovReporting(0));
+        final AnalogValueObject av1 = d1.addObject(new AnalogValueObject(
+                d1, 1, "av1", 10, EngineeringUnits.amperes, true).supportCovReporting(0));
 
         final CovNotifListener listener2 = new CovNotifListener();
         d2.getEventHandler().addListener(listener2);
@@ -513,8 +518,8 @@ public class ChangeOfValueTest extends AbstractTest {
 
     @Test
     public void nonStandardProperties() throws Exception {
-        final AnalogValueObject av =
-                new AnalogValueObject(d1, 0, "av0", 10, EngineeringUnits.amperes, false).supportCovReporting(4);
+        final AnalogValueObject av = d1.addObject(new AnalogValueObject(
+                d1, 0, "av0", 10, EngineeringUnits.amperes, false).supportCovReporting(4));
 
         final CovNotifListener listener = new CovNotifListener();
         d2.getEventHandler().addListener(listener);
@@ -543,10 +548,10 @@ public class ChangeOfValueTest extends AbstractTest {
 
     @Test
     public void valueSourceCommandable() throws Exception {
-        final AnalogValueObject av =
-                new AnalogValueObject(d1, 0, "av0", 10, EngineeringUnits.amperes, false).supportCommandable(0) //
-                        .supportValueSource() //
-                        .supportCovReporting(4);
+        final AnalogValueObject av = d1.addObject(new AnalogValueObject(
+                d1, 0, "av0", 10, EngineeringUnits.amperes, false).supportCommandable(0) //
+                .supportValueSource() //
+                .supportCovReporting(4));
 
         final CovNotifListener listener = new CovNotifListener();
         d2.getEventHandler().addListener(listener);

--- a/src/test/java/com/serotonin/bacnet4j/obj/DeviceObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/DeviceObjectTest.java
@@ -86,13 +86,13 @@ public class DeviceObjectTest extends AbstractTest {
 
     @Override
     public void afterInit() throws Exception {
-        av0 = new AnalogValueObject(d1, 0, "av0", 50, EngineeringUnits.amperes, false);
-        new AnalogValueObject(d1, 1, "av1", 50, EngineeringUnits.amperes, false);
-        new AnalogValueObject(d1, 2, "av2", 50, EngineeringUnits.amperes, false);
-        new BinaryValueObject(d1, 0, "bv0", BinaryPV.inactive, false);
-        new BinaryValueObject(d1, 1, "bv1", BinaryPV.inactive, false);
-        new BinaryValueObject(d1, 2, "bv2", BinaryPV.inactive, false);
-        new BinaryValueObject(d1, 3, "bv3", BinaryPV.inactive, false);
+        av0 = d1.addObject(new AnalogValueObject(d1, 0, "av0", 50, EngineeringUnits.amperes, false));
+        d1.addObject(new AnalogValueObject(d1, 1, "av1", 50, EngineeringUnits.amperes, false));
+        d1.addObject(new AnalogValueObject(d1, 2, "av2", 50, EngineeringUnits.amperes, false));
+        d1.addObject(new BinaryValueObject(d1, 0, "bv0", BinaryPV.inactive, false));
+        d1.addObject(new BinaryValueObject(d1, 1, "bv1", BinaryPV.inactive, false));
+        d1.addObject(new BinaryValueObject(d1, 2, "bv2", BinaryPV.inactive, false));
+        d1.addObject(new BinaryValueObject(d1, 3, "bv3", BinaryPV.inactive, false));
     }
 
     @Test
@@ -241,8 +241,8 @@ public class DeviceObjectTest extends AbstractTest {
     @Test
     public void intrinsicAlarms() throws Exception {
         final DeviceObject dev = d1.getDeviceObject();
-        final NotificationClassObject nc =
-                new NotificationClassObject(d1, 7, "nc7", 100, 5, 200, new EventTransitionBits(false, false, false));
+        final NotificationClassObject nc = d1.addObject(new NotificationClassObject(
+                d1, 7, "nc7", 100, 5, 200, new EventTransitionBits(false, false, false)));
         final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
         recipients.add(new Destination(new Recipient(rd2.getAddress()), new UnsignedInteger(10), Boolean.FALSE,
                 new EventTransitionBits(true, true, true)));

--- a/src/test/java/com/serotonin/bacnet4j/obj/EventEnrollmentObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/EventEnrollmentObjectTest.java
@@ -78,13 +78,14 @@ public class EventEnrollmentObjectTest extends AbstractTest {
 
     @Override
     public void afterInit() throws Exception {
-        av0 = new AnalogValueObject(d3, 0, "av0", 0, EngineeringUnits.noUnits, false);
+        av0 = d3.addObject(new AnalogValueObject(d3, 0, "av0", 0, EngineeringUnits.noUnits, false));
         av0.writePropertyInternal(PropertyIdentifier.reliability, Reliability.noFaultDetected);
 
-        av1 = new AnalogValueObject(d3, 1, "av1", 0, EngineeringUnits.noUnits, false);
+        av1 = d3.addObject(new AnalogValueObject(d3, 1, "av1", 0, EngineeringUnits.noUnits, false));
         av1.writePropertyInternal(PropertyIdentifier.minPresValue, new Real(50));
 
-        nc = new NotificationClassObject(d1, 5, "nc5", 100, 5, 200, new EventTransitionBits(false, false, false));
+        nc = d1.addObject(new NotificationClassObject(
+                d1, 5, "nc5", 100, 5, 200, new EventTransitionBits(false, false, false)));
     }
 
     @SuppressWarnings("unchecked")
@@ -97,9 +98,10 @@ public class EventEnrollmentObjectTest extends AbstractTest {
                 new PropertyStates(Reliability.activationFailure), //
                 new PropertyStates(Reliability.communicationFailure), //
                 new PropertyStates(Reliability.configurationError));
-        final EventEnrollmentObject ee = new EventEnrollmentObject(d1, 0, "ee0", ref, NotifyType.event,
+        final EventEnrollmentObject ee = d1.addObject(new EventEnrollmentObject(
+                d1, 0, "ee0", ref, NotifyType.event,
                 new EventParameter(new ChangeOfState(new UnsignedInteger(1), alarmValues)),
-                new EventTransitionBits(true, true, true), 5, 100, null, null);
+                new EventTransitionBits(true, true, true), 5, 100, null, null));
 
         final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
         recipients.add(new Destination(new Recipient(rd2.getAddress()), new UnsignedInteger(10), Boolean.TRUE,
@@ -259,10 +261,11 @@ public class EventEnrollmentObjectTest extends AbstractTest {
         final DeviceObjectPropertyReference ref =
                 new DeviceObjectPropertyReference(new ObjectIdentifier(ObjectType.analogValue, 1),
                         PropertyIdentifier.minPresValue, null, new ObjectIdentifier(ObjectType.device, 3));
-        final EventEnrollmentObject ee = new EventEnrollmentObject(d1, 0, "ee0", ref, NotifyType.alarm,
+        final EventEnrollmentObject ee = d1.addObject(new EventEnrollmentObject(
+                d1, 0, "ee0", ref, NotifyType.alarm,
                 new EventParameter(new OutOfRange(new UnsignedInteger(1), new Real(30), new Real(70), new Real(0))),
                 new EventTransitionBits(true, true, true), 5, 100, null, new FaultParameter(
-                new FaultOutOfRange(new FaultNormalValue(new Real(10)), new FaultNormalValue(new Real(90)))));
+                new FaultOutOfRange(new FaultNormalValue(new Real(10)), new FaultNormalValue(new Real(90))))));
 
         final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
         recipients.add(new Destination(new Recipient(rd2.getAddress()), new UnsignedInteger(10), Boolean.TRUE,
@@ -387,10 +390,10 @@ public class EventEnrollmentObjectTest extends AbstractTest {
         final DeviceObjectPropertyReference ref =
                 new DeviceObjectPropertyReference(new ObjectIdentifier(ObjectType.analogValue, 1),
                         PropertyIdentifier.minPresValue, null, new ObjectIdentifier(ObjectType.device, 3));
-        final EventEnrollmentObject ee = new EventEnrollmentObject(d1, 0, "ee0", ref, NotifyType.alarm,
+        final EventEnrollmentObject ee = d1.addObject(new EventEnrollmentObject(d1, 0, "ee0", ref, NotifyType.alarm,
                 new EventParameter(new OutOfRange(new UnsignedInteger(1), new Real(30), new Real(70), new Real(0))),
                 new EventTransitionBits(true, true, true), 5, 100, null, new FaultParameter(
-                new FaultOutOfRange(new FaultNormalValue(new Real(10)), new FaultNormalValue(new Real(90)))));
+                new FaultOutOfRange(new FaultNormalValue(new Real(10)), new FaultNormalValue(new Real(90))))));
 
         final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
         recipients.add(new Destination(new Recipient(rd2.getAddress()), new UnsignedInteger(10), Boolean.TRUE,
@@ -434,10 +437,11 @@ public class EventEnrollmentObjectTest extends AbstractTest {
         final DeviceObjectPropertyReference ref =
                 new DeviceObjectPropertyReference(new ObjectIdentifier(ObjectType.analogValue, 1),
                         PropertyIdentifier.minPresValue, null, new ObjectIdentifier(ObjectType.device, 3));
-        final EventEnrollmentObject ee = new EventEnrollmentObject(d1, 0, "ee0", ref, NotifyType.alarm,
+        final EventEnrollmentObject ee = d1.addObject(new EventEnrollmentObject(
+                d1, 0, "ee0", ref, NotifyType.alarm,
                 new EventParameter(new OutOfRange(new UnsignedInteger(1), new Real(30), new Real(70), new Real(0))),
                 new EventTransitionBits(true, true, true), 5, 100, null, new FaultParameter(
-                new FaultOutOfRange(new FaultNormalValue(new Real(10)), new FaultNormalValue(new Real(90)))));
+                new FaultOutOfRange(new FaultNormalValue(new Real(10)), new FaultNormalValue(new Real(90))))));
 
         // Change the event parameters of the enrollment.
         var response = d2.send(rd1, new WritePropertyRequest(ee.getId(), PropertyIdentifier.eventParameters, null,

--- a/src/test/java/com/serotonin/bacnet4j/obj/EventLogObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/EventLogObjectTest.java
@@ -99,14 +99,14 @@ public class EventLogObjectTest extends AbstractTest {
 
     @Override
     public void afterInit() throws Exception {
-        nc = new NotificationClassObject(d1, 23, "nc", 1, 2, 3, new EventTransitionBits(true, true, true));
+        nc = d1.addObject(new NotificationClassObject(
+                d1, 23, "nc", 1, 2, 3, new EventTransitionBits(true, true, true)));
     }
 
     @Test
     public void logging() throws Exception {
-        final EventLogObject el =
-                new EventLogObject(d1, 0, "el", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
-                        DateTime.UNSPECIFIED, false, 20);
+        final EventLogObject el = d1.addObject(new EventLogObject(
+                d1, 0, "el", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED, DateTime.UNSPECIFIED, false, 20));
 
         // The buffer should still be empty
         assertEquals(0, el.getBuffer().size());
@@ -142,10 +142,10 @@ public class EventLogObjectTest extends AbstractTest {
     @Test
     public void intrinsicReporting() throws Exception {
         // Create a triggered trend log with intrinsic reporting enabled.
-        final EventLogObject el =
-                new EventLogObject(d1, 0, "el", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
-                        DateTime.UNSPECIFIED, false, 20) //
-                        .supportIntrinsicReporting(5, 23, new EventTransitionBits(true, true, true), NotifyType.event);
+        final EventLogObject el = d1.addObject(new EventLogObject(
+                d1, 0, "el", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
+                DateTime.UNSPECIFIED, false, 20)
+                .supportIntrinsicReporting(5, 23, new EventTransitionBits(true, true, true), NotifyType.event));
 
         // Add d2 as an event recipient.
         final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
@@ -271,16 +271,17 @@ public class EventLogObjectTest extends AbstractTest {
     @Test
     public void eventReporting() throws Exception {
         // Create a triggered trend log
-        final EventLogObject el =
-                new EventLogObject(d1, 0, "el", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
-                        DateTime.UNSPECIFIED, false, 20);
+        final EventLogObject el = d1.addObject(new EventLogObject(
+                d1, 0, "el", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
+                DateTime.UNSPECIFIED, false, 20));
 
         // Create the event enrollment.
         final DeviceObjectPropertyReference ref =
                 new DeviceObjectPropertyReference(el.getId(), PropertyIdentifier.totalRecordCount, null, d1.getId());
-        final EventEnrollmentObject ee = new EventEnrollmentObject(d1, 0, "ee", ref, NotifyType.event,
+        final EventEnrollmentObject ee = d1.addObject(new EventEnrollmentObject(
+                d1, 0, "ee", ref, NotifyType.event,
                 new EventParameter(new BufferReady(new UnsignedInteger(3), UnsignedInteger.ZERO)),
-                new EventTransitionBits(true, true, true), 23, 1000, null, null);
+                new EventTransitionBits(true, true, true), 23, 1000, null, null));
 
         // Set d2 as an event recipient.
         final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
@@ -356,9 +357,9 @@ public class EventLogObjectTest extends AbstractTest {
     @Test
     public void stopWhenFull() throws Exception {
         // Create a triggered trend log
-        final EventLogObject el =
-                new EventLogObject(d1, 0, "el", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
-                        DateTime.UNSPECIFIED, true, 4);
+        final EventLogObject el = d1.addObject(new EventLogObject(
+                d1, 0, "el", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
+                DateTime.UNSPECIFIED, true, 4));
 
         // Add a couple records and validate the buffer content
         d2.send(rd1, n1).get();
@@ -422,9 +423,9 @@ public class EventLogObjectTest extends AbstractTest {
     @Test
     public void enableDisable() throws Exception {
         // Create a disabled triggered trend log
-        final EventLogObject el =
-                new EventLogObject(d1, 0, "el", new LinkedListLogBuffer<>(), false, DateTime.UNSPECIFIED,
-                        DateTime.UNSPECIFIED, true, 4);
+        final EventLogObject el = d1.addObject(new EventLogObject(
+                d1, 0, "el", new LinkedListLogBuffer<>(), false, DateTime.UNSPECIFIED,
+                DateTime.UNSPECIFIED, true, 4));
         assertEquals(0, el.getBuffer().size());
 
         // Add a couple records and validate the buffer content
@@ -454,8 +455,8 @@ public class EventLogObjectTest extends AbstractTest {
         DateTime stopTime = new DateTime(nowgg);
 
         // Create a triggered trend log
-        final EventLogObject el =
-                new EventLogObject(d1, 0, "el", new LinkedListLogBuffer<>(), true, startTime, stopTime, true, 7);
+        final EventLogObject el = d1.addObject(new EventLogObject(
+                d1, 0, "el", new LinkedListLogBuffer<>(), true, startTime, stopTime, true, 7));
         assertTrue(el.isLogDisabled());
         assertEquals(0, el.getBuffer().size());
 
@@ -522,9 +523,9 @@ public class EventLogObjectTest extends AbstractTest {
     @Test
     public void readLogBuffer() throws Exception {
         // Create a triggered trend log
-        final EventLogObject el =
-                new EventLogObject(d1, 0, "el", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
-                        DateTime.UNSPECIFIED, true, 7);
+        final EventLogObject el = d1.addObject(new EventLogObject(
+                d1, 0, "el", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
+                DateTime.UNSPECIFIED, true, 7));
 
         // Try to do a network read of the buffer. It should not be readable.
         assertBACnetServiceException(() -> el.readProperty(PropertyIdentifier.logBuffer, null), ErrorClass.property,
@@ -534,9 +535,9 @@ public class EventLogObjectTest extends AbstractTest {
     @Test
     public void purge() throws Exception {
         // Create a triggered trend log
-        final EventLogObject el =
-                new EventLogObject(d1, 0, "el", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
-                        DateTime.UNSPECIFIED, true, 7);
+        final EventLogObject el = d1.addObject(new EventLogObject(
+                d1, 0, "el", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
+                DateTime.UNSPECIFIED, true, 7));
 
         // Trigger a few updates.
         d2.send(rd1, n2).get();

--- a/src/test/java/com/serotonin/bacnet4j/obj/FileObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/FileObjectTest.java
@@ -53,13 +53,13 @@ public class FileObjectTest extends AbstractTest {
 
     @Test
     public void streamReadFileSize() throws Exception {
-        final FileObject f = new FileObject(d1, 0, "test", new StreamAccess(new File(path)));
+        final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new StreamAccess(new File(path))));
         assertEquals(new UnsignedInteger(922), f.readProperty(PropertyIdentifier.fileSize, null));
     }
 
     @Test
     public void recordReadFileSize() throws Exception {
-        final FileObject f = new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(new File(path)));
+        final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(new File(path))));
         assertEquals(new UnsignedInteger(922), f.readProperty(PropertyIdentifier.fileSize, null));
     }
 
@@ -67,7 +67,7 @@ public class FileObjectTest extends AbstractTest {
     public void streamWriteFileSize() throws Exception {
         // Write a zero file size.
         doInCopy((file) -> {
-            final FileObject f = new FileObject(d1, 0, "test", new StreamAccess(file));
+            final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new StreamAccess(file)));
             f.writeProperty(null, PropertyIdentifier.fileSize, UnsignedInteger.ZERO);
             assertEquals(UnsignedInteger.ZERO, f.readProperty(PropertyIdentifier.fileSize, null));
             d1.removeObject(f.getId());
@@ -75,7 +75,7 @@ public class FileObjectTest extends AbstractTest {
 
         // Write > 0 and < file size.
         doInCopy((file) -> {
-            final FileObject f = new FileObject(d1, 0, "test", new StreamAccess(file));
+            final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new StreamAccess(file)));
             f.writeProperty(null, PropertyIdentifier.fileSize, new UnsignedInteger(100));
             assertEquals(new UnsignedInteger(100), f.readProperty(PropertyIdentifier.fileSize, null));
             d1.removeObject(f.getId());
@@ -83,7 +83,7 @@ public class FileObjectTest extends AbstractTest {
 
         // Write a file size == size
         doInCopy((file) -> {
-            final FileObject f = new FileObject(d1, 0, "test", new StreamAccess(file));
+            final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new StreamAccess(file)));
             f.writeProperty(null, PropertyIdentifier.fileSize, new UnsignedInteger(922));
             assertEquals(new UnsignedInteger(922), f.readProperty(PropertyIdentifier.fileSize, null));
             d1.removeObject(f.getId());
@@ -91,7 +91,7 @@ public class FileObjectTest extends AbstractTest {
 
         // Write a file size > size
         doInCopy((file) -> {
-            final FileObject f = new FileObject(d1, 0, "test", new StreamAccess(file));
+            final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new StreamAccess(file)));
             f.writeProperty(null, PropertyIdentifier.fileSize, new UnsignedInteger(1001));
             assertEquals(new UnsignedInteger(1001), f.readProperty(PropertyIdentifier.fileSize, null));
             d1.removeObject(f.getId());
@@ -102,7 +102,7 @@ public class FileObjectTest extends AbstractTest {
     public void recordWriteFileSize() throws Exception {
         // Write a zero record count.
         doInCopy((file) -> {
-            final FileObject f = new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(file));
+            final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(file)));
             f.writeProperty(null, PropertyIdentifier.fileSize, UnsignedInteger.ZERO);
             assertEquals(UnsignedInteger.ZERO, f.readProperty(PropertyIdentifier.recordCount, null));
             assertEquals(UnsignedInteger.ZERO, f.readProperty(PropertyIdentifier.fileSize, null));
@@ -111,7 +111,7 @@ public class FileObjectTest extends AbstractTest {
 
         // Write > 0 and < size record count.
         doInCopy((file) -> {
-            final FileObject f = new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(file));
+            final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(file)));
             f.writeProperty(null, PropertyIdentifier.fileSize, new UnsignedInteger(100));
             assertEquals(new UnsignedInteger(2), f.readProperty(PropertyIdentifier.recordCount, null));
             assertEquals(new UnsignedInteger(100), f.readProperty(PropertyIdentifier.fileSize, null));
@@ -120,7 +120,7 @@ public class FileObjectTest extends AbstractTest {
 
         // Write > 0 and < size record count.
         doInCopy((file) -> {
-            final FileObject f = new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(file));
+            final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(file)));
             //Since Newlines are CRLF on windows and CR on OSX and LF on Unix
             if (SystemUtils.IS_OS_WINDOWS)
                 f.writeProperty(null, PropertyIdentifier.fileSize, new UnsignedInteger(921));
@@ -136,7 +136,7 @@ public class FileObjectTest extends AbstractTest {
 
         // Write a record count == size
         doInCopy((file) -> {
-            final FileObject f = new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(file));
+            final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(file)));
             if (SystemUtils.IS_OS_WINDOWS)
                 f.writeProperty(null, PropertyIdentifier.fileSize, new UnsignedInteger(922));
             else
@@ -151,7 +151,7 @@ public class FileObjectTest extends AbstractTest {
 
         // Write a record count > size
         doInCopy((file) -> {
-            final FileObject f = new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(file));
+            final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(file)));
             if (SystemUtils.IS_OS_WINDOWS)
                 f.writeProperty(null, PropertyIdentifier.fileSize, new UnsignedInteger(1001));
             else
@@ -173,7 +173,7 @@ public class FileObjectTest extends AbstractTest {
         assumeFalse(TestUtils.isDockerEnv());
 
         final File file = new File(path);
-        final FileObject f = new FileObject(d1, 0, "test", new StreamAccess(file));
+        final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new StreamAccess(file)));
 
         if (file.setWritable(true)) {
             assertEquals(Boolean.FALSE, f.readProperty(PropertyIdentifier.readOnly, null));
@@ -187,7 +187,7 @@ public class FileObjectTest extends AbstractTest {
 
     @Test
     public void streamReadRecordCount() throws Exception {
-        final FileObject f = new FileObject(d1, 0, "test", new StreamAccess(new File(path)));
+        final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new StreamAccess(new File(path))));
         TestUtils.assertBACnetServiceException(() -> {
             f.readProperty(PropertyIdentifier.recordCount, null);
         }, ErrorClass.property, ErrorCode.readAccessDenied);
@@ -195,13 +195,13 @@ public class FileObjectTest extends AbstractTest {
 
     @Test
     public void recordReadRecordCount() throws Exception {
-        final FileObject f = new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(new File(path)));
+        final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(new File(path))));
         assertEquals(new UnsignedInteger(14), f.readProperty(PropertyIdentifier.recordCount, null));
     }
 
     @Test
     public void streamWriteRecordCount() throws Exception {
-        final FileObject f = new FileObject(d1, 0, "test", new StreamAccess(new File(path)));
+        final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new StreamAccess(new File(path))));
         TestUtils.assertBACnetServiceException(() -> {
             f.writeProperty(null, new PropertyValue(PropertyIdentifier.recordCount, UnsignedInteger.ZERO));
         }, ErrorClass.property, ErrorCode.writeAccessDenied);
@@ -211,7 +211,7 @@ public class FileObjectTest extends AbstractTest {
     public void recordWriteRecordCount() throws Exception {
         // Write a zero record count.
         doInCopy((file) -> {
-            final FileObject f = new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(file));
+            final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(file)));
             f.writeProperty(null, PropertyIdentifier.recordCount, UnsignedInteger.ZERO);
             assertEquals(UnsignedInteger.ZERO, f.readProperty(PropertyIdentifier.recordCount, null));
             assertEquals(UnsignedInteger.ZERO, f.readProperty(PropertyIdentifier.fileSize, null));
@@ -220,7 +220,7 @@ public class FileObjectTest extends AbstractTest {
 
         // Write > 0 and < size record count.
         doInCopy((file) -> {
-            final FileObject f = new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(file));
+            final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(file)));
             f.writeProperty(null, PropertyIdentifier.recordCount, new UnsignedInteger(10));
             assertEquals(new UnsignedInteger(10), f.readProperty(PropertyIdentifier.recordCount, null));
             //Since Newlines are CRLF on windows and CR on OSX and LF on Unix
@@ -233,7 +233,7 @@ public class FileObjectTest extends AbstractTest {
 
         // Write a record count == size
         doInCopy((file) -> {
-            final FileObject f = new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(file));
+            final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(file)));
             f.writeProperty(null, PropertyIdentifier.recordCount, new UnsignedInteger(14));
             assertEquals(new UnsignedInteger(14), f.readProperty(PropertyIdentifier.recordCount, null));
             //Since Newlines are CRLF on windows and CR on OSX and LF on Unix
@@ -246,7 +246,7 @@ public class FileObjectTest extends AbstractTest {
 
         // Write a record count > size
         doInCopy((file) -> {
-            final FileObject f = new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(file));
+            final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(file)));
             f.writeProperty(null, PropertyIdentifier.recordCount, new UnsignedInteger(25));
             assertEquals(new UnsignedInteger(25), f.readProperty(PropertyIdentifier.recordCount, null));
             //Since Newlines are CRLF on windows and CR on OSX and LF on Unix

--- a/src/test/java/com/serotonin/bacnet4j/obj/FileObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/FileObjectTest.java
@@ -66,7 +66,7 @@ public class FileObjectTest extends AbstractTest {
     @Test
     public void streamWriteFileSize() throws Exception {
         // Write a zero file size.
-        doInCopy((file) -> {
+        doInCopy(file -> {
             final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new StreamAccess(file)));
             f.writeProperty(null, PropertyIdentifier.fileSize, UnsignedInteger.ZERO);
             assertEquals(UnsignedInteger.ZERO, f.readProperty(PropertyIdentifier.fileSize, null));
@@ -74,7 +74,7 @@ public class FileObjectTest extends AbstractTest {
         });
 
         // Write > 0 and < file size.
-        doInCopy((file) -> {
+        doInCopy(file -> {
             final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new StreamAccess(file)));
             f.writeProperty(null, PropertyIdentifier.fileSize, new UnsignedInteger(100));
             assertEquals(new UnsignedInteger(100), f.readProperty(PropertyIdentifier.fileSize, null));
@@ -82,7 +82,7 @@ public class FileObjectTest extends AbstractTest {
         });
 
         // Write a file size == size
-        doInCopy((file) -> {
+        doInCopy(file -> {
             final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new StreamAccess(file)));
             f.writeProperty(null, PropertyIdentifier.fileSize, new UnsignedInteger(922));
             assertEquals(new UnsignedInteger(922), f.readProperty(PropertyIdentifier.fileSize, null));
@@ -90,7 +90,7 @@ public class FileObjectTest extends AbstractTest {
         });
 
         // Write a file size > size
-        doInCopy((file) -> {
+        doInCopy(file -> {
             final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new StreamAccess(file)));
             f.writeProperty(null, PropertyIdentifier.fileSize, new UnsignedInteger(1001));
             assertEquals(new UnsignedInteger(1001), f.readProperty(PropertyIdentifier.fileSize, null));
@@ -101,7 +101,7 @@ public class FileObjectTest extends AbstractTest {
     @Test
     public void recordWriteFileSize() throws Exception {
         // Write a zero record count.
-        doInCopy((file) -> {
+        doInCopy(file -> {
             final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(file)));
             f.writeProperty(null, PropertyIdentifier.fileSize, UnsignedInteger.ZERO);
             assertEquals(UnsignedInteger.ZERO, f.readProperty(PropertyIdentifier.recordCount, null));
@@ -110,7 +110,7 @@ public class FileObjectTest extends AbstractTest {
         });
 
         // Write > 0 and < size record count.
-        doInCopy((file) -> {
+        doInCopy(file -> {
             final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(file)));
             f.writeProperty(null, PropertyIdentifier.fileSize, new UnsignedInteger(100));
             assertEquals(new UnsignedInteger(2), f.readProperty(PropertyIdentifier.recordCount, null));
@@ -119,7 +119,7 @@ public class FileObjectTest extends AbstractTest {
         });
 
         // Write > 0 and < size record count.
-        doInCopy((file) -> {
+        doInCopy(file -> {
             final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(file)));
             //Since Newlines are CRLF on windows and CR on OSX and LF on Unix
             if (SystemUtils.IS_OS_WINDOWS)
@@ -135,7 +135,7 @@ public class FileObjectTest extends AbstractTest {
         });
 
         // Write a record count == size
-        doInCopy((file) -> {
+        doInCopy(file -> {
             final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(file)));
             if (SystemUtils.IS_OS_WINDOWS)
                 f.writeProperty(null, PropertyIdentifier.fileSize, new UnsignedInteger(922));
@@ -150,7 +150,7 @@ public class FileObjectTest extends AbstractTest {
         });
 
         // Write a record count > size
-        doInCopy((file) -> {
+        doInCopy(file -> {
             final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(file)));
             if (SystemUtils.IS_OS_WINDOWS)
                 f.writeProperty(null, PropertyIdentifier.fileSize, new UnsignedInteger(1001));
@@ -210,7 +210,7 @@ public class FileObjectTest extends AbstractTest {
     @Test
     public void recordWriteRecordCount() throws Exception {
         // Write a zero record count.
-        doInCopy((file) -> {
+        doInCopy(file -> {
             final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(file)));
             f.writeProperty(null, PropertyIdentifier.recordCount, UnsignedInteger.ZERO);
             assertEquals(UnsignedInteger.ZERO, f.readProperty(PropertyIdentifier.recordCount, null));
@@ -219,7 +219,7 @@ public class FileObjectTest extends AbstractTest {
         });
 
         // Write > 0 and < size record count.
-        doInCopy((file) -> {
+        doInCopy(file -> {
             final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(file)));
             f.writeProperty(null, PropertyIdentifier.recordCount, new UnsignedInteger(10));
             assertEquals(new UnsignedInteger(10), f.readProperty(PropertyIdentifier.recordCount, null));
@@ -232,7 +232,7 @@ public class FileObjectTest extends AbstractTest {
         });
 
         // Write a record count == size
-        doInCopy((file) -> {
+        doInCopy(file -> {
             final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(file)));
             f.writeProperty(null, PropertyIdentifier.recordCount, new UnsignedInteger(14));
             assertEquals(new UnsignedInteger(14), f.readProperty(PropertyIdentifier.recordCount, null));
@@ -245,7 +245,7 @@ public class FileObjectTest extends AbstractTest {
         });
 
         // Write a record count > size
-        doInCopy((file) -> {
+        doInCopy(file -> {
             final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(file)));
             f.writeProperty(null, PropertyIdentifier.recordCount, new UnsignedInteger(25));
             assertEquals(new UnsignedInteger(25), f.readProperty(PropertyIdentifier.recordCount, null));

--- a/src/test/java/com/serotonin/bacnet4j/obj/GroupObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/GroupObjectTest.java
@@ -54,7 +54,7 @@ import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 public class GroupObjectTest extends AbstractTest {
     @Test
     public void preventGroupReferences() throws Exception {
-        final GroupObject g = new GroupObject(d1, 0, "g", new SequenceOf<>());
+        final GroupObject g = d1.addObject(new GroupObject(d1, 0, "g", new SequenceOf<>()));
 
         // Make sure groups cannot be added.
         TestUtils.assertBACnetServiceException(() -> {
@@ -85,15 +85,16 @@ public class GroupObjectTest extends AbstractTest {
     @Test
     public void readPresentValue() throws Exception {
         // Create some objects to read.
-        final AnalogInputObject ai = new AnalogInputObject(d1, 0, "ai", 0, EngineeringUnits.noUnits, false);
-        final BinaryValueObject bv = new BinaryValueObject(d1, 0, "bv", BinaryPV.inactive, false);
-        final MultistateValueObject mv = new MultistateValueObject(d1, 0, "mv", 4,
+        final AnalogInputObject ai = d1.addObject(new AnalogInputObject(
+                d1, 0, "ai", 0, EngineeringUnits.noUnits, false));
+        final BinaryValueObject bv = d1.addObject(new BinaryValueObject(d1, 0, "bv", BinaryPV.inactive, false));
+        final MultistateValueObject mv = d1.addObject(new MultistateValueObject(d1, 0, "mv", 4,
                 new BACnetArray<>(new CharacterString("Off"), new CharacterString("On"), new CharacterString("Auto"),
                         new CharacterString("Optional")),
-                1, false);
+                1, false));
 
         // Create the group
-        final GroupObject g = new GroupObject(d1, 0, "g",
+        final GroupObject g = d1.addObject(new GroupObject(d1, 0, "g",
                 new SequenceOf<>( //
                         new ReadAccessSpecification(ai.getId(),
                                 new SequenceOf<>( //
@@ -112,7 +113,7 @@ public class GroupObjectTest extends AbstractTest {
                                         new PropertyReference(PropertyIdentifier.stateText, new UnsignedInteger(10)))),
                         //
                         new ReadAccessSpecification(new ObjectIdentifier(ObjectType.accumulator, 0),
-                                PropertyIdentifier.presentValue)));
+                                PropertyIdentifier.presentValue))));
 
         SequenceOf<ReadAccessResult> presentValue = (SequenceOf<ReadAccessResult>) g
                 .readProperty(PropertyIdentifier.presentValue, null);

--- a/src/test/java/com/serotonin/bacnet4j/obj/IntrinsicAlarmTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/IntrinsicAlarmTest.java
@@ -87,16 +87,17 @@ public class IntrinsicAlarmTest extends AbstractTest {
 
     @Override
     public void afterInit() throws Exception {
-        bv = new BinaryValueObject(d1, 0, "bvName1", BinaryPV.inactive, true);
+        bv = d1.addObject(new BinaryValueObject(d1, 0, "bvName1", BinaryPV.inactive, true));
         bv.writePropertyInternal(PropertyIdentifier.outOfService, Boolean.FALSE);
 
-        mv = new MultistateValueObject(d1, 0, "mvName1", 7, new BACnetArray<>(new CharacterString( //
+        mv = d1.addObject(new MultistateValueObject(d1, 0, "mvName1", 7, new BACnetArray<>(new CharacterString( //
                 "normal1"), new CharacterString("normal2"), new CharacterString("normal3"), //
                 new CharacterString("alarm1"), new CharacterString("alarm2"), //
-                new CharacterString("fault1"), new CharacterString("fault2")), 1, true);
+                new CharacterString("fault1"), new CharacterString("fault2")), 1, true));
         mv.writePropertyInternal(PropertyIdentifier.outOfService, Boolean.FALSE);
 
-        nc = new NotificationClassObject(d1, 7, "nc7", 100, 5, 200, new EventTransitionBits(true, true, true));
+        nc = d1.addObject(new NotificationClassObject(
+                d1, 7, "nc7", 100, 5, 200, new EventTransitionBits(true, true, true)));
     }
 
     @Test

--- a/src/test/java/com/serotonin/bacnet4j/obj/LifeSafetyPointObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/LifeSafetyPointObjectTest.java
@@ -74,10 +74,12 @@ public class LifeSafetyPointObjectTest extends AbstractTest {
 
     @Override
     public void afterInit() throws Exception {
-        lsp = new LifeSafetyPointObject(d1, 0, "lsp", LifeSafetyState.quiet, LifeSafetyMode.on, false,
+        lsp = d1.addObject(new LifeSafetyPointObject(
+                d1, 0, "lsp", LifeSafetyState.quiet, LifeSafetyMode.on, false,
                 new SequenceOf<>(LifeSafetyMode.on, LifeSafetyMode.off, LifeSafetyMode.enabled),
-                LifeSafetyOperation.none, SilencedState.unsilenced);
-        nc = new NotificationClassObject(d1, 17, "nc17", 100, 5, 200, new EventTransitionBits(false, false, false));
+                LifeSafetyOperation.none, SilencedState.unsilenced));
+        nc = d1.addObject(new NotificationClassObject(
+                d1, 17, "nc17", 100, 5, 200, new EventTransitionBits(false, false, false)));
 
         final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
         recipients.add(new Destination(new Recipient(rd2.getAddress()), new UnsignedInteger(10), Boolean.TRUE,
@@ -432,14 +434,15 @@ public class LifeSafetyPointObjectTest extends AbstractTest {
                 new DeviceObjectPropertyReference(1, lsp.getId(), PropertyIdentifier.presentValue);
         final DeviceObjectPropertyReference modeRef =
                 new DeviceObjectPropertyReference(1, lsp.getId(), PropertyIdentifier.mode);
-        final EventEnrollmentObject ee = new EventEnrollmentObject(d1, 0, "ee", pvRef, NotifyType.alarm,
+        final EventEnrollmentObject ee = d1.addObject(new EventEnrollmentObject(
+                d1, 0, "ee", pvRef, NotifyType.alarm,
                 new EventParameter(new ChangeOfLifeSafety(new UnsignedInteger(30),
                         new BACnetArray<>(LifeSafetyState.tamper, LifeSafetyState.testSupervisory), //
                         new BACnetArray<>(LifeSafetyState.testActive, LifeSafetyState.testAlarm), //
                         modeRef)), new EventTransitionBits(true, true, true), 17, 1000, new UnsignedInteger(50), //
                 new FaultParameter(
                         new FaultLifeSafety(new BACnetArray<>(LifeSafetyState.fault, LifeSafetyState.faultAlarm),
-                                modeRef)));
+                                modeRef))));
 
         // Ensure that initializing the event enrollment object didn't fire any notifications.
         awaitEquals(EventState.normal, () -> ee.readProperty(PropertyIdentifier.eventState));

--- a/src/test/java/com/serotonin/bacnet4j/obj/LifeSafetyZoneObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/LifeSafetyZoneObjectTest.java
@@ -81,10 +81,12 @@ public class LifeSafetyZoneObjectTest extends AbstractTest {
 
     @Override
     public void afterInit() throws Exception {
-        lsz = new LifeSafetyZoneObject(d1, 0, "lsz", LifeSafetyState.quiet, LifeSafetyMode.on, false,
+        lsz = d1.addObject(new LifeSafetyZoneObject(
+                d1, 0, "lsz", LifeSafetyState.quiet, LifeSafetyMode.on, false,
                 new SequenceOf<>(LifeSafetyMode.on, LifeSafetyMode.off, LifeSafetyMode.enabled),
-                LifeSafetyOperation.none, SilencedState.unsilenced, new SequenceOf<>());
-        nc = new NotificationClassObject(d1, 17, "nc17", 100, 5, 200, new EventTransitionBits(false, false, false));
+                LifeSafetyOperation.none, SilencedState.unsilenced, new SequenceOf<>()));
+        nc = d1.addObject(new NotificationClassObject(
+                d1, 17, "nc17", 100, 5, 200, new EventTransitionBits(false, false, false)));
 
         final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
         recipients.add(new Destination(new Recipient(rd2.getAddress()), new UnsignedInteger(10), Boolean.TRUE,
@@ -441,14 +443,15 @@ public class LifeSafetyZoneObjectTest extends AbstractTest {
                 new DeviceObjectPropertyReference(1, lsz.getId(), PropertyIdentifier.presentValue);
         final DeviceObjectPropertyReference modeRef =
                 new DeviceObjectPropertyReference(1, lsz.getId(), PropertyIdentifier.mode);
-        final EventEnrollmentObject ee = new EventEnrollmentObject(d1, 0, "ee", pvRef, NotifyType.alarm,
+        final EventEnrollmentObject ee = d1.addObject(new EventEnrollmentObject(
+                d1, 0, "ee", pvRef, NotifyType.alarm,
                 new EventParameter(new ChangeOfLifeSafety(new UnsignedInteger(30),
                         new BACnetArray<>(LifeSafetyState.tamper, LifeSafetyState.testSupervisory), //
                         new BACnetArray<>(LifeSafetyState.testActive, LifeSafetyState.testAlarm), //
                         modeRef)), new EventTransitionBits(true, true, true), 17, 1000, new UnsignedInteger(50), //
                 new FaultParameter(
                         new FaultLifeSafety(new BACnetArray<>(LifeSafetyState.fault, LifeSafetyState.faultAlarm),
-                                modeRef)));
+                                modeRef))));
 
         // Ensure that initializing the event enrollment object didn't fire any notifications.
         quiesce();

--- a/src/test/java/com/serotonin/bacnet4j/obj/MultistateInputObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/MultistateInputObjectTest.java
@@ -66,12 +66,14 @@ public class MultistateInputObjectTest extends AbstractTest {
 
     @Override
     public void afterInit() throws Exception {
-        mi = new MultistateInputObject(d1, 0, "mi", 5, new BACnetArray<>(new CharacterString("Off"), //
-                new CharacterString("On"), //
-                new CharacterString("Auto"), //
-                new CharacterString("Fan"), //
-                new CharacterString("Other")), 1, false);
-        nc = new NotificationClassObject(d1, 17, "nc17", 100, 5, 200, new EventTransitionBits(false, false, false));
+        mi = d1.addObject(new MultistateInputObject(d1, 0, "mi", 5, new BACnetArray<>(new CharacterString("Off"),
+                new CharacterString("On"),
+                new CharacterString("Auto"),
+                new CharacterString("Fan"),
+                new CharacterString("Other")),
+                1, false));
+        nc = d1.addObject(new NotificationClassObject(
+                d1, 17, "nc17", 100, 5, 200, new EventTransitionBits(false, false, false)));
     }
 
     @Test
@@ -172,10 +174,11 @@ public class MultistateInputObjectTest extends AbstractTest {
 
         final DeviceObjectPropertyReference ref =
                 new DeviceObjectPropertyReference(1, mi.getId(), PropertyIdentifier.presentValue);
-        final EventEnrollmentObject ee = new EventEnrollmentObject(d1, 0, "ee", ref, NotifyType.alarm,
+        final EventEnrollmentObject ee = d1.addObject(new EventEnrollmentObject(
+                d1, 0, "ee", ref, NotifyType.alarm,
                 new EventParameter(new ChangeOfState(new UnsignedInteger(30),
                         new SequenceOf<>(new PropertyStates(new UnsignedInteger(4))))),
-                new EventTransitionBits(true, true, true), 17, 1000, null, null);
+                new EventTransitionBits(true, true, true), 17, 1000, null, null));
 
         // Set up the notification destination
         final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);

--- a/src/test/java/com/serotonin/bacnet4j/obj/MultistateOutputObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/MultistateOutputObjectTest.java
@@ -64,12 +64,14 @@ public class MultistateOutputObjectTest extends AbstractTest {
 
     @Override
     public void afterInit() throws Exception {
-        mo = new MultistateOutputObject(d1, 0, "mo", 5, new BACnetArray<>(new CharacterString("Off"), //
-                new CharacterString("On"), //
-                new CharacterString("Auto"), //
-                new CharacterString("Fan"), //
-                new CharacterString("Other")), 2, 5, false);
-        nc = new NotificationClassObject(d1, 17, "nc17", 100, 5, 200, new EventTransitionBits(false, false, false));
+        mo = d1.addObject(new MultistateOutputObject(d1, 0, "mo", 5, new BACnetArray<>(
+                new CharacterString("Off"),
+                new CharacterString("On"),
+                new CharacterString("Auto"),
+                new CharacterString("Fan"),
+                new CharacterString("Other")), 2, 5, false));
+        nc = d1.addObject(new NotificationClassObject(
+                d1, 17, "nc17", 100, 5, 200, new EventTransitionBits(false, false, false)));
     }
 
     @Test
@@ -81,9 +83,9 @@ public class MultistateOutputObjectTest extends AbstractTest {
 
     @Test
     public void inconsistentStateText() {
+        var stateText = new BACnetArray<>(new CharacterString("a"));
         assertThrows(IllegalArgumentException.class,
-                () -> new MultistateOutputObject(d1, 1, "mv1", 7, new BACnetArray<>(new CharacterString("a")), 1, 1,
-                        true));
+                () -> new MultistateOutputObject(d1, 1, "mv1", 7, stateText, 1, 1, true));
     }
 
     @Test
@@ -160,7 +162,7 @@ public class MultistateOutputObjectTest extends AbstractTest {
         assertEquals(Boolean.FALSE, notif.ackRequired());
         assertEquals(EventState.normal, notif.fromState());
         assertEquals(EventState.offnormal, notif.toState());
-        CommandFailureNotif commandFailure = ((NotificationParameters) notif.eventValues()).getParameter();
+        CommandFailureNotif commandFailure = notif.eventValues().getParameter();
         assertEquals(new UnsignedInteger(2),
                 AmbiguousValue.convertTo(commandFailure.getCommandValue(), UnsignedInteger.class));
         assertEquals(new StatusFlags(true, false, false, false), commandFailure.getStatusFlags());
@@ -213,10 +215,10 @@ public class MultistateOutputObjectTest extends AbstractTest {
 
         final DeviceObjectPropertyReference ref =
                 new DeviceObjectPropertyReference(1, mo.getId(), PropertyIdentifier.presentValue);
-        final EventEnrollmentObject ee = new EventEnrollmentObject(d1, 0, "ee", ref, NotifyType.alarm,
+        final EventEnrollmentObject ee = d1.addObject(new EventEnrollmentObject(d1, 0, "ee", ref, NotifyType.alarm,
                 new EventParameter(new CommandFailure(new UnsignedInteger(30),
                         new DeviceObjectPropertyReference(1, mo.getId(), PropertyIdentifier.feedbackValue))),
-                new EventTransitionBits(true, true, true), 17, 1000, null, null);
+                new EventTransitionBits(true, true, true), 17, 1000, null, null));
 
         // Set up the notification destination
         final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);

--- a/src/test/java/com/serotonin/bacnet4j/obj/NotificationClassObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/NotificationClassObjectTest.java
@@ -50,7 +50,8 @@ public class NotificationClassObjectTest extends AbstractTest {
 
     @Override
     public void afterInit() throws Exception {
-        nc = new NotificationClassObject(d1, 0, "notifClass", 100, 5, 200, new EventTransitionBits(true, true, true));
+        nc = d1.addObject(new NotificationClassObject(
+                d1, 0, "notifClass", 100, 5, 200, new EventTransitionBits(true, true, true)));
     }
 
     /**

--- a/src/test/java/com/serotonin/bacnet4j/obj/NotificationForwarderObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/NotificationForwarderObjectTest.java
@@ -105,9 +105,8 @@ public class NotificationForwarderObjectTest extends AbstractTest {
 
     @Test
     public void subscriptions() throws Exception {
-        final NotificationForwarderObject nf =
-                new NotificationForwarderObject(d1, 0, "nf", false, new ProcessIdSelection(Null.instance), portFilter,
-                        false);
+        final NotificationForwarderObject nf = d1.addObject(new NotificationForwarderObject(
+                d1, 0, "nf", false, new ProcessIdSelection(Null.instance), portFilter, false));
 
         // Add a few subscribers.
         new AddListElementRequest(nf.getId(), PropertyIdentifier.subscribedRecipients, null, new SequenceOf<>(
@@ -193,20 +192,19 @@ public class NotificationForwarderObjectTest extends AbstractTest {
 
     @Test
     public void notifications() throws Exception {
-        final NotificationForwarderObject nf =
-                new NotificationForwarderObject(d1, 0, "nf", false, new ProcessIdSelection(Null.instance), portFilter,
-                        false);
+        final NotificationForwarderObject nf = d1.addObject(new NotificationForwarderObject(
+                d1, 0, "nf", false, new ProcessIdSelection(Null.instance), portFilter, false));
 
         // Create EventLog objects to track forwardings
-        final EventLogObject el2 =
-                new EventLogObject(d2, 0, "el", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
-                        DateTime.UNSPECIFIED, false, 100);
-        final EventLogObject el3 =
-                new EventLogObject(d3, 0, "el", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
-                        DateTime.UNSPECIFIED, false, 100);
-        final EventLogObject el4 =
-                new EventLogObject(d4, 0, "el", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
-                        DateTime.UNSPECIFIED, false, 100);
+        final EventLogObject el2 = d2.addObject(new EventLogObject(
+                d2, 0, "el", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
+                DateTime.UNSPECIFIED, false, 100));
+        final EventLogObject el3 = d3.addObject(new EventLogObject(
+                d3, 0, "el", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
+                DateTime.UNSPECIFIED, false, 100));
+        final EventLogObject el4 = d4.addObject(new EventLogObject(
+                d4, 0, "el", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
+                DateTime.UNSPECIFIED, false, 100));
 
         // Add el2 and el3 as recipients, and el4 as a subscriber. el3 is set to not receive toNormal.
         new AddListElementRequest(nf.getId(), PropertyIdentifier.recipientList, null, new SequenceOf<>(
@@ -316,9 +314,8 @@ public class NotificationForwarderObjectTest extends AbstractTest {
 
         d1.setPersistence(new FilePersistence(file));
 
-        NotificationForwarderObject nf =
-                new NotificationForwarderObject(d1, 0, "nf", false, new ProcessIdSelection(Null.instance), portFilter,
-                        false);
+        NotificationForwarderObject nf = d1.addObject(new NotificationForwarderObject(
+                d1, 0, "nf", false, new ProcessIdSelection(Null.instance), portFilter, false));
 
         // Ensure that there are no recipients or subscriptions.
         SequenceOf<Destination> recipients = nf.readProperty(PropertyIdentifier.subscribedRecipients);
@@ -352,8 +349,8 @@ public class NotificationForwarderObjectTest extends AbstractTest {
 
         //
         // Create the object new again and ensure that the lists were loaded from the file.
-        nf = new NotificationForwarderObject(d1, 0, "nf", false, new ProcessIdSelection(Null.instance), portFilter,
-                false);
+        nf = d1.addObject(new NotificationForwarderObject(
+                d1, 0, "nf", false, new ProcessIdSelection(Null.instance), portFilter, false));
         recipients = nf.readProperty(PropertyIdentifier.recipientList);
         assertEquals(2, recipients.size());
         subscriptions = nf.readProperty(PropertyIdentifier.subscribedRecipients);

--- a/src/test/java/com/serotonin/bacnet4j/obj/PulseConverterObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/PulseConverterObjectTest.java
@@ -79,8 +79,9 @@ public class PulseConverterObjectTest extends AbstractTest {
 
     @Override
     public void afterInit() throws Exception {
-        pc = new PulseConverterObject(d1, 0, "pc", 0, 7.5F, EngineeringUnits.amperes, false);
-        nc = new NotificationClassObject(d1, 54, "nc54", 100, 5, 200, new EventTransitionBits(true, true, true));
+        pc = d1.addObject(new PulseConverterObject(d1, 0, "pc", 0, 7.5F, EngineeringUnits.amperes, false));
+        nc = d1.addObject(new NotificationClassObject(
+                d1, 54, "nc54", 100, 5, 200, new EventTransitionBits(true, true, true)));
     }
 
     @SuppressWarnings("unchecked")
@@ -427,9 +428,10 @@ public class PulseConverterObjectTest extends AbstractTest {
         awaitEquals(new StatusFlags(false, true, false, false), () -> pc.get(PropertyIdentifier.statusFlags));
 
         // Add the accumulator object. Polling should now succeed.
-        final AccumulatorObject a = new AccumulatorObject(d1, 0, "a", 50, 0, EngineeringUnits.amperes, false,
+        final AccumulatorObject a = d1.addObject(new AccumulatorObject(
+                d1, 0, "a", 50, 0, EngineeringUnits.amperes, false,
                 new Scale(new SignedInteger(10)), new Prescale(new UnsignedInteger(1), new UnsignedInteger(1)), 1000,
-                5);
+                5));
         clock.plusSeconds(5);
         awaitEquals(Reliability.noFaultDetected, () -> pc.get(PropertyIdentifier.reliability));
         awaitEquals(new StatusFlags(false, false, false, false), () -> pc.get(PropertyIdentifier.statusFlags));

--- a/src/test/java/com/serotonin/bacnet4j/obj/ScheduleObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/ScheduleObjectTest.java
@@ -93,10 +93,10 @@ public class ScheduleObjectTest extends AbstractTest {
         // Not really a full test. The effective period could be better.
         clock.set(2115, java.time.Month.MAY, 1, 12, 0, 0);
 
-        final AnalogValueObject av0 =
-                new AnalogValueObject(d2, 0, "av0", 98, EngineeringUnits.amperes, false).supportCommandable(-2);
-        final AnalogValueObject av1 =
-                new AnalogValueObject(d1, 1, "av1", 99, EngineeringUnits.amperesPerMeter, false).supportCommandable(-1);
+        final AnalogValueObject av0 = d2.addObject(new AnalogValueObject(
+                d2, 0, "av0", 98, EngineeringUnits.amperes, false).supportCommandable(-2));
+        final AnalogValueObject av1 = d1.addObject(new AnalogValueObject(
+                d1, 1, "av1", 99, EngineeringUnits.amperesPerMeter, false).supportCommandable(-1));
 
         final Primitive defaultScheduledValue = new Real(999);
         final ScheduleObject so = createScheduleObject(av0, av1, defaultScheduledValue);
@@ -144,10 +144,10 @@ public class ScheduleObjectTest extends AbstractTest {
     public void nullScheduleDefaultTest() throws Exception {
         clock.set(2115, java.time.Month.MAY, 1, 12, 0, 0);
 
-        final AnalogValueObject av0 =
-                new AnalogValueObject(d2, 0, "av0", 98, EngineeringUnits.amperes, false).supportCommandable(-2);
-        final AnalogValueObject av1 =
-                new AnalogValueObject(d1, 1, "av1", 99, EngineeringUnits.amperesPerMeter, false).supportCommandable(-1);
+        final AnalogValueObject av0 = d2.addObject(new AnalogValueObject(
+                d2, 0, "av0", 98, EngineeringUnits.amperes, false).supportCommandable(-2));
+        final AnalogValueObject av1 = d1.addObject(new AnalogValueObject(
+                d1, 1, "av1", 99, EngineeringUnits.amperesPerMeter, false).supportCommandable(-1));
 
         final Primitive defaultScheduledValue = new Null();
         final ScheduleObject so = createScheduleObject(av0, av1, defaultScheduledValue);
@@ -230,8 +230,8 @@ public class ScheduleObjectTest extends AbstractTest {
     @SuppressWarnings("unchecked")
     @Test
     public void intrinsicAlarms() throws Exception {
-        final NotificationClassObject nc =
-                new NotificationClassObject(d1, 7, "nc7", 100, 5, 200, new EventTransitionBits(false, false, false));
+        final NotificationClassObject nc = d1.addObject(new NotificationClassObject(
+                d1, 7, "nc7", 100, 5, 200, new EventTransitionBits(false, false, false)));
         final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
         recipients.add(new Destination(new Recipient(rd2.getAddress()), new UnsignedInteger(10), Boolean.TRUE,
                 new EventTransitionBits(true, true, true)));
@@ -240,8 +240,8 @@ public class ScheduleObjectTest extends AbstractTest {
         final EventNotifListener listener = new EventNotifListener();
         d2.getEventHandler().addListener(listener);
 
-        final AnalogValueObject av1 =
-                new AnalogValueObject(d1, 1, "av1", 99, EngineeringUnits.amperesPerMeter, false).supportCommandable(-1);
+        final AnalogValueObject av1 = d1.addObject(new AnalogValueObject(
+                d1, 1, "av1", 99, EngineeringUnits.amperesPerMeter, false).supportCommandable(-1));
 
         final SequenceOf<SpecialEvent> exceptionSchedule = new SequenceOf<>(
                 new SpecialEvent(new CalendarEntry(new Date(-1, null, -1, DayOfWeek.WEDNESDAY)), new SequenceOf<>(),
@@ -250,9 +250,9 @@ public class ScheduleObjectTest extends AbstractTest {
         final SequenceOf<DeviceObjectPropertyReference> listOfObjectPropertyReferences = new SequenceOf<>( //
                 new DeviceObjectPropertyReference(av1.getId(), PropertyIdentifier.presentValue, null, null) //
         );
-        final ScheduleObject so =
-                new ScheduleObject(d1, 0, "sch0", new DateRange(Date.UNSPECIFIED, Date.UNSPECIFIED), null,
-                        exceptionSchedule, new Real(8), listOfObjectPropertyReferences, 12, false);
+        final ScheduleObject so = d1.addObject(new ScheduleObject(
+                d1, 0, "sch0", new DateRange(Date.UNSPECIFIED, Date.UNSPECIFIED), null,
+                exceptionSchedule, new Real(8), listOfObjectPropertyReferences, 12, false));
         so.supportIntrinsicReporting(7, new EventTransitionBits(true, true, true), NotifyType.alarm);
 
         // Ensure that initializing the intrinsic reporting didn't fire any notifications.
@@ -288,9 +288,9 @@ public class ScheduleObjectTest extends AbstractTest {
      */
     @Test
     public void listValues() throws Exception {
-        final ScheduleObject so =
-                new ScheduleObject(d1, 0, "sch0", new DateRange(Date.MINIMUM_DATE, Date.MAXIMUM_DATE), null,
-                        new SequenceOf<>(), new Real(8), new SequenceOf<>(), 12, false);
+        final ScheduleObject so = d1.addObject(new ScheduleObject(
+                d1, 0, "sch0", new DateRange(Date.MINIMUM_DATE, Date.MAXIMUM_DATE), null,
+                new SequenceOf<>(), new Real(8), new SequenceOf<>(), 12, false));
 
         // Add a few items to the list.
         final ObjectIdentifier oid = new ObjectIdentifier(ObjectType.analogInput, 0);
@@ -332,9 +332,9 @@ public class ScheduleObjectTest extends AbstractTest {
 
     @Test
     public void changeDataType() throws Exception {
-        final AnalogValueObject av =
-                new AnalogValueObject(d1, 0, "av0", 98, EngineeringUnits.amperes, false).supportCommandable(-2);
-        final BinaryValueObject bv = new BinaryValueObject(d1, 0, "bv0", BinaryPV.inactive, false);
+        final AnalogValueObject av = d1.addObject(new AnalogValueObject(
+                d1, 0, "av0", 98, EngineeringUnits.amperes, false).supportCommandable(-2));
+        final BinaryValueObject bv = d1.addObject(new BinaryValueObject(d1, 0, "bv0", BinaryPV.inactive, false));
 
         final SequenceOf<SpecialEvent> binarySchedule = new SequenceOf<>(
                 new SpecialEvent(new CalendarEntry(new Date(-1, null, -1, DayOfWeek.WEDNESDAY)),
@@ -351,9 +351,9 @@ public class ScheduleObjectTest extends AbstractTest {
         final BinaryPV binaryDefaultValue = BinaryPV.inactive;
         final Real analogDefaultValue = new Real(1);
 
-        final ScheduleObject so =
-                new ScheduleObject(d1, 1, "sch0", new DateRange(Date.MINIMUM_DATE, Date.MAXIMUM_DATE), null,
-                        binarySchedule, binaryDefaultValue, binaryReferences, 12, false);
+        final ScheduleObject so = d1.addObject(new ScheduleObject(
+                d1, 1, "sch0", new DateRange(Date.MINIMUM_DATE, Date.MAXIMUM_DATE), null,
+                binarySchedule, binaryDefaultValue, binaryReferences, 12, false));
 
         Assert.assertEquals(binaryDefaultValue, so.readProperty(PropertyIdentifier.scheduleDefault));
         Assert.assertEquals(binaryReferences, so.readProperty(PropertyIdentifier.listOfObjectPropertyReferences));
@@ -381,8 +381,8 @@ public class ScheduleObjectTest extends AbstractTest {
 
     @Test
     public void validations() throws Exception {
-        final AnalogValueObject av =
-                new AnalogValueObject(d2, 0, "av0", 98, EngineeringUnits.amperes, false).supportCommandable(-2);
+        final AnalogValueObject av = d2.addObject(new AnalogValueObject(
+                d2, 0, "av0", 98, EngineeringUnits.amperes, false).supportCommandable(-2));
 
         //
         // Entries in the list of property references must reference properties of this type
@@ -442,7 +442,7 @@ public class ScheduleObjectTest extends AbstractTest {
         //
         // Validation for data type change
         assertBACnetServiceException(() -> {
-            BinaryValueObject bv1 = new BinaryValueObject(d1, 1, "bv1", BinaryPV.inactive, false);
+            BinaryValueObject bv1 = d1.addObject(new BinaryValueObject(d1, 1, "bv1", BinaryPV.inactive, false));
             final BACnetArray<DailySchedule> weekly = new BACnetArray<>( //
                     new DailySchedule(new SequenceOf<>(new TimeValue(new Time(d1), BinaryPV.active))), //
                     new DailySchedule(new SequenceOf<>()), //
@@ -451,11 +451,11 @@ public class ScheduleObjectTest extends AbstractTest {
                     new DailySchedule(new SequenceOf<>()), //
                     new DailySchedule(new SequenceOf<>()), //
                     new DailySchedule(new SequenceOf<>()));
-            ScheduleObject so =
-                    new ScheduleObject(d1, 1, "sch5", new DateRange(Date.MINIMUM_DATE, Date.MAXIMUM_DATE), weekly,
-                            new SequenceOf<>(), BinaryPV.inactive, new SequenceOf<>(
-                            new DeviceObjectPropertyReference(1, bv1.getId(), PropertyIdentifier.presentValue)), 12,
-                            false);
+            ScheduleObject so = d1.addObject(new ScheduleObject(
+                    d1, 1, "sch5", new DateRange(Date.MINIMUM_DATE, Date.MAXIMUM_DATE), weekly,
+                    new SequenceOf<>(), BinaryPV.inactive, new SequenceOf<>(
+                    new DeviceObjectPropertyReference(1, bv1.getId(), PropertyIdentifier.presentValue)), 12,
+                    false));
 
             // Try to change data type from binary to analog
             so.writeProperty(null, PropertyIdentifier.listOfObjectPropertyReferences, new SequenceOf<>(
@@ -474,7 +474,7 @@ public class ScheduleObjectTest extends AbstractTest {
                         // The Wednesday during the 4th week of each month.
                 );
 
-        final CalendarObject co = new CalendarObject(d1, 0, "cal0", dateList);
+        final CalendarObject co = d1.addObject(new CalendarObject(d1, 0, "cal0", dateList));
 
         final DateRange effectivePeriod = new DateRange(Date.UNSPECIFIED, Date.UNSPECIFIED);
 
@@ -516,7 +516,8 @@ public class ScheduleObjectTest extends AbstractTest {
                 new DeviceObjectPropertyReference(av1.getId(), PropertyIdentifier.presentValue, null, null) //
         );
 
-        return new ScheduleObject(d1, 0, "sch0", effectivePeriod, weeklySchedule, exceptionSchedule, scheduleDefault,
-                listOfObjectPropertyReferences, 12, false);
+        return d1.addObject(new ScheduleObject(
+                d1, 0, "sch0", effectivePeriod, weeklySchedule, exceptionSchedule, scheduleDefault,
+                listOfObjectPropertyReferences, 12, false));
     }
 }

--- a/src/test/java/com/serotonin/bacnet4j/obj/TrendLogMultipleObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/TrendLogMultipleObjectTest.java
@@ -96,9 +96,11 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
 
     @Override
     public void afterInit() throws Exception {
-        nc = new NotificationClassObject(d1, 23, "nc", 1, 2, 3, new EventTransitionBits(true, true, true));
-        ao = new AnalogValueObject(d1, 0, "ao", 0, EngineeringUnits.noUnits, false).supportCovReporting(0.5F);
-        ai = new AnalogInputObject(d2, 0, "ai", 0, EngineeringUnits.noUnits, false);
+        nc = d1.addObject(new NotificationClassObject(
+                d1, 23, "nc", 1, 2, 3, new EventTransitionBits(true, true, true)));
+        ao = d1.addObject(new AnalogValueObject(
+                d1, 0, "ao", 0, EngineeringUnits.noUnits, false).supportCovReporting(0.5F));
+        ai = d2.addObject(new AnalogInputObject(d2, 0, "ai", 0, EngineeringUnits.noUnits, false));
 
         props = new BACnetArray<>( //
                 // Remote
@@ -121,10 +123,10 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
     @Test
     public void pollingAlignedWithOffset() throws Exception {
         // Construct the log to poll each minute, aligned, and with a 2s offset.
-        final TrendLogMultipleObject tl =
-                new TrendLogMultipleObject(d1, 0, "tlm", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
-                        DateTime.UNSPECIFIED, props, 0, false, 20) //
-                        .withPolled(1, MINUTES, true, 2, SECONDS);
+        final TrendLogMultipleObject tl = d1.addObject(new TrendLogMultipleObject(
+                d1, 0, "tlm", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
+                DateTime.UNSPECIFIED, props, 0, false, 20)
+                .withPolled(1, MINUTES, true, 2, SECONDS));
 
         assertEquals(0, tl.getRecordCount());
 
@@ -174,14 +176,14 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
         ai.writePropertyInternal(PropertyIdentifier.presentValue, new Real(3));
 
         // Advance the clock to the new polling time.
-        final int minutes = (62 - clock.get(ChronoField.MINUTE_OF_HOUR)) % 60;
+        final int minutes = (60 - clock.get(ChronoField.MINUTE_OF_HOUR)) % 60;
         clock.plusMinutes(minutes);
         LOG.debug("poll: {}", clock.instant());
 
         awaitEquals(3, tl::getRecordCount);
         assertEquals(3, tl.getRecordCount());
         final LogMultipleRecord record2 = tl.getRecord(2);
-        assertEquals(2, record2.getTimestamp().getTime().getMinute());
+        assertEquals(0, record2.getTimestamp().getTime().getMinute());
         assertEquals(3, record2.getSequenceNumber());
         assertEquals(5, record2.getLogData().getData().size());
         assertEquals(new Real(3), record2.getLogData().getData().get(0).getDatum());
@@ -209,9 +211,9 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
 
     @Test
     public void trigger() throws Exception {
-        final TrendLogMultipleObject tl =
-                new TrendLogMultipleObject(d1, 0, "tlm", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
-                        DateTime.UNSPECIFIED, props, 0, false, 20);
+        final TrendLogMultipleObject tl = d1.addObject(new TrendLogMultipleObject(
+                d1, 0, "tlm", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
+                DateTime.UNSPECIFIED, props, 0, false, 20));
 
         final DateTime now = new DateTime(clock.millis());
 
@@ -252,10 +254,10 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
     @Test
     public void intrinsicReporting() throws Exception {
         // Create a triggered trend log with intrinsic reporting enabled.
-        final TrendLogMultipleObject tl =
-                new TrendLogMultipleObject(d1, 0, "tlm", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
-                        DateTime.UNSPECIFIED, props, 0, false, 20) //
-                        .supportIntrinsicReporting(5, 23, new EventTransitionBits(true, true, true), NotifyType.event);
+        final TrendLogMultipleObject tl = d1.addObject(new TrendLogMultipleObject(
+                d1, 0, "tlm", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
+                DateTime.UNSPECIFIED, props, 0, false, 20) //
+                .supportIntrinsicReporting(5, 23, new EventTransitionBits(true, true, true), NotifyType.event));
 
         final RemoteDevice rd2 = d1.getRemoteDeviceBlocking(2);
 
@@ -381,16 +383,17 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
     @Test
     public void eventReporting() throws Exception {
         // Create a triggered trend log
-        final TrendLogMultipleObject tl =
-                new TrendLogMultipleObject(d1, 0, "tlm", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
-                        DateTime.UNSPECIFIED, props, 0, false, 20);
+        final TrendLogMultipleObject tl = d1.addObject(new TrendLogMultipleObject(
+                d1, 0, "tlm", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
+                DateTime.UNSPECIFIED, props, 0, false, 20));
 
         // Create the event enrollment.
         final DeviceObjectPropertyReference ref =
                 new DeviceObjectPropertyReference(tl.getId(), PropertyIdentifier.totalRecordCount, null, d1.getId());
-        final EventEnrollmentObject ee = new EventEnrollmentObject(d1, 0, "ee", ref, NotifyType.event,
+        final EventEnrollmentObject ee = d1.addObject(new EventEnrollmentObject(
+                d1, 0, "ee", ref, NotifyType.event,
                 new EventParameter(new BufferReady(new UnsignedInteger(3), UnsignedInteger.ZERO)),
-                new EventTransitionBits(true, true, true), 23, 1000, null, null);
+                new EventTransitionBits(true, true, true), 23, 1000, null, null));
 
         // Set d2 as an event recipient.
         final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
@@ -459,9 +462,9 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
     @Test
     public void stopWhenFull() throws Exception {
         // Create a triggered trend log
-        final TrendLogMultipleObject tl =
-                new TrendLogMultipleObject(d1, 0, "tlm", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
-                        DateTime.UNSPECIFIED, props, 0, true, 4);
+        final TrendLogMultipleObject tl = d1.addObject(new TrendLogMultipleObject(
+                d1, 0, "tlm", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
+                DateTime.UNSPECIFIED, props, 0, true, 4));
 
         final SequenceOf<LogDataElement> logData = new SequenceOf<>( //
                 new LogDataElement(new Real(0)), //
@@ -529,9 +532,9 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
     @Test
     public void enableDisable() throws Exception {
         // Create a disabled triggered trend log
-        final TrendLogMultipleObject tl =
-                new TrendLogMultipleObject(d1, 0, "tlm", new LinkedListLogBuffer<>(), false, DateTime.UNSPECIFIED,
-                        DateTime.UNSPECIFIED, props, 0, true, 4);
+        final TrendLogMultipleObject tl = d1.addObject(new TrendLogMultipleObject(
+                d1, 0, "tlm", new LinkedListLogBuffer<>(), false, DateTime.UNSPECIFIED,
+                DateTime.UNSPECIFIED, props, 0, true, 4));
 
         assertEquals(0, tl.getRecordCount());
 
@@ -567,9 +570,9 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
                 new LogDataElement(noPropSpecified));
 
         // Create a triggered trend log
-        final TrendLogMultipleObject tl =
-                new TrendLogMultipleObject(d1, 0, "tlm", new LinkedListLogBuffer<>(), true, startTime, stopTime, props,
-                        0, true, 7);
+        final TrendLogMultipleObject tl = d1.addObject(new TrendLogMultipleObject(
+                d1, 0, "tlm", new LinkedListLogBuffer<>(), true, startTime, stopTime, props,
+                0, true, 7));
 
         assertTrue(tl.isLogDisabled());
         assertEquals(0, tl.getRecordCount());
@@ -631,9 +634,9 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
     @Test
     public void readLogBuffer() throws Exception {
         // Create a triggered trend log
-        final TrendLogMultipleObject tl =
-                new TrendLogMultipleObject(d1, 0, "tlm", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
-                        DateTime.UNSPECIFIED, props, 0, true, 7);
+        final TrendLogMultipleObject tl = d1.addObject(new TrendLogMultipleObject(
+                d1, 0, "tlm", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
+                DateTime.UNSPECIFIED, props, 0, true, 7));
 
         // Try to do a network read of the buffer. It should not be readable.
         assertBACnetServiceException(() -> tl.readProperty(PropertyIdentifier.logBuffer, null), ErrorClass.property,
@@ -643,9 +646,9 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
     @Test
     public void purge() throws Exception {
         // Create a triggered trend log
-        final TrendLogMultipleObject tl =
-                new TrendLogMultipleObject(d1, 0, "tlm", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
-                        DateTime.UNSPECIFIED, props, 0, true, 7);
+        final TrendLogMultipleObject tl = d1.addObject(new TrendLogMultipleObject(
+                d1, 0, "tlm", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
+                DateTime.UNSPECIFIED, props, 0, true, 7));
 
         // Trigger a few updates.
         doTriggers(tl, 2);
@@ -675,9 +678,9 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
                 new LogDataElement(noPropSpecified));
 
         // Create a triggered trend log
-        final TrendLogMultipleObject tl =
-                new TrendLogMultipleObject(d1, 0, "tlm", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
-                        DateTime.UNSPECIFIED, props, 0, true, 100);
+        final TrendLogMultipleObject tl = d1.addObject(new TrendLogMultipleObject(
+                d1, 0, "tlm", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
+                DateTime.UNSPECIFIED, props, 0, true, 100));
 
         doTriggers(tl, 2);
         assertEquals(2, tl.getRecordCount());

--- a/src/test/java/com/serotonin/bacnet4j/obj/TrendLogObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/TrendLogObjectTest.java
@@ -324,7 +324,7 @@ public class TrendLogObjectTest extends AbstractTest {
                 d1, 0, "tl0", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
                 DateTime.UNSPECIFIED,
                 new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, false,
-                20).withTriggered());
+                20));
 
         final DateTime now = new DateTime(clock.millis());
 
@@ -364,7 +364,7 @@ public class TrendLogObjectTest extends AbstractTest {
                 d1, 0, "tl0", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
                 DateTime.UNSPECIFIED,
                 new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, false,
-                20).withTriggered()
+                20)
                 .supportIntrinsicReporting(5, 23, new EventTransitionBits(true, true, true), NotifyType.event));
 
         final RemoteDevice rd2 = d1.getRemoteDeviceBlocking(2);
@@ -496,7 +496,7 @@ public class TrendLogObjectTest extends AbstractTest {
                 d1, 0, "tl", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
                 DateTime.UNSPECIFIED,
                 new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, false,
-                20).withTriggered());
+                20));
 
         // Create the event enrollment.
         final DeviceObjectPropertyReference ref =
@@ -578,7 +578,7 @@ public class TrendLogObjectTest extends AbstractTest {
                 d1, 0, "tl", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
                 DateTime.UNSPECIFIED,
                 new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, true,
-                4).withTriggered());
+                4));
 
         final DateTime now = new DateTime(clock.millis());
         final StatusFlags sf = new StatusFlags(false, false, false, false);
@@ -828,8 +828,9 @@ public class TrendLogObjectTest extends AbstractTest {
                 d1, 0, "tl", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
                 DateTime.UNSPECIFIED,
                 new DeviceObjectPropertyReference(3, ai.getId(), PropertyIdentifier.presentValue), 0, false,
-                20).supportIntrinsicReporting(20, 23, new EventTransitionBits(true, true, true),
-                NotifyType.event).withCov(100, new ClientCov(Null.instance)));
+                20)
+                .supportIntrinsicReporting(20, 23, new EventTransitionBits(true, true, true), NotifyType.event)
+                .withCov(100, new ClientCov(Null.instance)));
 
         // Wait for the notification.
         awaitEquals(1, listener::getNotifCount);

--- a/src/test/java/com/serotonin/bacnet4j/obj/TrendLogObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/TrendLogObjectTest.java
@@ -92,28 +92,31 @@ public class TrendLogObjectTest extends AbstractTest {
 
     @Override
     public void afterInit() throws Exception {
-        nc = new NotificationClassObject(d1, 23, "nc", 1, 2, 3, new EventTransitionBits(true, true, true));
-        ao = new AnalogValueObject(d1, 0, "ao", 0, EngineeringUnits.noUnits, false).supportCovReporting(0.5F);
-        ai = new AnalogInputObject(d2, 0, "ai", 0, EngineeringUnits.noUnits, false).supportCovReporting(0.5F);
+        nc = d1.addObject(new NotificationClassObject(
+                d1, 23, "nc", 1, 2, 3, new EventTransitionBits(true, true, true)));
+        ao = d1.addObject(new AnalogValueObject(
+                d1, 0, "ao", 0, EngineeringUnits.noUnits, false).supportCovReporting(0.5F));
+        ai = d2.addObject(new AnalogInputObject(
+                d2, 0, "ai", 0, EngineeringUnits.noUnits, false).supportCovReporting(0.5F));
     }
 
     @Test
     public void remotePollingAlignedWithOffset() throws Exception {
-        final TrendLogObject tl =
-                new TrendLogObject(d1, 0, "tl0", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
-                        DateTime.UNSPECIFIED,
-                        new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, false,
-                        20).withPolled(1, TimeUnit.MINUTES, true, 2, TimeUnit.SECONDS);
+        final TrendLogObject tl = d1.addObject(new TrendLogObject(
+                d1, 0, "tl0", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
+                DateTime.UNSPECIFIED,
+                new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, false,
+                20).withPolled(1, TimeUnit.MINUTES, true, 2, TimeUnit.SECONDS));
         polling(tl, ai);
     }
 
     @Test
     public void localPolling() throws Exception {
-        final TrendLogObject tl =
-                new TrendLogObject(d1, 0, "tl0", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
-                        DateTime.UNSPECIFIED,
-                        new DeviceObjectPropertyReference(1, ao.getId(), PropertyIdentifier.presentValue), 0, false,
-                        20).withPolled(1, TimeUnit.MINUTES, true, 2, TimeUnit.SECONDS);
+        final TrendLogObject tl = d1.addObject(new TrendLogObject(
+                d1, 0, "tl0", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
+                DateTime.UNSPECIFIED,
+                new DeviceObjectPropertyReference(1, ao.getId(), PropertyIdentifier.presentValue), 0, false,
+                20).withPolled(1, TimeUnit.MINUTES, true, 2, TimeUnit.SECONDS));
         polling(tl, ao);
     }
 
@@ -195,21 +198,21 @@ public class TrendLogObjectTest extends AbstractTest {
 
     @Test
     public void remoteCov() throws Exception {
-        final TrendLogObject tl =
-                new TrendLogObject(d1, 0, "tl0", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
-                        DateTime.UNSPECIFIED,
-                        new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, false,
-                        20).withCov(100, new ClientCov(Null.instance));
+        final TrendLogObject tl = d1.addObject(new TrendLogObject(
+                d1, 0, "tl0", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
+                DateTime.UNSPECIFIED,
+                new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, false,
+                20).withCov(100, new ClientCov(Null.instance)));
         cov(tl, d2, ai);
     }
 
     @Test
     public void localCov() throws Exception {
-        final TrendLogObject tl =
-                new TrendLogObject(d1, 0, "tl0", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
-                        DateTime.UNSPECIFIED,
-                        new DeviceObjectPropertyReference(1, ao.getId(), PropertyIdentifier.presentValue), 0, false,
-                        20).withCov(100, new ClientCov(new Real(0.3F)));
+        final TrendLogObject tl = d1.addObject(new TrendLogObject(
+                d1, 0, "tl0", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
+                DateTime.UNSPECIFIED,
+                new DeviceObjectPropertyReference(1, ao.getId(), PropertyIdentifier.presentValue), 0, false,
+                20).withCov(100, new ClientCov(new Real(0.3F))));
         cov(tl, d1, ao);
     }
 
@@ -317,11 +320,11 @@ public class TrendLogObjectTest extends AbstractTest {
 
     @Test
     public void trigger() throws Exception {
-        final TrendLogObject tl =
-                new TrendLogObject(d1, 0, "tl0", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
-                        DateTime.UNSPECIFIED,
-                        new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, false,
-                        20).withTriggered();
+        final TrendLogObject tl = d1.addObject(new TrendLogObject(
+                d1, 0, "tl0", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
+                DateTime.UNSPECIFIED,
+                new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, false,
+                20).withTriggered());
 
         final DateTime now = new DateTime(clock.millis());
 
@@ -357,12 +360,12 @@ public class TrendLogObjectTest extends AbstractTest {
     @Test
     public void intrinsicReporting() throws Exception {
         // Create a triggered trend log with intrinsic reporting enabled.
-        final TrendLogObject tl =
-                new TrendLogObject(d1, 0, "tl0", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
-                        DateTime.UNSPECIFIED,
-                        new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, false,
-                        20).withTriggered()
-                        .supportIntrinsicReporting(5, 23, new EventTransitionBits(true, true, true), NotifyType.event);
+        final TrendLogObject tl = d1.addObject(new TrendLogObject(
+                d1, 0, "tl0", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
+                DateTime.UNSPECIFIED,
+                new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, false,
+                20).withTriggered()
+                .supportIntrinsicReporting(5, 23, new EventTransitionBits(true, true, true), NotifyType.event));
 
         final RemoteDevice rd2 = d1.getRemoteDeviceBlocking(2);
 
@@ -489,18 +492,19 @@ public class TrendLogObjectTest extends AbstractTest {
     @Test
     public void eventReporting() throws Exception {
         // Create a triggered trend log
-        final TrendLogObject tl =
-                new TrendLogObject(d1, 0, "tl", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
-                        DateTime.UNSPECIFIED,
-                        new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, false,
-                        20).withTriggered();
+        final TrendLogObject tl = d1.addObject(new TrendLogObject(
+                d1, 0, "tl", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
+                DateTime.UNSPECIFIED,
+                new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, false,
+                20).withTriggered());
 
         // Create the event enrollment.
         final DeviceObjectPropertyReference ref =
                 new DeviceObjectPropertyReference(tl.getId(), PropertyIdentifier.totalRecordCount, null, d1.getId());
-        final EventEnrollmentObject ee = new EventEnrollmentObject(d1, 0, "ee", ref, NotifyType.event,
+        final EventEnrollmentObject ee = d1.addObject(new EventEnrollmentObject(
+                d1, 0, "ee", ref, NotifyType.event,
                 new EventParameter(new BufferReady(new UnsignedInteger(3), UnsignedInteger.ZERO)),
-                new EventTransitionBits(true, true, true), 23, 1000, null, null);
+                new EventTransitionBits(true, true, true), 23, 1000, null, null));
 
         // Set d2 as an event recipient.
         final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
@@ -570,11 +574,11 @@ public class TrendLogObjectTest extends AbstractTest {
     @Test
     public void stopWhenFull() throws Exception {
         // Create a triggered trend log
-        final TrendLogObject tl =
-                new TrendLogObject(d1, 0, "tl", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
-                        DateTime.UNSPECIFIED,
-                        new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, true,
-                        4).withTriggered();
+        final TrendLogObject tl = d1.addObject(new TrendLogObject(
+                d1, 0, "tl", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
+                DateTime.UNSPECIFIED,
+                new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, true,
+                4).withTriggered());
 
         final DateTime now = new DateTime(clock.millis());
         final StatusFlags sf = new StatusFlags(false, false, false, false);
@@ -640,10 +644,10 @@ public class TrendLogObjectTest extends AbstractTest {
     @Test
     public void enableDisable() throws Exception {
         // Create a disabled triggered trend log
-        final TrendLogObject tl =
-                new TrendLogObject(d1, 0, "tl", new LinkedListLogBuffer<>(), false, DateTime.UNSPECIFIED,
-                        DateTime.UNSPECIFIED,
-                        new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, true, 4);
+        final TrendLogObject tl = d1.addObject(new TrendLogObject(
+                d1, 0, "tl", new LinkedListLogBuffer<>(), false, DateTime.UNSPECIFIED,
+                DateTime.UNSPECIFIED,
+                new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, true, 4));
         assertEquals(0, tl.getRecordCount());
 
         // Add a couple records and validate the buffer content
@@ -671,9 +675,9 @@ public class TrendLogObjectTest extends AbstractTest {
         DateTime stopTime = new DateTime(nowgg);
 
         // Create a triggered trend log
-        final TrendLogObject tl =
-                new TrendLogObject(d1, 0, "tl", new LinkedListLogBuffer<>(), true, startTime, stopTime,
-                        new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, true, 7);
+        final TrendLogObject tl = d1.addObject(new TrendLogObject(
+                d1, 0, "tl", new LinkedListLogBuffer<>(), true, startTime, stopTime,
+                new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, true, 7));
         assertTrue(tl.isLogDisabled());
         assertEquals(0, tl.getRecordCount());
 
@@ -738,10 +742,10 @@ public class TrendLogObjectTest extends AbstractTest {
     @Test
     public void readLogBuffer() throws Exception {
         // Create a triggered trend log
-        final TrendLogObject tl =
-                new TrendLogObject(d1, 0, "tl", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
-                        DateTime.UNSPECIFIED,
-                        new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, true, 7);
+        final TrendLogObject tl = d1.addObject(new TrendLogObject(
+                d1, 0, "tl", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
+                DateTime.UNSPECIFIED,
+                new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, true, 7));
 
         // Try to do a network read of the buffer. It should not be readable.
         assertBACnetServiceException(() -> tl.readProperty(PropertyIdentifier.logBuffer, null), ErrorClass.property,
@@ -753,10 +757,10 @@ public class TrendLogObjectTest extends AbstractTest {
         final DateTime now = new DateTime(clock.millis());
 
         // Create a triggered trend log
-        final TrendLogObject tl =
-                new TrendLogObject(d1, 0, "tl", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
-                        DateTime.UNSPECIFIED,
-                        new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, true, 7);
+        final TrendLogObject tl = d1.addObject(new TrendLogObject(
+                d1, 0, "tl", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
+                DateTime.UNSPECIFIED,
+                new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, true, 7));
 
         // Trigger a few updates.
         doTriggers(tl, 2);
@@ -779,11 +783,11 @@ public class TrendLogObjectTest extends AbstractTest {
         final StatusFlags sf = new StatusFlags(false, false, false, false);
 
         // Create a triggered trend log
-        final TrendLogObject tl =
-                new TrendLogObject(d1, 0, "tl", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
-                        DateTime.UNSPECIFIED,
-                        new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, true,
-                        100);
+        final TrendLogObject tl = d1.addObject(new TrendLogObject(
+                d1, 0, "tl", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
+                DateTime.UNSPECIFIED,
+                new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, true,
+                100));
 
         ao.writePropertyInternal(PropertyIdentifier.presentValue, new Real(13));
         ai.writePropertyInternal(PropertyIdentifier.presentValue, new Real(14));
@@ -820,12 +824,12 @@ public class TrendLogObjectTest extends AbstractTest {
 
         LOG.debug("start");
         // Create a COV trend log that references a device that doesn't exist.
-        final TrendLogObject tl =
-                new TrendLogObject(d1, 0, "tl", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
-                        DateTime.UNSPECIFIED,
-                        new DeviceObjectPropertyReference(3, ai.getId(), PropertyIdentifier.presentValue), 0, false,
-                        20).supportIntrinsicReporting(20, 23, new EventTransitionBits(true, true, true),
-                        NotifyType.event).withCov(100, new ClientCov(Null.instance));
+        final TrendLogObject tl = d1.addObject(new TrendLogObject(
+                d1, 0, "tl", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
+                DateTime.UNSPECIFIED,
+                new DeviceObjectPropertyReference(3, ai.getId(), PropertyIdentifier.presentValue), 0, false,
+                20).supportIntrinsicReporting(20, 23, new EventTransitionBits(true, true, true),
+                NotifyType.event).withCov(100, new ClientCov(Null.instance)));
 
         // Wait for the notification.
         awaitEquals(1, listener::getNotifCount);

--- a/src/test/java/com/serotonin/bacnet4j/obj/mixin/CommandableMixinTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/mixin/CommandableMixinTest.java
@@ -73,7 +73,8 @@ import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 public class CommandableMixinTest extends AbstractTest {
     @Test
     public void avNotCommandableNotValueSource() throws BACnetServiceException {
-        final AnalogValueObject av = new AnalogValueObject(d1, 0, "av0", 0, EngineeringUnits.noUnits, false);
+        final AnalogValueObject av = d1.addObject(new AnalogValueObject(
+                d1, 0, "av0", 0, EngineeringUnits.noUnits, false));
         final ValueSource valueSource = createValueSource(12);
 
         assertEquals(new Real(0), av.get(PropertyIdentifier.presentValue));
@@ -118,8 +119,8 @@ public class CommandableMixinTest extends AbstractTest {
 
     @Test
     public void bvCommandableNotValueSource() throws Exception {
-        final BinaryValueObject bv =
-                new BinaryValueObject(d1, 0, "bv0", BinaryPV.inactive, false).supportCommandable(BinaryPV.inactive);
+        final BinaryValueObject bv = d1.addObject(new BinaryValueObject(
+                d1, 0, "bv0", BinaryPV.inactive, false).supportCommandable(BinaryPV.inactive));
 
         // Assert default values.
         assertEquals(BinaryPV.inactive, bv.get(PropertyIdentifier.presentValue));
@@ -188,7 +189,8 @@ public class CommandableMixinTest extends AbstractTest {
 
     @Test
     public void bvNotCommandableValueSource() throws Exception {
-        final BinaryValueObject bv = new BinaryValueObject(d1, 0, "bv0", BinaryPV.inactive, false).supportValueSource();
+        final BinaryValueObject bv = d1.addObject(new BinaryValueObject(
+                d1, 0, "bv0", BinaryPV.inactive, false).supportValueSource());
         bv.writeProperty(null, new PropertyValue(PropertyIdentifier.outOfService, Boolean.TRUE));
 
         // Assert default values.
@@ -229,9 +231,8 @@ public class CommandableMixinTest extends AbstractTest {
 
     @Test
     public void bvCommandableValueSource() throws Exception {
-        final BinaryValueObject bv =
-                new BinaryValueObject(d1, 0, "bv0", BinaryPV.inactive, false).supportCommandable(BinaryPV.inactive)
-                        .supportValueSource();
+        final BinaryValueObject bv = d1.addObject(new BinaryValueObject(
+                d1, 0, "bv0", BinaryPV.inactive, false).supportCommandable(BinaryPV.inactive).supportValueSource());
 
         // Assert default values.
         assertEquals(BinaryPV.inactive, bv.get(PropertyIdentifier.presentValue));
@@ -329,8 +330,8 @@ public class CommandableMixinTest extends AbstractTest {
 
     @Test
     public void boMinOnOffTime() throws Exception {
-        final BinaryOutputObject bo =
-                new BinaryOutputObject(d1, 0, "bo0", BinaryPV.inactive, false, Polarity.normal, BinaryPV.inactive);
+        final BinaryOutputObject bo = d1.addObject(new BinaryOutputObject(
+                d1, 0, "bo0", BinaryPV.inactive, false, Polarity.normal, BinaryPV.inactive));
 
         // Assert default values.
         assertEquals(BinaryPV.inactive, bo.get(PropertyIdentifier.presentValue));
@@ -426,7 +427,8 @@ public class CommandableMixinTest extends AbstractTest {
 
     @Test
     public void writable() throws BACnetServiceException {
-        final BinaryValueObject bv = new BinaryValueObject(d1, 0, "bv", BinaryPV.inactive, false).supportWritable();
+        final BinaryValueObject bv = d1.addObject(new BinaryValueObject(
+                d1, 0, "bv", BinaryPV.inactive, false).supportWritable());
 
         // Write with priority not allowed.
         assertBACnetServiceException(() -> bv.writeProperty(null,
@@ -441,7 +443,7 @@ public class CommandableMixinTest extends AbstractTest {
 
     @Test
     public void notWritable() throws BACnetServiceException {
-        final BinaryValueObject bv = new BinaryValueObject(d1, 0, "bv", BinaryPV.inactive, false);
+        final BinaryValueObject bv = d1.addObject(new BinaryValueObject(d1, 0, "bv", BinaryPV.inactive, false));
 
         // Write with priority not allowed.
         assertBACnetServiceException(() -> bv.writeProperty(null,

--- a/src/test/java/com/serotonin/bacnet4j/obj/mixin/ObjectIdAndNameMixinTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/mixin/ObjectIdAndNameMixinTest.java
@@ -94,8 +94,8 @@ public class ObjectIdAndNameMixinTest {
     @Test
     public void uniqueInstanceNumber() throws Exception {
         final LocalDevice d1 = new LocalDevice(1, new DefaultTransport(new TestNetwork(map, 1, 0))).initialize();
-        final GroupObject go0 = new GroupObject(d1, 0, "go0", new SequenceOf<>());
-        final GroupObject go1 = new GroupObject(d1, 1, "go1", new SequenceOf<>());
+        final GroupObject go0 = d1.addObject(new GroupObject(d1, 0, "go0", new SequenceOf<>()));
+        final GroupObject go1 = d1.addObject(new GroupObject(d1, 1, "go1", new SequenceOf<>()));
         TestUtils.assertBACnetServiceException(() -> {
             go0.writeProperty(null, new PropertyValue(PropertyIdentifier.objectIdentifier, go1.getId()));
         }, ErrorClass.property, ErrorCode.duplicateObjectId);
@@ -112,8 +112,8 @@ public class ObjectIdAndNameMixinTest {
     @Test
     public void uniqueName() throws Exception {
         final LocalDevice d1 = new LocalDevice(1, new DefaultTransport(new TestNetwork(map, 1, 0))).initialize();
-        final GroupObject go0 = new GroupObject(d1, 0, "go0", new SequenceOf<>());
-        new GroupObject(d1, 1, "go1", new SequenceOf<>());
+        final GroupObject go0 = d1.addObject(new GroupObject(d1, 0, "go0", new SequenceOf<>()));
+        d1.addObject(new GroupObject(d1, 1, "go1", new SequenceOf<>()));
         TestUtils.assertBACnetServiceException(() -> {
             go0.writeProperty(null, new PropertyValue(PropertyIdentifier.objectName, new CharacterString("go1")));
         }, ErrorClass.property, ErrorCode.duplicateName);

--- a/src/test/java/com/serotonin/bacnet4j/service/confirmed/AtomicReadFileRequestTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/service/confirmed/AtomicReadFileRequestTest.java
@@ -66,7 +66,7 @@ public class AtomicReadFileRequestTest {
     @Before
     public void before() throws Exception {
         d1 = new LocalDevice(1, new DefaultTransport(new TestNetwork(map, 1, 0))).initialize();
-        ai = new AnalogInputObject(d1, 0, "ai", 0, EngineeringUnits.noUnits, false);
+        ai = d1.addObject(new AnalogInputObject(d1, 0, "ai", 0, EngineeringUnits.noUnits, false));
     }
 
     @After
@@ -75,7 +75,7 @@ public class AtomicReadFileRequestTest {
     }
 
     @Test
-    public void errors() throws Exception {
+    public void errors() {
         // Use an oid what doesn't exist.
         TestUtils.assertRequestHandleException(() -> {
             new AtomicReadFileRequest(new ObjectIdentifier(ObjectType.file, 0),
@@ -94,7 +94,7 @@ public class AtomicReadFileRequestTest {
     @Test
     public void stream() throws Exception {
         // Create the file object to use.
-        final FileObject f = new FileObject(d1, 0, "test", new StreamAccess(new File(path)));
+        final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new StreamAccess(new File(path))));
 
         // Read starting at -1.
         TestUtils.assertRequestHandleException(() -> {
@@ -153,7 +153,7 @@ public class AtomicReadFileRequestTest {
     @Test
     public void record() throws Exception {
         // Create the file object to use.
-        final FileObject f = new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(new File(path)));
+        final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(new File(path))));
 
         // Read starting at -1.
         TestUtils.assertRequestHandleException(() -> {

--- a/src/test/java/com/serotonin/bacnet4j/service/confirmed/AtomicWriteFileRequestTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/service/confirmed/AtomicWriteFileRequestTest.java
@@ -70,7 +70,7 @@ public class AtomicWriteFileRequestTest {
     @Before
     public void before() throws Exception {
         d1 = new LocalDevice(1, new DefaultTransport(new TestNetwork(map, 1, 0))).initialize();
-        ai = new AnalogInputObject(d1, 0, "ai", 0, EngineeringUnits.noUnits, false);
+        ai = d1.addObject(new AnalogInputObject(d1, 0, "ai", 0, EngineeringUnits.noUnits, false));
     }
 
     @After
@@ -98,7 +98,7 @@ public class AtomicWriteFileRequestTest {
     @Test
     public void stream() throws Exception {
         // Create the file object to use.
-        final FileObject f = new FileObject(d1, 0, "test", new StreamAccess(new File(path)));
+        final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new StreamAccess(new File(path))));
 
         // Write starting at -2.
         TestUtils.assertRequestHandleException(() -> {
@@ -116,7 +116,7 @@ public class AtomicWriteFileRequestTest {
 
         // Do a legitimate write into an existing range.
         doInCopy((file) -> {
-            final FileObject f1 = new FileObject(d1, 1, "test", new StreamAccess(file));
+            final FileObject f1 = d1.addObject(new FileObject(d1, 1, "test", new StreamAccess(file)));
             final AtomicWriteFileAck wack = (AtomicWriteFileAck) new AtomicWriteFileRequest(f1.getId(),
                     new com.serotonin.bacnet4j.service.confirmed.AtomicWriteFileRequest.StreamAccess(
                             new SignedInteger(600), new OctetString("!@#$%".getBytes()))).handle(d1, null);
@@ -134,7 +134,7 @@ public class AtomicWriteFileRequestTest {
 
         // Do a legitimate write to exactly the end of the file.
         doInCopy((file) -> {
-            final FileObject f1 = new FileObject(d1, 1, "test", new StreamAccess(file));
+            final FileObject f1 = d1.addObject(new FileObject(d1, 1, "test", new StreamAccess(file)));
             final AtomicWriteFileAck wack = (AtomicWriteFileAck) new AtomicWriteFileRequest(f1.getId(),
                     new com.serotonin.bacnet4j.service.confirmed.AtomicWriteFileRequest.StreamAccess(
                             new SignedInteger(917), new OctetString("!@#$%".getBytes()))).handle(d1, null);
@@ -152,7 +152,7 @@ public class AtomicWriteFileRequestTest {
 
         // Do a legitimate write a bit beyond the end of the file.
         doInCopy((file) -> {
-            final FileObject f1 = new FileObject(d1, 1, "test", new StreamAccess(file));
+            final FileObject f1 = d1.addObject(new FileObject(d1, 1, "test", new StreamAccess(file)));
             final AtomicWriteFileAck wack = (AtomicWriteFileAck) new AtomicWriteFileRequest(f1.getId(),
                     new com.serotonin.bacnet4j.service.confirmed.AtomicWriteFileRequest.StreamAccess(
                             new SignedInteger(919), new OctetString("!@#$%".getBytes()))).handle(d1, null);
@@ -170,7 +170,7 @@ public class AtomicWriteFileRequestTest {
 
         // Do a legitimate write starting beyond the end of the file.
         doInCopy((file) -> {
-            final FileObject f1 = new FileObject(d1, 1, "test", new StreamAccess(file));
+            final FileObject f1 = d1.addObject(new FileObject(d1, 1, "test", new StreamAccess(file)));
             final AtomicWriteFileAck wack = (AtomicWriteFileAck) new AtomicWriteFileRequest(f1.getId(),
                     new com.serotonin.bacnet4j.service.confirmed.AtomicWriteFileRequest.StreamAccess(
                             new SignedInteger(930), new OctetString("!@#$%".getBytes()))).handle(d1, null);
@@ -189,7 +189,7 @@ public class AtomicWriteFileRequestTest {
 
         // Do a legitimate write append.
         doInCopy((file) -> {
-            final FileObject f1 = new FileObject(d1, 1, "test", new StreamAccess(file));
+            final FileObject f1 = d1.addObject(new FileObject(d1, 1, "test", new StreamAccess(file)));
             final AtomicWriteFileAck wack = (AtomicWriteFileAck) new AtomicWriteFileRequest(f1.getId(),
                     new com.serotonin.bacnet4j.service.confirmed.AtomicWriteFileRequest.StreamAccess(
                             new SignedInteger(-1), new OctetString("!@#$%".getBytes()))).handle(d1, null);
@@ -209,7 +209,7 @@ public class AtomicWriteFileRequestTest {
     @Test
     public void record() throws Exception {
         // Create the file object to use.
-        final FileObject f = new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(new File(path)));
+        final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(new File(path))));
 
         // Write starting at -2.
         TestUtils.assertRequestHandleException(() -> {
@@ -228,7 +228,7 @@ public class AtomicWriteFileRequestTest {
 
         // Do a legitimate write of an existing range.
         doInCopy((file) -> {
-            final FileObject f1 = new FileObject(d1, 1, "test", new CrlfDelimitedFileAccess(file));
+            final FileObject f1 = d1.addObject(new FileObject(d1, 1, "test", new CrlfDelimitedFileAccess(file)));
             final AtomicWriteFileAck wack = (AtomicWriteFileAck) new AtomicWriteFileRequest(f1.getId(),
                     new com.serotonin.bacnet4j.service.confirmed.AtomicWriteFileRequest.RecordAccess(
                             new SignedInteger(0), new UnsignedInteger(3), new SequenceOf<>( //
@@ -255,7 +255,7 @@ public class AtomicWriteFileRequestTest {
 
         // Do a legitimate write past the end of the file
         doInCopy((file) -> {
-            final FileObject f1 = new FileObject(d1, 1, "test", new CrlfDelimitedFileAccess(file));
+            final FileObject f1 = d1.addObject(new FileObject(d1, 1, "test", new CrlfDelimitedFileAccess(file)));
             final AtomicWriteFileAck wack = (AtomicWriteFileAck) new AtomicWriteFileRequest(f1.getId(),
                     new com.serotonin.bacnet4j.service.confirmed.AtomicWriteFileRequest.RecordAccess(
                             new SignedInteger(12), new UnsignedInteger(3), new SequenceOf<>( //
@@ -281,7 +281,7 @@ public class AtomicWriteFileRequestTest {
 
         // Do a legitimate write starting past the end of the file
         doInCopy((file) -> {
-            final FileObject f1 = new FileObject(d1, 1, "test", new CrlfDelimitedFileAccess(file));
+            final FileObject f1 = d1.addObject(new FileObject(d1, 1, "test", new CrlfDelimitedFileAccess(file)));
             final AtomicWriteFileAck wack = (AtomicWriteFileAck) new AtomicWriteFileRequest(f1.getId(),
                     new com.serotonin.bacnet4j.service.confirmed.AtomicWriteFileRequest.RecordAccess(
                             new SignedInteger(16), new UnsignedInteger(3), new SequenceOf<>( //
@@ -311,7 +311,7 @@ public class AtomicWriteFileRequestTest {
 
         // Do a legitimate write appending
         doInCopy((file) -> {
-            final FileObject f1 = new FileObject(d1, 1, "test", new CrlfDelimitedFileAccess(file));
+            final FileObject f1 = d1.addObject(new FileObject(d1, 1, "test", new CrlfDelimitedFileAccess(file)));
             final AtomicWriteFileAck wack = (AtomicWriteFileAck) new AtomicWriteFileRequest(f1.getId(),
                     new com.serotonin.bacnet4j.service.confirmed.AtomicWriteFileRequest.RecordAccess(
                             new SignedInteger(-1), new UnsignedInteger(3), new SequenceOf<>( //
@@ -342,7 +342,7 @@ public class AtomicWriteFileRequestTest {
         doInCopy((file) -> {
             final long originalTime = file.lastModified();
             Thread.sleep(1); // Ensures that the time changes from  the original
-            final FileObject f1 = new FileObject(d1, 1, "test", new StreamAccess(file));
+            final FileObject f1 = d1.addObject(new FileObject(d1, 1, "test", new StreamAccess(file)));
             new AtomicWriteFileRequest(f1.getId(),
                     new com.serotonin.bacnet4j.service.confirmed.AtomicWriteFileRequest.StreamAccess(
                             new SignedInteger(600), new OctetString("!@#$%".getBytes()))).handle(d1, null);

--- a/src/test/java/com/serotonin/bacnet4j/service/confirmed/AtomicWriteFileRequestTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/service/confirmed/AtomicWriteFileRequestTest.java
@@ -28,6 +28,7 @@
 package com.serotonin.bacnet4j.service.confirmed;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -79,7 +80,7 @@ public class AtomicWriteFileRequestTest {
     }
 
     @Test
-    public void errors() throws Exception {
+    public void errors() {
         // Use an oid what doesn't exist.
         TestUtils.assertRequestHandleException(() -> {
             new AtomicWriteFileRequest(new ObjectIdentifier(ObjectType.file, 0),
@@ -88,15 +89,13 @@ public class AtomicWriteFileRequestTest {
         }, ErrorClass.object, ErrorCode.unknownObject);
 
         // Use an oid what is not a file object.
-        TestUtils.assertRequestHandleException(() -> {
-            new AtomicWriteFileRequest(ai.getId(),
-                    new com.serotonin.bacnet4j.service.confirmed.AtomicWriteFileRequest.StreamAccess(
-                            new SignedInteger(2), new OctetString(new byte[0]))).handle(d1, null);
-        }, ErrorClass.services, ErrorCode.inconsistentObjectType);
+        TestUtils.assertRequestHandleException(() -> new AtomicWriteFileRequest(ai.getId(),
+                new AtomicWriteFileRequest.StreamAccess(new SignedInteger(2), new OctetString(new byte[0]))
+        ).handle(d1, null), ErrorClass.services, ErrorCode.inconsistentObjectType);
     }
 
     @Test
-    public void stream() throws Exception {
+    public void streamAccess() throws Exception {
         // Create the file object to use.
         final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new StreamAccess(new File(path))));
 
@@ -115,12 +114,12 @@ public class AtomicWriteFileRequestTest {
         }, ErrorClass.services, ErrorCode.invalidFileAccessMethod);
 
         // Do a legitimate write into an existing range.
-        doInCopy((file) -> {
+        doInCopy(file -> {
             final FileObject f1 = d1.addObject(new FileObject(d1, 1, "test", new StreamAccess(file)));
             final AtomicWriteFileAck wack = (AtomicWriteFileAck) new AtomicWriteFileRequest(f1.getId(),
                     new com.serotonin.bacnet4j.service.confirmed.AtomicWriteFileRequest.StreamAccess(
                             new SignedInteger(600), new OctetString("!@#$%".getBytes()))).handle(d1, null);
-            assertEquals(false, wack.isRecordAccess());
+            assertFalse(wack.isRecordAccess());
             assertEquals(new SignedInteger(600), wack.getFileStart());
 
             // Do a read to confirm the change.
@@ -133,12 +132,12 @@ public class AtomicWriteFileRequestTest {
         });
 
         // Do a legitimate write to exactly the end of the file.
-        doInCopy((file) -> {
+        doInCopy(file -> {
             final FileObject f1 = d1.addObject(new FileObject(d1, 1, "test", new StreamAccess(file)));
             final AtomicWriteFileAck wack = (AtomicWriteFileAck) new AtomicWriteFileRequest(f1.getId(),
                     new com.serotonin.bacnet4j.service.confirmed.AtomicWriteFileRequest.StreamAccess(
                             new SignedInteger(917), new OctetString("!@#$%".getBytes()))).handle(d1, null);
-            assertEquals(false, wack.isRecordAccess());
+            assertFalse(wack.isRecordAccess());
             assertEquals(new SignedInteger(917), wack.getFileStart());
 
             // Do a read to confirm the change.
@@ -151,12 +150,12 @@ public class AtomicWriteFileRequestTest {
         });
 
         // Do a legitimate write a bit beyond the end of the file.
-        doInCopy((file) -> {
+        doInCopy(file -> {
             final FileObject f1 = d1.addObject(new FileObject(d1, 1, "test", new StreamAccess(file)));
             final AtomicWriteFileAck wack = (AtomicWriteFileAck) new AtomicWriteFileRequest(f1.getId(),
                     new com.serotonin.bacnet4j.service.confirmed.AtomicWriteFileRequest.StreamAccess(
                             new SignedInteger(919), new OctetString("!@#$%".getBytes()))).handle(d1, null);
-            assertEquals(false, wack.isRecordAccess());
+            assertFalse(wack.isRecordAccess());
             assertEquals(new SignedInteger(919), wack.getFileStart());
 
             // Do a read to confirm the change.
@@ -169,12 +168,12 @@ public class AtomicWriteFileRequestTest {
         });
 
         // Do a legitimate write starting beyond the end of the file.
-        doInCopy((file) -> {
+        doInCopy(file -> {
             final FileObject f1 = d1.addObject(new FileObject(d1, 1, "test", new StreamAccess(file)));
             final AtomicWriteFileAck wack = (AtomicWriteFileAck) new AtomicWriteFileRequest(f1.getId(),
                     new com.serotonin.bacnet4j.service.confirmed.AtomicWriteFileRequest.StreamAccess(
                             new SignedInteger(930), new OctetString("!@#$%".getBytes()))).handle(d1, null);
-            assertEquals(false, wack.isRecordAccess());
+            assertFalse(wack.isRecordAccess());
             assertEquals(new SignedInteger(930), wack.getFileStart());
 
             // Do a read to confirm the change.
@@ -188,12 +187,12 @@ public class AtomicWriteFileRequestTest {
         });
 
         // Do a legitimate write append.
-        doInCopy((file) -> {
+        doInCopy(file -> {
             final FileObject f1 = d1.addObject(new FileObject(d1, 1, "test", new StreamAccess(file)));
             final AtomicWriteFileAck wack = (AtomicWriteFileAck) new AtomicWriteFileRequest(f1.getId(),
                     new com.serotonin.bacnet4j.service.confirmed.AtomicWriteFileRequest.StreamAccess(
                             new SignedInteger(-1), new OctetString("!@#$%".getBytes()))).handle(d1, null);
-            assertEquals(false, wack.isRecordAccess());
+            assertFalse(wack.isRecordAccess());
             assertEquals(new SignedInteger(922), wack.getFileStart());
 
             // Do a read to confirm the change.
@@ -207,7 +206,7 @@ public class AtomicWriteFileRequestTest {
     }
 
     @Test
-    public void record() throws Exception {
+    public void recordAccess() throws Exception {
         // Create the file object to use.
         final FileObject f = d1.addObject(new FileObject(d1, 0, "test", new CrlfDelimitedFileAccess(new File(path))));
 
@@ -227,7 +226,7 @@ public class AtomicWriteFileRequestTest {
         }, ErrorClass.services, ErrorCode.invalidFileAccessMethod);
 
         // Do a legitimate write of an existing range.
-        doInCopy((file) -> {
+        doInCopy(file -> {
             final FileObject f1 = d1.addObject(new FileObject(d1, 1, "test", new CrlfDelimitedFileAccess(file)));
             final AtomicWriteFileAck wack = (AtomicWriteFileAck) new AtomicWriteFileRequest(f1.getId(),
                     new com.serotonin.bacnet4j.service.confirmed.AtomicWriteFileRequest.RecordAccess(
@@ -235,7 +234,7 @@ public class AtomicWriteFileRequestTest {
                             new OctetString("Write 1".getBytes()), //
                             new OctetString("Write 2".getBytes()), //
                             new OctetString("Write 3".getBytes())))).handle(d1, null);
-            assertEquals(true, wack.isRecordAccess());
+            assertTrue(wack.isRecordAccess());
             assertEquals(new SignedInteger(0), wack.getFileStart());
 
             // Do a read to confirm the change.
@@ -254,7 +253,7 @@ public class AtomicWriteFileRequestTest {
         });
 
         // Do a legitimate write past the end of the file
-        doInCopy((file) -> {
+        doInCopy(file -> {
             final FileObject f1 = d1.addObject(new FileObject(d1, 1, "test", new CrlfDelimitedFileAccess(file)));
             final AtomicWriteFileAck wack = (AtomicWriteFileAck) new AtomicWriteFileRequest(f1.getId(),
                     new com.serotonin.bacnet4j.service.confirmed.AtomicWriteFileRequest.RecordAccess(
@@ -262,7 +261,7 @@ public class AtomicWriteFileRequestTest {
                             new OctetString("Write 1".getBytes()), //
                             new OctetString("Write 2".getBytes()), //
                             new OctetString("Write 3".getBytes())))).handle(d1, null);
-            assertEquals(true, wack.isRecordAccess());
+            assertTrue(wack.isRecordAccess());
             assertEquals(new SignedInteger(12), wack.getFileStart());
 
             // Do a read to confirm the change.
@@ -280,7 +279,7 @@ public class AtomicWriteFileRequestTest {
         });
 
         // Do a legitimate write starting past the end of the file
-        doInCopy((file) -> {
+        doInCopy(file -> {
             final FileObject f1 = d1.addObject(new FileObject(d1, 1, "test", new CrlfDelimitedFileAccess(file)));
             final AtomicWriteFileAck wack = (AtomicWriteFileAck) new AtomicWriteFileRequest(f1.getId(),
                     new com.serotonin.bacnet4j.service.confirmed.AtomicWriteFileRequest.RecordAccess(
@@ -288,7 +287,7 @@ public class AtomicWriteFileRequestTest {
                             new OctetString("Write 1".getBytes()), //
                             new OctetString("Write 2".getBytes()), //
                             new OctetString("Write 3".getBytes())))).handle(d1, null);
-            assertEquals(true, wack.isRecordAccess());
+            assertTrue(wack.isRecordAccess());
             assertEquals(new SignedInteger(16), wack.getFileStart());
 
             // Do a read to confirm the change.
@@ -310,7 +309,7 @@ public class AtomicWriteFileRequestTest {
 
 
         // Do a legitimate write appending
-        doInCopy((file) -> {
+        doInCopy(file -> {
             final FileObject f1 = d1.addObject(new FileObject(d1, 1, "test", new CrlfDelimitedFileAccess(file)));
             final AtomicWriteFileAck wack = (AtomicWriteFileAck) new AtomicWriteFileRequest(f1.getId(),
                     new com.serotonin.bacnet4j.service.confirmed.AtomicWriteFileRequest.RecordAccess(
@@ -318,7 +317,7 @@ public class AtomicWriteFileRequestTest {
                             new OctetString("Write 1".getBytes()), //
                             new OctetString("Write 2".getBytes()), //
                             new OctetString("Write 3".getBytes())))).handle(d1, null);
-            assertEquals(true, wack.isRecordAccess());
+            assertTrue(wack.isRecordAccess());
             assertEquals(new SignedInteger(14), wack.getFileStart());
 
             // Do a read to confirm the change.
@@ -339,7 +338,7 @@ public class AtomicWriteFileRequestTest {
 
     @Test
     public void modificationDate() throws Exception {
-        doInCopy((file) -> {
+        doInCopy(file -> {
             final long originalTime = file.lastModified();
             Thread.sleep(1); // Ensures that the time changes from  the original
             final FileObject f1 = d1.addObject(new FileObject(d1, 1, "test", new StreamAccess(file)));

--- a/src/test/java/com/serotonin/bacnet4j/service/confirmed/CreateObjectRequestTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/service/confirmed/CreateObjectRequestTest.java
@@ -60,11 +60,11 @@ public class CreateObjectRequestTest extends AbstractTest {
 
     @Override
     public void afterInit() throws Exception {
-        go0 = new GroupObject(d1, 0, "existing group", new SequenceOf<>());
+        go0 = d1.addObject(new GroupObject(d1, 0, "existing group", new SequenceOf<>()));
     }
 
     @Test
-    public void unsupportedObjectType() throws Exception {
+    public void unsupportedObjectType() {
         final CreateObjectError err = TestUtils.assertErrorAPDUException(() -> {
             d2.send(rd1, new CreateObjectRequest(new ObjectIdentifier(ObjectType.lift, 0), new SequenceOf<>())).get();
         }, ErrorClass.object, ErrorCode.unsupportedObjectType);
@@ -73,7 +73,7 @@ public class CreateObjectRequestTest extends AbstractTest {
     }
 
     @Test
-    public void noCreator() throws Exception {
+    public void noCreator() {
         final CreateObjectError err = TestUtils.assertErrorAPDUException(() -> {
             d2.send(rd1, new CreateObjectRequest(ObjectType.device, new SequenceOf<>())).get();
         }, ErrorClass.object, ErrorCode.dynamicCreationNotSupported);
@@ -82,7 +82,7 @@ public class CreateObjectRequestTest extends AbstractTest {
     }
 
     @Test
-    public void duplicateInstanceNumber() throws Exception {
+    public void duplicateInstanceNumber() {
         final CreateObjectError err = TestUtils.assertErrorAPDUException(() -> {
             d2.send(rd1, new CreateObjectRequest(go0.getId(), new SequenceOf<>())).get();
         }, ErrorClass.object, ErrorCode.objectIdentifierAlreadyExists);
@@ -91,7 +91,7 @@ public class CreateObjectRequestTest extends AbstractTest {
     }
 
     @Test
-    public void duplicateName() throws Exception {
+    public void duplicateName() {
         final CreateObjectError err = TestUtils.assertErrorAPDUException(() -> {
             d2.send(rd1,
                             new CreateObjectRequest(ObjectType.group, new SequenceOf<>(

--- a/src/test/java/com/serotonin/bacnet4j/service/confirmed/LifeSafetyOperationRequestTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/service/confirmed/LifeSafetyOperationRequestTest.java
@@ -70,11 +70,13 @@ public class LifeSafetyOperationRequestTest {
     public void before() throws Exception {
         localDevice.initialize();
 
-        ai = new AnalogInputObject(localDevice, 0, "ai", 5, EngineeringUnits.noUnits, false);
-        lsp = new LifeSafetyPointObject(localDevice, 0, "lsp", LifeSafetyState.alarm, LifeSafetyMode.on, false,
-                new SequenceOf<>(), LifeSafetyOperation.none, SilencedState.unsilenced);
-        lsz = new LifeSafetyZoneObject(localDevice, 0, "lzp", LifeSafetyState.alarm, LifeSafetyMode.on, false,
-                new SequenceOf<>(), LifeSafetyOperation.none, SilencedState.unsilenced, new SequenceOf<>());
+        ai = localDevice.addObject(new AnalogInputObject(localDevice, 0, "ai", 5, EngineeringUnits.noUnits, false));
+        lsp = localDevice.addObject(new LifeSafetyPointObject(
+                localDevice, 0, "lsp", LifeSafetyState.alarm, LifeSafetyMode.on, false,
+                new SequenceOf<>(), LifeSafetyOperation.none, SilencedState.unsilenced));
+        lsz = localDevice.addObject(new LifeSafetyZoneObject(
+                localDevice, 0, "lzp", LifeSafetyState.alarm, LifeSafetyMode.on, false,
+                new SequenceOf<>(), LifeSafetyOperation.none, SilencedState.unsilenced, new SequenceOf<>()));
     }
 
     @After

--- a/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadPriorityArrayTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadPriorityArrayTest.java
@@ -68,8 +68,8 @@ public class ReadPriorityArrayTest {
         //Add Objects and properties
         priorityArray = new PriorityArray().put(1, new UnsignedInteger(11111)).put(2, new UnsignedInteger(22222)).put(3,
                 new UnsignedInteger(33333));
-        final AnalogValueObject analogValueObject = new AnalogValueObject(remoteDevice, 1, "analogValueOne", 77.7f,
-                EngineeringUnits.degreesFahrenheit, false);
+        final AnalogValueObject analogValueObject = remoteDevice.addObject(new AnalogValueObject(
+                remoteDevice, 1, "analogValueOne", 77.7f, EngineeringUnits.degreesFahrenheit, false));
         analogValueObject.writePropertyInternal(PropertyIdentifier.priorityArray, priorityArray);
 
         //Search Remotedevice

--- a/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadPropertyMultipleRequestTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadPropertyMultipleRequestTest.java
@@ -73,7 +73,7 @@ public class ReadPropertyMultipleRequestTest {
         localDevice = new LocalDevice(1, new DefaultTransport(new TestNetwork(map, 1, 0)));
         localDevice.initialize();
 
-        g0 = new GroupObject(localDevice, 0, "g0", new SequenceOf<>());
+        g0 = localDevice.addObject(new GroupObject(localDevice, 0, "g0", new SequenceOf<>()));
         g0.writePropertyInternal(PropertyIdentifier.description, new CharacterString("my description"));
     }
 

--- a/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadRangeRequestTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadRangeRequestTest.java
@@ -138,15 +138,16 @@ public class ReadRangeRequestTest {
 
         final LocalDevice d11 =
                 new LocalDevice(11, new DefaultTransport(new TestNetwork(map, 11, 0))).withClock(clock).initialize();
-        final AnalogInputObject ai = new AnalogInputObject(d11, 0, "ai", 12, EngineeringUnits.noUnits, false);
+        final AnalogInputObject ai = d11.addObject(new AnalogInputObject(
+                d11, 0, "ai", 12, EngineeringUnits.noUnits, false));
 
         final LocalDevice d12 =
                 new LocalDevice(12, new DefaultTransport(new TestNetwork(map, 12, 0))).withClock(clock).initialize();
         final TrendLogMultipleObject tl =
-                new TrendLogMultipleObject(d12, 0, "tlm", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
-                        DateTime.UNSPECIFIED, new BACnetArray<>(
+                d12.addObject(new TrendLogMultipleObject(d12, 0, "tlm", new LinkedListLogBuffer<>(), true,
+                        DateTime.UNSPECIFIED, DateTime.UNSPECIFIED, new BACnetArray<>(
                         new DeviceObjectPropertyReference(11, ai.getId(), PropertyIdentifier.presentValue)), 0, false,
-                        100);
+                        100));
 
         final RemoteDevice rd12 = d11.getRemoteDeviceBlocking(12);
         final DateTime now = new DateTime(clock.millis());

--- a/src/test/java/com/serotonin/bacnet4j/service/confirmed/WritePropertyMultipleRequestTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/service/confirmed/WritePropertyMultipleRequestTest.java
@@ -66,10 +66,10 @@ public class WritePropertyMultipleRequestTest {
         remoteDevice = new LocalDevice(remoteDeviceId, new DefaultTransport(new TestNetwork(map, remoteDeviceId, 0)))
                 .initialize();
 
-        msv0 = new MultistateValueObject(remoteDevice, 0, "msv0", 4,
+        msv0 = remoteDevice.addObject(new MultistateValueObject(remoteDevice, 0, "msv0", 4,
                 new BACnetArray<>(new CharacterString("a"), new CharacterString("b"), new CharacterString("c"),
                         new CharacterString("d")),
-                1, false);
+                1, false));
         msv0.writePropertyInternal(PropertyIdentifier.description, new CharacterString("my description"));
 
         // Get the local reference to the remove device

--- a/src/test/java/com/serotonin/bacnet4j/util/BackupRestoreTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/util/BackupRestoreTest.java
@@ -109,14 +109,14 @@ public class BackupRestoreTest {
                 final File streamFile = copy(file, "stream");
                 final File recordFile = copy(file, "record");
 
-                final FileObject stream = new FileObject(localDevice,
+                final FileObject stream = localDevice.addObject(new FileObject(localDevice,
                         localDevice.getNextInstanceObjectNumber(ObjectType.file), "configurationFile",
-                        new StreamAccess(streamFile));
-                final FileObject record = new FileObject(localDevice,
+                        new StreamAccess(streamFile)));
+                final FileObject rec = localDevice.addObject(new FileObject(localDevice,
                         localDevice.getNextInstanceObjectNumber(ObjectType.file), "configurationFile",
-                        new CrlfDelimitedFileAccess(recordFile));
+                        new CrlfDelimitedFileAccess(recordFile)));
                 localDevice.getDeviceObject().writePropertyInternal(PropertyIdentifier.configurationFiles,
-                        new BACnetArray<>(stream.getId(), record.getId()));
+                        new BACnetArray<>(stream.getId(), rec.getId()));
             }
 
             // Override finishRestore to check the copied files and ensure that they match the originals.
@@ -133,8 +133,8 @@ public class BackupRestoreTest {
                     final FileObject stream = (FileObject) localDevice.getObject(configurationFiles.get(0));
                     final File restoredStream = ((StreamAccess) stream.getFileAccess()).getFile();
 
-                    final FileObject record = (FileObject) localDevice.getObject(configurationFiles.get(1));
-                    final File restoredRecord = ((CrlfDelimitedFileAccess) record.getFileAccess()).getFile();
+                    final FileObject rec = (FileObject) localDevice.getObject(configurationFiles.get(1));
+                    final File restoredRecord = ((CrlfDelimitedFileAccess) rec.getFileAccess()).getFile();
 
                     try {
                         TestUtils.assertFileContentEquals(restoredStream, file);

--- a/src/test/java/com/serotonin/bacnet4j/util/PropertyUtilsTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/util/PropertyUtilsTest.java
@@ -86,15 +86,15 @@ public class PropertyUtilsTest {
     private static void addObjects(final LocalDevice d) throws Exception {
         final int id = d.getInstanceNumber();
         d.writePropertyInternal(PropertyIdentifier.objectName, str("d" + id));
-        new BinaryValueObject(d, 0, "ai0", BinaryPV.active, false).writePropertyInternal(
+        d.addObject(new BinaryValueObject(d, 0, "ai0", BinaryPV.active, false).writePropertyInternal(
                         PropertyIdentifier.inactiveText, str("inactiveText"))
-                .writePropertyInternal(PropertyIdentifier.activeText, str("activeText"));
-        new BinaryValueObject(d, 1, "ai1", BinaryPV.inactive, false).writePropertyInternal(
+                .writePropertyInternal(PropertyIdentifier.activeText, str("activeText")));
+        d.addObject(new BinaryValueObject(d, 1, "ai1", BinaryPV.inactive, false).writePropertyInternal(
                         PropertyIdentifier.inactiveText, str("inactiveText"))
-                .writePropertyInternal(PropertyIdentifier.activeText, str("activeText"));
-        new BinaryValueObject(d, 2, "ai2", BinaryPV.active, false).writePropertyInternal(
+                .writePropertyInternal(PropertyIdentifier.activeText, str("activeText")));
+        d.addObject(new BinaryValueObject(d, 2, "ai2", BinaryPV.active, false).writePropertyInternal(
                         PropertyIdentifier.inactiveText, str("inactiveText"))
-                .writePropertyInternal(PropertyIdentifier.activeText, str("activeText"));
+                .writePropertyInternal(PropertyIdentifier.activeText, str("activeText")));
     }
 
     private static CharacterString str(final String s) {

--- a/src/test/java/com/serotonin/bacnet4j/util/RequestUtilsTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/util/RequestUtilsTest.java
@@ -184,7 +184,8 @@ public class RequestUtilsTest {
     public void sendOneAtATimeOnError() throws Exception {
         final LocalDevice d1 = new LocalDevice(1, new DefaultTransport(new TestNetwork(map, 1, 0))).initialize();
         final LocalDevice d2 = new LocalDevice(2, new DefaultTransport(new TestNetwork(map, 2, 0))).initialize();
-        final AnalogInputObject ai = new AnalogInputObject(d2, 0, "ai", 0, EngineeringUnits.noUnits, false);
+        final AnalogInputObject ai = d2.addObject(new AnalogInputObject(
+                d2, 0, "ai", 0, EngineeringUnits.noUnits, false));
         final RemoteDevice rd2 = d1.getRemoteDeviceBlocking(2);
 
         final List<Map<String, Object>> listenerUpdates = new ArrayList<>();


### PR DESCRIPTION
This PR is preparatory to adding the network port object. I fixes what was an annoyance and became a problem, being that bacnet objects were automatically added to devices upon construction. This is problematic because subclasses of bacnet objects do not initialize properly since the initializer is called in the base class.

Changes generally fall into two categories:
1) the removal of automatic adds of objects to local devices in construction
2) the "manual" adding of objects to local devices in tests

This is a breaking change, and so the version has a major increase to 7.0.0.
