### PR TITLE
MANGO-2995 Spec compliance fixes et al

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ var av = localDevice.addObject(new AnalogValueObject(localDevice, ...));
 - Serialization bug fixes
 - Removal of deprecated code
 - Introduction of BACnet Secure Connection implementation as SC node connecting to Hub
+- Fixes of various spec compliance issues, including data types and spec type implementations. The use of Unsigned32
+  instead of UnsignedInteger. This will cause a break with existing client code that expects to be able to do the
+  following:
+
+```
+UnsignedInteger ui = trendLog.get(PropertyIdentifier.recordCount)
+```
 
 *Version 6.2.0*
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ var av = localDevice.addObject(new AnalogValueObject(localDevice, ...));
   following:
 
 ```
-UnsignedInteger ui = trendLog.get(PropertyIdentifier.recordCount)
+UnsignedInteger ui = trendLog.get(PropertyIdentifier.recordCount); // Immediate ClassCastException
+trendLogMult.writeProperty(PropertyIdentifier.recordCount, new UnsignedInteger(100)); // Possibly delayed ClassCastException
 ```
 
 *Version 6.2.0*

--- a/src/main/java/com/serotonin/bacnet4j/obj/EventLogObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/EventLogObject.java
@@ -27,42 +27,22 @@
 
 package com.serotonin.bacnet4j.obj;
 
-import java.util.Objects;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.serotonin.bacnet4j.LocalDevice;
 import com.serotonin.bacnet4j.event.DeviceEventAdapter;
-import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.obj.logBuffer.LinkedListLogBuffer;
 import com.serotonin.bacnet4j.obj.logBuffer.LogBuffer;
-import com.serotonin.bacnet4j.obj.mixin.HasStatusFlagsMixin;
-import com.serotonin.bacnet4j.obj.mixin.ReadOnlyPropertyMixin;
-import com.serotonin.bacnet4j.obj.mixin.event.IntrinsicReportingMixin;
-import com.serotonin.bacnet4j.obj.mixin.event.eventAlgo.BufferReadyAlgo;
 import com.serotonin.bacnet4j.service.confirmed.ConfirmedEventNotificationRequest;
 import com.serotonin.bacnet4j.type.Encodable;
 import com.serotonin.bacnet4j.type.constructed.DateTime;
-import com.serotonin.bacnet4j.type.constructed.DeviceObjectPropertyReference;
 import com.serotonin.bacnet4j.type.constructed.EventLogRecord;
 import com.serotonin.bacnet4j.type.constructed.EventTransitionBits;
 import com.serotonin.bacnet4j.type.constructed.LogStatus;
-import com.serotonin.bacnet4j.type.constructed.PropertyValue;
-import com.serotonin.bacnet4j.type.constructed.StatusFlags;
 import com.serotonin.bacnet4j.type.constructed.TimeStamp;
-import com.serotonin.bacnet4j.type.constructed.ValueSource;
-import com.serotonin.bacnet4j.type.enumerated.ErrorClass;
-import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
 import com.serotonin.bacnet4j.type.enumerated.EventState;
 import com.serotonin.bacnet4j.type.enumerated.EventType;
 import com.serotonin.bacnet4j.type.enumerated.NotifyType;
 import com.serotonin.bacnet4j.type.enumerated.ObjectType;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
-import com.serotonin.bacnet4j.type.enumerated.Reliability;
-import com.serotonin.bacnet4j.type.notificationParameters.BufferReadyNotif;
 import com.serotonin.bacnet4j.type.notificationParameters.NotificationParameters;
 import com.serotonin.bacnet4j.type.primitive.Boolean;
 import com.serotonin.bacnet4j.type.primitive.CharacterString;
@@ -70,12 +50,7 @@ import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
 import com.serotonin.bacnet4j.type.primitive.Unsigned32;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
-/**
- * TODO
- * - Align intervals considering daylight savings time.
- */
-public class EventLogObject extends BACnetObject {
-    static final Logger LOG = LoggerFactory.getLogger(EventLogObject.class);
+public class EventLogObject extends LogBase {
 
     // CreateObject constructor
     public static EventLogObject create(LocalDevice localDevice, int instanceNumber) {
@@ -86,10 +61,6 @@ public class EventLogObject extends BACnetObject {
     }
 
     private final LogBuffer<EventLogRecord> buffer;
-
-    private boolean logDisabled;
-    private ScheduledFuture<?> startTimeFuture;
-    private ScheduledFuture<?> stopTimeFuture;
     private final DeviceEventAdapter eventListener;
 
     /**
@@ -98,31 +69,15 @@ public class EventLogObject extends BACnetObject {
     public EventLogObject(LocalDevice localDevice, int instanceNumber, String name,
             LogBuffer<EventLogRecord> buffer, boolean enable, DateTime startTime,
             DateTime stopTime, boolean stopWhenFull, int bufferSize) {
-        super(localDevice, ObjectType.eventLog, instanceNumber, name);
+        super(localDevice, ObjectType.eventLog, instanceNumber, name, enable, startTime, stopTime, stopWhenFull,
+                bufferSize);
 
-        Objects.requireNonNull(localDevice);
-        Objects.requireNonNull(name);
-        Objects.requireNonNull(startTime);
-        Objects.requireNonNull(stopTime);
-
-        set(PropertyIdentifier.enable, Boolean.valueOf(enable));
-        set(PropertyIdentifier.startTime, startTime);
-        set(PropertyIdentifier.stopTime, stopTime);
-        set(PropertyIdentifier.stopWhenFull, Boolean.valueOf(stopWhenFull));
-        set(PropertyIdentifier.bufferSize, new Unsigned32(bufferSize));
         set(PropertyIdentifier.logBuffer, buffer);
-        set(PropertyIdentifier.recordCount, Unsigned32.ZERO);
-        set(PropertyIdentifier.totalRecordCount, Unsigned32.ZERO);
-        set(PropertyIdentifier.statusFlags, new StatusFlags(false, false, false, false));
-        set(PropertyIdentifier.reliability, Reliability.noFaultDetected);
 
         updateStartTime(startTime);
         updateStopTime(stopTime);
 
-        // Mixins
-        addMixin(new HasStatusFlagsMixin(this));
-        addMixin(new ReadOnlyPropertyMixin(this, PropertyIdentifier.logBuffer, PropertyIdentifier.reliability,
-                PropertyIdentifier.totalRecordCount));
+        addLogMixins();
 
         this.buffer = buffer;
         logDisabled = !allowLogging(getNow());
@@ -146,106 +101,23 @@ public class EventLogObject extends BACnetObject {
 
     public EventLogObject supportIntrinsicReporting(int notificationThreshold, int notificationClass,
             EventTransitionBits eventEnable, NotifyType notifyType) {
-        Objects.requireNonNull(eventEnable);
-        Objects.requireNonNull(notifyType);
-
-        // Prepare the object with all of the properties that intrinsic reporting will need.
-        // User-defined properties
-        writePropertyInternal(PropertyIdentifier.notificationThreshold, new Unsigned32(notificationThreshold));
-        writePropertyInternal(PropertyIdentifier.recordsSinceNotification, Unsigned32.ZERO);
-        writePropertyInternal(PropertyIdentifier.lastNotifyRecord, Unsigned32.ZERO);
-        writePropertyInternal(PropertyIdentifier.eventState, EventState.normal);
-        writePropertyInternal(PropertyIdentifier.notificationClass, new UnsignedInteger(notificationClass));
-        writePropertyInternal(PropertyIdentifier.eventEnable, eventEnable);
-        writePropertyInternal(PropertyIdentifier.notifyType, notifyType);
-        writePropertyInternal(PropertyIdentifier.eventDetectionEnable, Boolean.TRUE);
-
-        BufferReadyAlgo algo = new BufferReadyAlgo(PropertyIdentifier.totalRecordCount,
-                new DeviceObjectPropertyReference(getId(), PropertyIdentifier.logBuffer, null,
-                        getLocalDevice().getId()),
-                PropertyIdentifier.notificationThreshold, PropertyIdentifier.lastNotifyRecord);
-
-        PropertyIdentifier[] triggerProps = new PropertyIdentifier[] { //
-                PropertyIdentifier.totalRecordCount, //
-                PropertyIdentifier.notificationThreshold};
-
-        // Now add the mixin.
-        addMixin(new IntrinsicReportingMixin(this, algo, null, PropertyIdentifier.totalRecordCount, triggerProps)
-                .withPostNotificationAction(notifParams -> {
-                    // After a notification has been sent, a couple values need to be updated.
-                    BufferReadyNotif brn = notifParams.getParameter();
-                    writePropertyInternal(PropertyIdentifier.lastNotifyRecord,
-                            new Unsigned32(brn.getCurrentNotification()));
-                    writePropertyInternal(PropertyIdentifier.recordsSinceNotification, Unsigned32.ZERO);
-                }));
-
+        baseSupportIntrinsicReporting(notificationThreshold, notificationClass, eventEnable, notifyType);
         return this;
-    }
-
-    public boolean isLogDisabled() {
-        return logDisabled;
     }
 
     public LogBuffer<EventLogRecord> getBuffer() {
         return buffer;
     }
 
-    public void setEnabled(boolean enabled) {
-        writePropertyInternal(PropertyIdentifier.enable, Boolean.valueOf(enabled));
-    }
-
     @Override
-    protected void beforeReadProperty(PropertyIdentifier pid) throws BACnetServiceException {
-        if (PropertyIdentifier.logBuffer.equals(pid)) {
-            throw new BACnetServiceException(ErrorClass.property, ErrorCode.readAccessDenied);
-        }
-    }
-
-    @Override
-    protected boolean validateProperty(ValueSource valueSource, PropertyValue value) throws BACnetServiceException {
-        if (PropertyIdentifier.enable.equals(value.getPropertyIdentifier())) {
-            Boolean enable = value.getValue();
-            Boolean stopWhenFull = get(PropertyIdentifier.stopWhenFull);
-            Unsigned32 bufferSize = get(PropertyIdentifier.bufferSize);
-
-            if (enable.booleanValue() && stopWhenFull.booleanValue() && bufferSize.intValue() == buffer.size()) {
-                throw new BACnetServiceException(ErrorClass.object, ErrorCode.logBufferFull);
-            }
-
-        } else if (PropertyIdentifier.startTime.equals(value.getPropertyIdentifier()) //
-                || PropertyIdentifier.stopTime.equals(value.getPropertyIdentifier())) {
-            // Ensure that the date time is either entirely unspecified or entirely specified.
-            DateTime dt = value.getValue();
-            if (dt.equals(DateTime.UNSPECIFIED))
-                return false;
-
-            if (!dt.isFullySpecified())
-                throw new BACnetServiceException(ErrorClass.property, ErrorCode.parameterOutOfRange);
-
-        } else if (PropertyIdentifier.bufferSize.equals(value.getPropertyIdentifier())) {
-            Boolean enable = get(PropertyIdentifier.enable);
-            if (enable.booleanValue()) {
-                throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
-            }
-        } else if (PropertyIdentifier.recordCount.equals(value.getPropertyIdentifier())) {
-            // Only allowed to write a zero to this record. What would any other value do?
-            Unsigned32 recordCount = value.getValue();
-            if (recordCount.intValue() != 0)
-                throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
-        }
-        return false;
+    protected int bufferSize() {
+        return buffer.size();
     }
 
     @Override
     protected void afterWriteProperty(PropertyIdentifier pid, Encodable oldValue, Encodable newValue) {
-        if (PropertyIdentifier.enable.equals(pid)) {
-            evaluateLogDisabled();
-        } else if (PropertyIdentifier.startTime.equals(pid)) {
-            updateStartTime((DateTime) newValue);
-        } else if (PropertyIdentifier.stopTime.equals(pid)) {
-            updateStopTime((DateTime) newValue);
-
-        } else if (PropertyIdentifier.stopWhenFull.equals(pid)) {
+        super.afterWriteProperty(pid, oldValue, newValue);
+        if (PropertyIdentifier.stopWhenFull.equals(pid)) {
             Boolean oldStopWhenFull = (Boolean) oldValue;
             Boolean stopWhenFull = (Boolean) newValue;
             if (!oldStopWhenFull.booleanValue() && stopWhenFull.booleanValue()) {
@@ -260,7 +132,6 @@ public class EventLogObject extends BACnetObject {
                     writePropertyInternal(PropertyIdentifier.enable, Boolean.FALSE);
                 }
             }
-
         } else if (PropertyIdentifier.bufferSize.equals(pid)) {
             Unsigned32 bufferSize = (Unsigned32) newValue;
             // In case the buffer size was reduced, remove extra entries in the buffer.
@@ -269,16 +140,11 @@ public class EventLogObject extends BACnetObject {
                     buffer.remove();
             }
             updateRecordCount();
-
-        } else if (PropertyIdentifier.recordCount.equals(pid)) {
-            Unsigned32 recordCount = (Unsigned32) newValue;
-            if (recordCount.intValue() == 0)
-                purge();
-
         }
     }
 
-    private void purge() {
+    @Override
+    protected void purge() {
         synchronized (buffer) {
             buffer.clear();
         }
@@ -286,40 +152,10 @@ public class EventLogObject extends BACnetObject {
         addLogRecordImpl(new EventLogRecord(getNow(), new LogStatus(logDisabled, true, false)));
     }
 
-    private void updateStartTime(DateTime startTime) {
-        cancelFuture(startTimeFuture);
-        if (!startTime.equals(DateTime.UNSPECIFIED)) {
-            DateTime now = getNow();
-            long diff = startTime.getGC().getTimeInMillis() - now.getGC().getTimeInMillis();
-            if (diff > 0) {
-                startTimeFuture = getLocalDevice().schedule(this::evaluateLogDisabled, diff, TimeUnit.MILLISECONDS);
-            }
-        }
-        evaluateLogDisabled();
-    }
-
-    private void updateStopTime(DateTime stopTime) {
-        cancelFuture(stopTimeFuture);
-        if (!stopTime.equals(DateTime.UNSPECIFIED)) {
-            DateTime now = getNow();
-            long diff = stopTime.getGC().getTimeInMillis() - now.getGC().getTimeInMillis();
-            if (diff > 0) {
-                stopTimeFuture = getLocalDevice().schedule(this::evaluateLogDisabled, diff, TimeUnit.MILLISECONDS);
-            }
-        }
-        evaluateLogDisabled();
-    }
-
     @Override
     protected void terminateImpl() {
-        cancelFuture(startTimeFuture);
-        cancelFuture(stopTimeFuture);
+        super.terminateImpl();
         getLocalDevice().getEventHandler().removeListener(eventListener);
-    }
-
-    private static void cancelFuture(ScheduledFuture<?> future) {
-        if (future != null)
-            future.cancel(false);
     }
 
     private synchronized void addLogRecord(EventLogRecord rec) {
@@ -331,15 +167,6 @@ public class EventLogObject extends BACnetObject {
         addLogRecordImpl(rec);
 
         fullCheck();
-    }
-
-    private void fullCheck() {
-        Boolean stopWhenFull = get(PropertyIdentifier.stopWhenFull);
-        Unsigned32 bufferSize = get(PropertyIdentifier.bufferSize);
-        if (stopWhenFull.booleanValue() && buffer.size() == bufferSize.intValue() - 1) {
-            // There is only one spot left in the buffer, and StopWhenFull is true. Set Enable to false.
-            writePropertyInternal(PropertyIdentifier.enable, Boolean.FALSE);
-        }
     }
 
     private void addLogRecordImpl(EventLogRecord rec) {
@@ -372,37 +199,8 @@ public class EventLogObject extends BACnetObject {
         writePropertyInternal(PropertyIdentifier.totalRecordCount, totalRecordCount);
     }
 
-    /**
-     * Determines whether logging should be performed based upon Enable, StartTime, and StopTime.
-     */
-    private boolean allowLogging(DateTime now) {
-        Boolean enabled = get(PropertyIdentifier.enable);
-        if (!enabled.booleanValue())
-            return false;
-
-        DateTime start = get(PropertyIdentifier.startTime);
-        DateTime stop = get(PropertyIdentifier.stopTime);
-
-        if (!start.equals(DateTime.UNSPECIFIED)) {
-            LOG.info("Checking start time");
-            if (now.compareTo(start) < 0)
-                return false;
-        }
-
-        if (!stop.equals(DateTime.UNSPECIFIED)) {
-            LOG.info("Checking stop time");
-            if (now.compareTo(stop) >= 0)
-                return false;
-        }
-
-        return true;
-    }
-
-    private void updateRecordCount() {
-        writePropertyInternal(PropertyIdentifier.recordCount, new Unsigned32(buffer.size()));
-    }
-
-    private void evaluateLogDisabled() {
+    @Override
+    protected void evaluateLogDisabled() {
         // Don't evaluate until instantiation is complete.
         if (buffer != null) {
             DateTime now = getNow();
@@ -414,9 +212,5 @@ public class EventLogObject extends BACnetObject {
                     addLogRecordImpl(new EventLogRecord(now, new LogStatus(logDisabled, false, false)));
             }
         }
-    }
-
-    private DateTime getNow() {
-        return new DateTime(getLocalDevice().getClock().millis());
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/obj/EventLogObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/EventLogObject.java
@@ -67,6 +67,7 @@ import com.serotonin.bacnet4j.type.notificationParameters.NotificationParameters
 import com.serotonin.bacnet4j.type.primitive.Boolean;
 import com.serotonin.bacnet4j.type.primitive.CharacterString;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
+import com.serotonin.bacnet4j.type.primitive.Unsigned32;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
 /**
@@ -77,7 +78,7 @@ public class EventLogObject extends BACnetObject {
     static final Logger LOG = LoggerFactory.getLogger(EventLogObject.class);
 
     // CreateObject constructor
-    public static EventLogObject create(final LocalDevice localDevice, final int instanceNumber) {
+    public static EventLogObject create(LocalDevice localDevice, int instanceNumber) {
         return new EventLogObject(localDevice, instanceNumber, ObjectType.eventLog.toString() + " " + instanceNumber,
                 new LinkedListLogBuffer<>(), false, DateTime.UNSPECIFIED, DateTime.UNSPECIFIED, false, 100) //
                 .supportIntrinsicReporting(20, 0, new EventTransitionBits(false, false, false),
@@ -94,9 +95,9 @@ public class EventLogObject extends BACnetObject {
     /**
      * Log buffers are expected to have been initialized to their buffer size.
      */
-    public EventLogObject(final LocalDevice localDevice, final int instanceNumber, final String name,
-            final LogBuffer<EventLogRecord> buffer, final boolean enable, final DateTime startTime,
-            final DateTime stopTime, final boolean stopWhenFull, final int bufferSize) {
+    public EventLogObject(LocalDevice localDevice, int instanceNumber, String name,
+            LogBuffer<EventLogRecord> buffer, boolean enable, DateTime startTime,
+            DateTime stopTime, boolean stopWhenFull, int bufferSize) {
         super(localDevice, ObjectType.eventLog, instanceNumber, name);
 
         Objects.requireNonNull(localDevice);
@@ -108,10 +109,10 @@ public class EventLogObject extends BACnetObject {
         set(PropertyIdentifier.startTime, startTime);
         set(PropertyIdentifier.stopTime, stopTime);
         set(PropertyIdentifier.stopWhenFull, Boolean.valueOf(stopWhenFull));
-        set(PropertyIdentifier.bufferSize, new UnsignedInteger(bufferSize));
+        set(PropertyIdentifier.bufferSize, new Unsigned32(bufferSize));
         set(PropertyIdentifier.logBuffer, buffer);
-        set(PropertyIdentifier.recordCount, UnsignedInteger.ZERO);
-        set(PropertyIdentifier.totalRecordCount, UnsignedInteger.ZERO);
+        set(PropertyIdentifier.recordCount, Unsigned32.ZERO);
+        set(PropertyIdentifier.totalRecordCount, Unsigned32.ZERO);
         set(PropertyIdentifier.statusFlags, new StatusFlags(false, false, false, false));
         set(PropertyIdentifier.reliability, Reliability.noFaultDetected);
 
@@ -128,12 +129,12 @@ public class EventLogObject extends BACnetObject {
 
         eventListener = new DeviceEventAdapter() {
             @Override
-            public void eventNotificationReceived(final UnsignedInteger processIdentifier,
-                    final ObjectIdentifier initiatingDeviceIdentifier, final ObjectIdentifier eventObjectIdentifier,
-                    final TimeStamp timeStamp, final UnsignedInteger notificationClass, final UnsignedInteger priority,
-                    final EventType eventType, final CharacterString messageText, final NotifyType notifyType,
-                    final Boolean ackRequired, final EventState fromState, final EventState toState,
-                    final NotificationParameters eventValues) {
+            public void eventNotificationReceived(UnsignedInteger processIdentifier,
+                    ObjectIdentifier initiatingDeviceIdentifier, ObjectIdentifier eventObjectIdentifier,
+                    TimeStamp timeStamp, UnsignedInteger notificationClass, UnsignedInteger priority,
+                    EventType eventType, CharacterString messageText, NotifyType notifyType,
+                    Boolean ackRequired, EventState fromState, EventState toState,
+                    NotificationParameters eventValues) {
                 addLogRecord(new EventLogRecord(getNow(),
                         new ConfirmedEventNotificationRequest(processIdentifier, initiatingDeviceIdentifier,
                                 eventObjectIdentifier, timeStamp, notificationClass, priority, eventType, messageText,
@@ -143,28 +144,28 @@ public class EventLogObject extends BACnetObject {
         localDevice.getEventHandler().addListener(eventListener);
     }
 
-    public EventLogObject supportIntrinsicReporting(final int notificationThreshold, final int notificationClass,
-            final EventTransitionBits eventEnable, final NotifyType notifyType) {
+    public EventLogObject supportIntrinsicReporting(int notificationThreshold, int notificationClass,
+            EventTransitionBits eventEnable, NotifyType notifyType) {
         Objects.requireNonNull(eventEnable);
         Objects.requireNonNull(notifyType);
 
         // Prepare the object with all of the properties that intrinsic reporting will need.
         // User-defined properties
-        writePropertyInternal(PropertyIdentifier.notificationThreshold, new UnsignedInteger(notificationThreshold));
-        writePropertyInternal(PropertyIdentifier.recordsSinceNotification, UnsignedInteger.ZERO);
-        writePropertyInternal(PropertyIdentifier.lastNotifyRecord, UnsignedInteger.ZERO);
+        writePropertyInternal(PropertyIdentifier.notificationThreshold, new Unsigned32(notificationThreshold));
+        writePropertyInternal(PropertyIdentifier.recordsSinceNotification, Unsigned32.ZERO);
+        writePropertyInternal(PropertyIdentifier.lastNotifyRecord, Unsigned32.ZERO);
         writePropertyInternal(PropertyIdentifier.eventState, EventState.normal);
         writePropertyInternal(PropertyIdentifier.notificationClass, new UnsignedInteger(notificationClass));
         writePropertyInternal(PropertyIdentifier.eventEnable, eventEnable);
         writePropertyInternal(PropertyIdentifier.notifyType, notifyType);
         writePropertyInternal(PropertyIdentifier.eventDetectionEnable, Boolean.TRUE);
 
-        final BufferReadyAlgo algo = new BufferReadyAlgo(PropertyIdentifier.totalRecordCount,
+        BufferReadyAlgo algo = new BufferReadyAlgo(PropertyIdentifier.totalRecordCount,
                 new DeviceObjectPropertyReference(getId(), PropertyIdentifier.logBuffer, null,
                         getLocalDevice().getId()),
                 PropertyIdentifier.notificationThreshold, PropertyIdentifier.lastNotifyRecord);
 
-        final PropertyIdentifier[] triggerProps = new PropertyIdentifier[] { //
+        PropertyIdentifier[] triggerProps = new PropertyIdentifier[] { //
                 PropertyIdentifier.totalRecordCount, //
                 PropertyIdentifier.notificationThreshold};
 
@@ -172,9 +173,10 @@ public class EventLogObject extends BACnetObject {
         addMixin(new IntrinsicReportingMixin(this, algo, null, PropertyIdentifier.totalRecordCount, triggerProps)
                 .withPostNotificationAction(notifParams -> {
                     // After a notification has been sent, a couple values need to be updated.
-                    final BufferReadyNotif brn = (BufferReadyNotif) notifParams.getParameter();
-                    writePropertyInternal(PropertyIdentifier.lastNotifyRecord, brn.getCurrentNotification());
-                    writePropertyInternal(PropertyIdentifier.recordsSinceNotification, UnsignedInteger.ZERO);
+                    BufferReadyNotif brn = notifParams.getParameter();
+                    writePropertyInternal(PropertyIdentifier.lastNotifyRecord,
+                            new Unsigned32(brn.getCurrentNotification()));
+                    writePropertyInternal(PropertyIdentifier.recordsSinceNotification, Unsigned32.ZERO);
                 }));
 
         return this;
@@ -188,24 +190,23 @@ public class EventLogObject extends BACnetObject {
         return buffer;
     }
 
-    public void setEnabled(final boolean enabled) {
+    public void setEnabled(boolean enabled) {
         writePropertyInternal(PropertyIdentifier.enable, Boolean.valueOf(enabled));
     }
 
     @Override
-    protected void beforeReadProperty(final PropertyIdentifier pid) throws BACnetServiceException {
+    protected void beforeReadProperty(PropertyIdentifier pid) throws BACnetServiceException {
         if (PropertyIdentifier.logBuffer.equals(pid)) {
             throw new BACnetServiceException(ErrorClass.property, ErrorCode.readAccessDenied);
         }
     }
 
     @Override
-    protected boolean validateProperty(final ValueSource valueSource, final PropertyValue value)
-            throws BACnetServiceException {
+    protected boolean validateProperty(ValueSource valueSource, PropertyValue value) throws BACnetServiceException {
         if (PropertyIdentifier.enable.equals(value.getPropertyIdentifier())) {
-            final Boolean enable = value.getValue();
-            final Boolean stopWhenFull = get(PropertyIdentifier.stopWhenFull);
-            final UnsignedInteger bufferSize = get(PropertyIdentifier.bufferSize);
+            Boolean enable = value.getValue();
+            Boolean stopWhenFull = get(PropertyIdentifier.stopWhenFull);
+            Unsigned32 bufferSize = get(PropertyIdentifier.bufferSize);
 
             if (enable.booleanValue() && stopWhenFull.booleanValue() && bufferSize.intValue() == buffer.size()) {
                 throw new BACnetServiceException(ErrorClass.object, ErrorCode.logBufferFull);
@@ -214,7 +215,7 @@ public class EventLogObject extends BACnetObject {
         } else if (PropertyIdentifier.startTime.equals(value.getPropertyIdentifier()) //
                 || PropertyIdentifier.stopTime.equals(value.getPropertyIdentifier())) {
             // Ensure that the date time is either entirely unspecified or entirely specified.
-            final DateTime dt = value.getValue();
+            DateTime dt = value.getValue();
             if (dt.equals(DateTime.UNSPECIFIED))
                 return false;
 
@@ -222,13 +223,13 @@ public class EventLogObject extends BACnetObject {
                 throw new BACnetServiceException(ErrorClass.property, ErrorCode.parameterOutOfRange);
 
         } else if (PropertyIdentifier.bufferSize.equals(value.getPropertyIdentifier())) {
-            final Boolean enable = get(PropertyIdentifier.enable);
+            Boolean enable = get(PropertyIdentifier.enable);
             if (enable.booleanValue()) {
                 throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
             }
         } else if (PropertyIdentifier.recordCount.equals(value.getPropertyIdentifier())) {
             // Only allowed to write a zero to this record. What would any other value do?
-            final UnsignedInteger recordCount = value.getValue();
+            Unsigned32 recordCount = value.getValue();
             if (recordCount.intValue() != 0)
                 throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
         }
@@ -236,8 +237,7 @@ public class EventLogObject extends BACnetObject {
     }
 
     @Override
-    protected void afterWriteProperty(final PropertyIdentifier pid, final Encodable oldValue,
-            final Encodable newValue) {
+    protected void afterWriteProperty(PropertyIdentifier pid, Encodable oldValue, Encodable newValue) {
         if (PropertyIdentifier.enable.equals(pid)) {
             evaluateLogDisabled();
         } else if (PropertyIdentifier.startTime.equals(pid)) {
@@ -246,11 +246,11 @@ public class EventLogObject extends BACnetObject {
             updateStopTime((DateTime) newValue);
 
         } else if (PropertyIdentifier.stopWhenFull.equals(pid)) {
-            final Boolean oldStopWhenFull = (Boolean) oldValue;
-            final Boolean stopWhenFull = (Boolean) newValue;
+            Boolean oldStopWhenFull = (Boolean) oldValue;
+            Boolean stopWhenFull = (Boolean) newValue;
             if (!oldStopWhenFull.booleanValue() && stopWhenFull.booleanValue()) {
                 // Turning StopWhenFull on.
-                final UnsignedInteger bufferSize = get(PropertyIdentifier.bufferSize);
+                Unsigned32 bufferSize = get(PropertyIdentifier.bufferSize);
                 if (buffer.size() >= bufferSize.intValue()) {
                     synchronized (buffer) {
                         while (buffer.size() >= bufferSize.intValue())
@@ -262,7 +262,7 @@ public class EventLogObject extends BACnetObject {
             }
 
         } else if (PropertyIdentifier.bufferSize.equals(pid)) {
-            final UnsignedInteger bufferSize = (UnsignedInteger) newValue;
+            Unsigned32 bufferSize = (Unsigned32) newValue;
             // In case the buffer size was reduced, remove extra entries in the buffer.
             synchronized (buffer) {
                 while (buffer.size() >= bufferSize.intValue())
@@ -271,7 +271,7 @@ public class EventLogObject extends BACnetObject {
             updateRecordCount();
 
         } else if (PropertyIdentifier.recordCount.equals(pid)) {
-            final UnsignedInteger recordCount = (UnsignedInteger) newValue;
+            Unsigned32 recordCount = (Unsigned32) newValue;
             if (recordCount.intValue() == 0)
                 purge();
 
@@ -282,15 +282,15 @@ public class EventLogObject extends BACnetObject {
         synchronized (buffer) {
             buffer.clear();
         }
-        writePropertyInternal(PropertyIdentifier.recordsSinceNotification, UnsignedInteger.ZERO);
+        writePropertyInternal(PropertyIdentifier.recordsSinceNotification, Unsigned32.ZERO);
         addLogRecordImpl(new EventLogRecord(getNow(), new LogStatus(logDisabled, true, false)));
     }
 
-    private void updateStartTime(final DateTime startTime) {
+    private void updateStartTime(DateTime startTime) {
         cancelFuture(startTimeFuture);
         if (!startTime.equals(DateTime.UNSPECIFIED)) {
-            final DateTime now = getNow();
-            final long diff = startTime.getGC().getTimeInMillis() - now.getGC().getTimeInMillis();
+            DateTime now = getNow();
+            long diff = startTime.getGC().getTimeInMillis() - now.getGC().getTimeInMillis();
             if (diff > 0) {
                 startTimeFuture = getLocalDevice().schedule(this::evaluateLogDisabled, diff, TimeUnit.MILLISECONDS);
             }
@@ -298,11 +298,11 @@ public class EventLogObject extends BACnetObject {
         evaluateLogDisabled();
     }
 
-    private void updateStopTime(final DateTime stopTime) {
+    private void updateStopTime(DateTime stopTime) {
         cancelFuture(stopTimeFuture);
         if (!stopTime.equals(DateTime.UNSPECIFIED)) {
-            final DateTime now = getNow();
-            final long diff = stopTime.getGC().getTimeInMillis() - now.getGC().getTimeInMillis();
+            DateTime now = getNow();
+            long diff = stopTime.getGC().getTimeInMillis() - now.getGC().getTimeInMillis();
             if (diff > 0) {
                 stopTimeFuture = getLocalDevice().schedule(this::evaluateLogDisabled, diff, TimeUnit.MILLISECONDS);
             }
@@ -317,12 +317,12 @@ public class EventLogObject extends BACnetObject {
         getLocalDevice().getEventHandler().removeListener(eventListener);
     }
 
-    private static void cancelFuture(final ScheduledFuture<?> future) {
+    private static void cancelFuture(ScheduledFuture<?> future) {
         if (future != null)
             future.cancel(false);
     }
 
-    private synchronized void addLogRecord(final EventLogRecord rec) {
+    private synchronized void addLogRecord(EventLogRecord rec) {
         // Check if logging is allowed.
         if (logDisabled)
             return;
@@ -334,16 +334,16 @@ public class EventLogObject extends BACnetObject {
     }
 
     private void fullCheck() {
-        final Boolean stopWhenFull = get(PropertyIdentifier.stopWhenFull);
-        final UnsignedInteger bufferSize = get(PropertyIdentifier.bufferSize);
+        Boolean stopWhenFull = get(PropertyIdentifier.stopWhenFull);
+        Unsigned32 bufferSize = get(PropertyIdentifier.bufferSize);
         if (stopWhenFull.booleanValue() && buffer.size() == bufferSize.intValue() - 1) {
             // There is only one spot left in the buffer, and StopWhenFull is true. Set Enable to false.
             writePropertyInternal(PropertyIdentifier.enable, Boolean.FALSE);
         }
     }
 
-    private void addLogRecordImpl(final EventLogRecord rec) {
-        final UnsignedInteger bufferSize = get(PropertyIdentifier.bufferSize);
+    private void addLogRecordImpl(EventLogRecord rec) {
+        Unsigned32 bufferSize = get(PropertyIdentifier.bufferSize);
 
         synchronized (buffer) {
             // Don't add more to the buffer than capacity.
@@ -357,17 +357,17 @@ public class EventLogObject extends BACnetObject {
 
         updateRecordCount();
 
-        final UnsignedInteger recordsSinceNotification = get(PropertyIdentifier.recordsSinceNotification);
+        Unsigned32 recordsSinceNotification = get(PropertyIdentifier.recordsSinceNotification);
         if (recordsSinceNotification != null) {
-            writePropertyInternal(PropertyIdentifier.recordsSinceNotification, recordsSinceNotification.increment32());
+            writePropertyInternal(PropertyIdentifier.recordsSinceNotification, recordsSinceNotification.increment());
         }
 
         // The total record count must be written last because it is the monitored property for intrinsic reporting.
-        UnsignedInteger totalRecordCount = get(PropertyIdentifier.totalRecordCount);
-        totalRecordCount = totalRecordCount.increment32();
+        Unsigned32 totalRecordCount = get(PropertyIdentifier.totalRecordCount);
+        totalRecordCount = totalRecordCount.increment();
         if (totalRecordCount.longValue() == 0)
             // Value overflowed. As per 12.27.15 set to 1.
-            totalRecordCount = new UnsignedInteger(1);
+            totalRecordCount = new Unsigned32(1);
         rec.setSequenceNumber(totalRecordCount.longValue());
         writePropertyInternal(PropertyIdentifier.totalRecordCount, totalRecordCount);
     }
@@ -375,13 +375,13 @@ public class EventLogObject extends BACnetObject {
     /**
      * Determines whether logging should be performed based upon Enable, StartTime, and StopTime.
      */
-    private boolean allowLogging(final DateTime now) {
-        final Boolean enabled = get(PropertyIdentifier.enable);
+    private boolean allowLogging(DateTime now) {
+        Boolean enabled = get(PropertyIdentifier.enable);
         if (!enabled.booleanValue())
             return false;
 
-        final DateTime start = get(PropertyIdentifier.startTime);
-        final DateTime stop = get(PropertyIdentifier.stopTime);
+        DateTime start = get(PropertyIdentifier.startTime);
+        DateTime stop = get(PropertyIdentifier.stopTime);
 
         if (!start.equals(DateTime.UNSPECIFIED)) {
             LOG.info("Checking start time");
@@ -399,14 +399,14 @@ public class EventLogObject extends BACnetObject {
     }
 
     private void updateRecordCount() {
-        writePropertyInternal(PropertyIdentifier.recordCount, new UnsignedInteger(buffer.size()));
+        writePropertyInternal(PropertyIdentifier.recordCount, new Unsigned32(buffer.size()));
     }
 
     private void evaluateLogDisabled() {
         // Don't evaluate until instantiation is complete.
         if (buffer != null) {
-            final DateTime now = getNow();
-            final boolean newValue = !allowLogging(now);
+            DateTime now = getNow();
+            boolean newValue = !allowLogging(now);
             if (logDisabled != newValue) {
                 logDisabled = newValue;
                 if (logDisabled)

--- a/src/main/java/com/serotonin/bacnet4j/obj/EventLogObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/EventLogObject.java
@@ -27,8 +27,11 @@
 
 package com.serotonin.bacnet4j.obj;
 
+import java.util.function.Consumer;
+
 import com.serotonin.bacnet4j.LocalDevice;
 import com.serotonin.bacnet4j.event.DeviceEventAdapter;
+import com.serotonin.bacnet4j.obj.logBuffer.ILogRecord;
 import com.serotonin.bacnet4j.obj.logBuffer.LinkedListLogBuffer;
 import com.serotonin.bacnet4j.obj.logBuffer.LogBuffer;
 import com.serotonin.bacnet4j.service.confirmed.ConfirmedEventNotificationRequest;
@@ -51,7 +54,6 @@ import com.serotonin.bacnet4j.type.primitive.Unsigned32;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
 public class EventLogObject extends LogBase {
-
     // CreateObject constructor
     public static EventLogObject create(LocalDevice localDevice, int instanceNumber) {
         return new EventLogObject(localDevice, instanceNumber, ObjectType.eventLog.toString() + " " + instanceNumber,
@@ -97,6 +99,18 @@ public class EventLogObject extends LogBase {
             }
         };
         localDevice.getEventHandler().addListener(eventListener);
+    }
+
+    /**
+     * Allows the consumer to work with the buffer in a thread-safe manner.
+     *
+     * @param consumer the work to do while synchronized.
+     */
+    @SuppressWarnings("unchecked")
+    public <E extends ILogRecord> void doWithBuffer(Consumer<LogBuffer<E>> consumer) {
+        synchronized (buffer) {
+            consumer.accept((LogBuffer<E>) buffer);
+        }
     }
 
     public EventLogObject supportIntrinsicReporting(int notificationThreshold, int notificationClass,
@@ -167,36 +181,6 @@ public class EventLogObject extends LogBase {
         addLogRecordImpl(rec);
 
         fullCheck();
-    }
-
-    private void addLogRecordImpl(EventLogRecord rec) {
-        Unsigned32 bufferSize = get(PropertyIdentifier.bufferSize);
-
-        synchronized (buffer) {
-            // Don't add more to the buffer than capacity.
-            if (buffer.size() == bufferSize.intValue()) {
-                // Buffer is already full. Drop the oldest record.
-                buffer.remove();
-            }
-
-            buffer.add(rec);
-        }
-
-        updateRecordCount();
-
-        Unsigned32 recordsSinceNotification = get(PropertyIdentifier.recordsSinceNotification);
-        if (recordsSinceNotification != null) {
-            writePropertyInternal(PropertyIdentifier.recordsSinceNotification, recordsSinceNotification.increment());
-        }
-
-        // The total record count must be written last because it is the monitored property for intrinsic reporting.
-        Unsigned32 totalRecordCount = get(PropertyIdentifier.totalRecordCount);
-        totalRecordCount = totalRecordCount.increment();
-        if (totalRecordCount.longValue() == 0)
-            // Value overflowed. As per 12.27.15 set to 1.
-            totalRecordCount = new Unsigned32(1);
-        rec.setSequenceNumber(totalRecordCount.longValue());
-        writePropertyInternal(PropertyIdentifier.totalRecordCount, totalRecordCount);
     }
 
     @Override

--- a/src/main/java/com/serotonin/bacnet4j/obj/LogBase.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/LogBase.java
@@ -1,0 +1,279 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2026 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
+package com.serotonin.bacnet4j.obj;
+
+import java.util.Objects;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import com.serotonin.bacnet4j.LocalDevice;
+import com.serotonin.bacnet4j.exception.BACnetServiceException;
+import com.serotonin.bacnet4j.obj.mixin.HasStatusFlagsMixin;
+import com.serotonin.bacnet4j.obj.mixin.ReadOnlyPropertyMixin;
+import com.serotonin.bacnet4j.obj.mixin.event.IntrinsicReportingMixin;
+import com.serotonin.bacnet4j.obj.mixin.event.eventAlgo.BufferReadyAlgo;
+import com.serotonin.bacnet4j.type.Encodable;
+import com.serotonin.bacnet4j.type.constructed.DateTime;
+import com.serotonin.bacnet4j.type.constructed.DeviceObjectPropertyReference;
+import com.serotonin.bacnet4j.type.constructed.EventTransitionBits;
+import com.serotonin.bacnet4j.type.constructed.PropertyValue;
+import com.serotonin.bacnet4j.type.constructed.StatusFlags;
+import com.serotonin.bacnet4j.type.constructed.ValueSource;
+import com.serotonin.bacnet4j.type.enumerated.ErrorClass;
+import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
+import com.serotonin.bacnet4j.type.enumerated.EventState;
+import com.serotonin.bacnet4j.type.enumerated.NotifyType;
+import com.serotonin.bacnet4j.type.enumerated.ObjectType;
+import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
+import com.serotonin.bacnet4j.type.enumerated.Reliability;
+import com.serotonin.bacnet4j.type.notificationParameters.BufferReadyNotif;
+import com.serotonin.bacnet4j.type.primitive.Boolean;
+import com.serotonin.bacnet4j.type.primitive.Unsigned32;
+import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
+
+/**
+ * Common base for log objects (Trend Log, Trend Log Multiple, Event Log). Handles the properties
+ * and behaviors shared by all buffered log types: Enable / Start_Time / Stop_Time scheduling,
+ * Buffer_Size / Record_Count validation, the mixin setup, and the intrinsic-reporting scaffolding.
+ */
+public abstract class LogBase extends BACnetObject {
+    protected boolean logDisabled;
+    protected ScheduledFuture<?> startTimeFuture;
+    protected ScheduledFuture<?> stopTimeFuture;
+
+    protected LogBase(LocalDevice localDevice, ObjectType type, int instanceNumber, String name, boolean enable,
+            DateTime startTime, DateTime stopTime, boolean stopWhenFull, int bufferSize) {
+        super(localDevice, type, instanceNumber, name);
+
+        Objects.requireNonNull(localDevice);
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(startTime);
+        Objects.requireNonNull(stopTime);
+
+        set(PropertyIdentifier.enable, Boolean.valueOf(enable));
+        set(PropertyIdentifier.startTime, startTime);
+        set(PropertyIdentifier.stopTime, stopTime);
+        set(PropertyIdentifier.stopWhenFull, Boolean.valueOf(stopWhenFull));
+        set(PropertyIdentifier.bufferSize, new Unsigned32(bufferSize));
+        set(PropertyIdentifier.recordCount, Unsigned32.ZERO);
+        set(PropertyIdentifier.totalRecordCount, Unsigned32.ZERO);
+        set(PropertyIdentifier.statusFlags, new StatusFlags(false, false, false, false));
+        set(PropertyIdentifier.reliability, Reliability.noFaultDetected);
+    }
+
+    /**
+     * Adds the {@link HasStatusFlagsMixin} and a {@link ReadOnlyPropertyMixin} for
+     * {@code Log_Buffer}, {@code Reliability}, and {@code Total_Record_Count}. Subclasses call
+     * this from their own construction sequence.
+     */
+    protected void addLogMixins() {
+        addMixin(new HasStatusFlagsMixin(this));
+        addMixin(new ReadOnlyPropertyMixin(this, PropertyIdentifier.logBuffer, PropertyIdentifier.reliability,
+                PropertyIdentifier.totalRecordCount));
+    }
+
+    protected void baseSupportIntrinsicReporting(int notificationThreshold, int notificationClass,
+            EventTransitionBits eventEnable, NotifyType notifyType) {
+        Objects.requireNonNull(eventEnable);
+        Objects.requireNonNull(notifyType);
+
+        writePropertyInternal(PropertyIdentifier.notificationThreshold, new Unsigned32(notificationThreshold));
+        writePropertyInternal(PropertyIdentifier.recordsSinceNotification, Unsigned32.ZERO);
+        writePropertyInternal(PropertyIdentifier.lastNotifyRecord, Unsigned32.ZERO);
+        writePropertyInternal(PropertyIdentifier.eventState, EventState.normal);
+        writePropertyInternal(PropertyIdentifier.notificationClass, new UnsignedInteger(notificationClass));
+        writePropertyInternal(PropertyIdentifier.eventEnable, eventEnable);
+        writePropertyInternal(PropertyIdentifier.notifyType, notifyType);
+        writePropertyInternal(PropertyIdentifier.eventDetectionEnable, Boolean.TRUE);
+
+        BufferReadyAlgo algo = new BufferReadyAlgo(PropertyIdentifier.totalRecordCount,
+                new DeviceObjectPropertyReference(getId(), PropertyIdentifier.logBuffer, null,
+                        getLocalDevice().getId()),
+                PropertyIdentifier.notificationThreshold, PropertyIdentifier.lastNotifyRecord);
+
+        PropertyIdentifier[] triggerProps = new PropertyIdentifier[] { //
+                PropertyIdentifier.totalRecordCount, //
+                PropertyIdentifier.notificationThreshold};
+
+        addMixin(new IntrinsicReportingMixin(this, algo, null, PropertyIdentifier.totalRecordCount, triggerProps)
+                .withPostNotificationAction(notifParams -> {
+                    if (notifParams.getParameter() instanceof BufferReadyNotif brn) {
+                        writePropertyInternal(PropertyIdentifier.lastNotifyRecord,
+                                new Unsigned32(brn.getCurrentNotification()));
+                        writePropertyInternal(PropertyIdentifier.recordsSinceNotification, Unsigned32.ZERO);
+                    }
+                }));
+    }
+
+    public boolean isLogDisabled() {
+        return logDisabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        writePropertyInternal(PropertyIdentifier.enable, Boolean.valueOf(enabled));
+    }
+
+    protected void updateStartTime(DateTime startTime) {
+        cancelFuture(startTimeFuture);
+        if (!startTime.equals(DateTime.UNSPECIFIED)) {
+            DateTime now = getNow();
+            long diff = startTime.getGC().getTimeInMillis() - now.getGC().getTimeInMillis();
+            if (diff > 0) {
+                startTimeFuture = getLocalDevice().schedule(this::evaluateLogDisabled, diff, TimeUnit.MILLISECONDS);
+            }
+        }
+        evaluateLogDisabled();
+    }
+
+    protected void updateStopTime(DateTime stopTime) {
+        cancelFuture(stopTimeFuture);
+        if (!stopTime.equals(DateTime.UNSPECIFIED)) {
+            DateTime now = getNow();
+            long diff = stopTime.getGC().getTimeInMillis() - now.getGC().getTimeInMillis();
+            if (diff > 0) {
+                stopTimeFuture = getLocalDevice().schedule(this::evaluateLogDisabled, diff, TimeUnit.MILLISECONDS);
+            }
+        }
+        evaluateLogDisabled();
+    }
+
+    protected static void cancelFuture(ScheduledFuture<?> future) {
+        if (future != null)
+            future.cancel(false);
+    }
+
+    protected DateTime getNow() {
+        return new DateTime(getLocalDevice().getClock().millis());
+    }
+
+    /**
+     * Returns the current number of records in the buffer. Used by common validation and by
+     * {@link #fullCheck()} / {@link #updateRecordCount()}.
+     */
+    protected abstract int bufferSize();
+
+    /**
+     * Reconsiders the {@code logDisabled} flag based on Enable, Start_Time, and Stop_Time, and
+     * flushes any subclass-specific log-status record if the flag transitions to true.
+     */
+    protected abstract void evaluateLogDisabled();
+
+    protected abstract void purge();
+
+    @Override
+    protected void beforeReadProperty(PropertyIdentifier pid) throws BACnetServiceException {
+        if (PropertyIdentifier.logBuffer.equals(pid)) {
+            throw new BACnetServiceException(ErrorClass.property, ErrorCode.readAccessDenied);
+        }
+    }
+
+    @Override
+    protected boolean validateProperty(ValueSource valueSource, PropertyValue value) throws BACnetServiceException {
+        if (PropertyIdentifier.enable.equals(value.getPropertyIdentifier())) {
+            Boolean enable = value.getValue();
+            Boolean stopWhenFull = get(PropertyIdentifier.stopWhenFull);
+            Unsigned32 bufferSize = get(PropertyIdentifier.bufferSize);
+
+            if (enable.booleanValue() && stopWhenFull.booleanValue() && bufferSize.intValue() == bufferSize()) {
+                throw new BACnetServiceException(ErrorClass.object, ErrorCode.logBufferFull);
+            }
+        } else if (PropertyIdentifier.startTime.equals(value.getPropertyIdentifier()) //
+                || PropertyIdentifier.stopTime.equals(value.getPropertyIdentifier())) {
+            DateTime dt = value.getValue();
+            if (dt.equals(DateTime.UNSPECIFIED))
+                return false;
+            if (!dt.isFullySpecified())
+                throw new BACnetServiceException(ErrorClass.property, ErrorCode.parameterOutOfRange);
+        } else if (PropertyIdentifier.bufferSize.equals(value.getPropertyIdentifier())) {
+            Boolean enable = get(PropertyIdentifier.enable);
+            if (enable.booleanValue()) {
+                throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
+            }
+        } else if (PropertyIdentifier.recordCount.equals(value.getPropertyIdentifier())) {
+            Unsigned32 recordCount = value.getValue();
+            if (recordCount.intValue() != 0)
+                throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
+        }
+        return false;
+    }
+
+    @Override
+    protected void afterWriteProperty(PropertyIdentifier pid, Encodable oldValue, Encodable newValue) {
+        if (PropertyIdentifier.enable.equals(pid)) {
+            evaluateLogDisabled();
+        } else if (PropertyIdentifier.startTime.equals(pid)) {
+            updateStartTime((DateTime) newValue);
+        } else if (PropertyIdentifier.stopTime.equals(pid)) {
+            updateStopTime((DateTime) newValue);
+        } else if (PropertyIdentifier.recordCount.equals(pid)) {
+            Unsigned32 recordCount = (Unsigned32) newValue;
+            if (recordCount.intValue() == 0)
+                purge();
+        }
+    }
+
+    @Override
+    protected void terminateImpl() {
+        cancelFuture(startTimeFuture);
+        cancelFuture(stopTimeFuture);
+    }
+
+    protected void fullCheck() {
+        Boolean stopWhenFull = get(PropertyIdentifier.stopWhenFull);
+        Unsigned32 bufferSize = get(PropertyIdentifier.bufferSize);
+        if (stopWhenFull.booleanValue() && bufferSize() == bufferSize.intValue() - 1) {
+            writePropertyInternal(PropertyIdentifier.enable, Boolean.FALSE);
+        }
+    }
+
+    protected boolean allowLogging(DateTime now) {
+        Boolean enabled = get(PropertyIdentifier.enable);
+        if (!enabled.booleanValue())
+            return false;
+
+        DateTime start = get(PropertyIdentifier.startTime);
+        DateTime stop = get(PropertyIdentifier.stopTime);
+
+        if (!start.equals(DateTime.UNSPECIFIED)) {
+            LOG.debug("Checking start time");
+            if (now.compareTo(start) < 0)
+                return false;
+        }
+
+        if (!stop.equals(DateTime.UNSPECIFIED)) {
+            LOG.debug("Checking stop time, now={}, stop={}", now, stop);
+            return now.compareTo(stop) < 0;
+        }
+
+        return true;
+    }
+
+    protected void updateRecordCount() {
+        writePropertyInternal(PropertyIdentifier.recordCount, new Unsigned32(bufferSize()));
+    }
+}

--- a/src/main/java/com/serotonin/bacnet4j/obj/LogBase.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/LogBase.java
@@ -30,9 +30,12 @@ package com.serotonin.bacnet4j.obj;
 import java.util.Objects;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 import com.serotonin.bacnet4j.LocalDevice;
 import com.serotonin.bacnet4j.exception.BACnetServiceException;
+import com.serotonin.bacnet4j.obj.logBuffer.ILogRecord;
+import com.serotonin.bacnet4j.obj.logBuffer.LogBuffer;
 import com.serotonin.bacnet4j.obj.mixin.HasStatusFlagsMixin;
 import com.serotonin.bacnet4j.obj.mixin.ReadOnlyPropertyMixin;
 import com.serotonin.bacnet4j.obj.mixin.event.IntrinsicReportingMixin;
@@ -275,5 +278,37 @@ public abstract class LogBase extends BACnetObject {
 
     protected void updateRecordCount() {
         writePropertyInternal(PropertyIdentifier.recordCount, new Unsigned32(bufferSize()));
+    }
+
+    public abstract <E extends ILogRecord> void doWithBuffer(Consumer<LogBuffer<E>> consumer);
+
+    protected <E extends ILogRecord> void addLogRecordImpl(E rec) {
+        Unsigned32 bufferSize = get(PropertyIdentifier.bufferSize);
+
+        doWithBuffer(buf -> {
+            // Don't add more to the buffer than capacity.
+            if (buf.size() == bufferSize.intValue()) {
+                // Buffer is already full. Drop the oldest record.
+                buf.remove();
+            }
+
+            buf.add(rec);
+        });
+
+        updateRecordCount();
+
+        Unsigned32 recordsSinceNotification = get(PropertyIdentifier.recordsSinceNotification);
+        if (recordsSinceNotification != null) {
+            writePropertyInternal(PropertyIdentifier.recordsSinceNotification, recordsSinceNotification.increment());
+        }
+
+        // The total record count must be written last because it is the monitored property for intrinsic reporting.
+        Unsigned32 totalRecordCount = get(PropertyIdentifier.totalRecordCount);
+        totalRecordCount = totalRecordCount.increment();
+        if (totalRecordCount.longValue() == 0)
+            // Value overflowed. As per 12.27.15, 12.30.21, 12.25.16 set to 1.
+            totalRecordCount = new Unsigned32(1);
+        rec.setSequenceNumber(totalRecordCount.longValue());
+        writePropertyInternal(PropertyIdentifier.totalRecordCount, totalRecordCount);
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/obj/ObjectProperties.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/ObjectProperties.java
@@ -47,7 +47,8 @@ import com.serotonin.bacnet4j.type.constructed.AuditOperationFlags;
 import com.serotonin.bacnet4j.type.constructed.AuthenticationFactor;
 import com.serotonin.bacnet4j.type.constructed.AuthenticationFactorFormat;
 import com.serotonin.bacnet4j.type.constructed.AuthenticationPolicy;
-import com.serotonin.bacnet4j.type.constructed.AuthorizationScope;
+import com.serotonin.bacnet4j.type.constructed.AuthorizationPolicy;
+import com.serotonin.bacnet4j.type.constructed.AuthorizationScopeDescription;
 import com.serotonin.bacnet4j.type.constructed.AuthorizationServer;
 import com.serotonin.bacnet4j.type.constructed.AuthorizationStatus;
 import com.serotonin.bacnet4j.type.constructed.BDTEntry;
@@ -211,42 +212,42 @@ public class ObjectProperties {
     private static final Map<ObjectType, Map<PropertyIdentifier, ObjectPropertyTypeDefinition>> objectPropertyTypes =
             new HashMap<>();
 
-    public static ObjectPropertyTypeDefinition getObjectPropertyTypeDefinition(final ObjectType objectType,
-            final PropertyIdentifier propertyIdentifier) {
-        final Map<PropertyIdentifier, ObjectPropertyTypeDefinition> props = objectPropertyTypes.get(objectType);
+    public static ObjectPropertyTypeDefinition getObjectPropertyTypeDefinition(ObjectType objectType,
+            PropertyIdentifier propertyIdentifier) {
+        Map<PropertyIdentifier, ObjectPropertyTypeDefinition> props = objectPropertyTypes.get(objectType);
         if (props == null)
             return null;
         return props.get(propertyIdentifier);
     }
 
-    public static ObjectPropertyTypeDefinition getObjectPropertyTypeDefinitionRequired(final ObjectType objectType,
-            final PropertyIdentifier propertyIdentifier) throws BACnetServiceException {
-        final ObjectPropertyTypeDefinition def = getObjectPropertyTypeDefinition(objectType, propertyIdentifier);
+    public static ObjectPropertyTypeDefinition getObjectPropertyTypeDefinitionRequired(ObjectType objectType,
+            PropertyIdentifier propertyIdentifier) throws BACnetServiceException {
+        ObjectPropertyTypeDefinition def = getObjectPropertyTypeDefinition(objectType, propertyIdentifier);
         if (def == null)
             throw new BACnetServiceException(ErrorClass.property, ErrorCode.unknownProperty,
                     objectType + "/" + propertyIdentifier);
         return def;
     }
 
-    public static List<ObjectPropertyTypeDefinition> getObjectPropertyTypeDefinitions(final ObjectType objectType) {
+    public static List<ObjectPropertyTypeDefinition> getObjectPropertyTypeDefinitions(ObjectType objectType) {
         return getObjectPropertyTypeDefinitions(objectType, 0);
     }
 
     public static List<ObjectPropertyTypeDefinition> getRequiredObjectPropertyTypeDefinitions(
-            final ObjectType objectType) {
+            ObjectType objectType) {
         return getObjectPropertyTypeDefinitions(objectType, 1);
     }
 
     public static List<ObjectPropertyTypeDefinition> getOptionalObjectPropertyTypeDefinitions(
-            final ObjectType objectType) {
+            ObjectType objectType) {
         return getObjectPropertyTypeDefinitions(objectType, 2);
     }
 
-    public static PropertyTypeDefinition getPropertyTypeDefinition(final PropertyIdentifier pid) {
+    public static PropertyTypeDefinition getPropertyTypeDefinition(PropertyIdentifier pid) {
         return propertyTypes.get(pid);
     }
 
-    public static boolean isCommandable(final ObjectType type, final PropertyIdentifier pid) {
+    public static boolean isCommandable(ObjectType type, PropertyIdentifier pid) {
         if (!pid.equals(PropertyIdentifier.presentValue))
             return false;
         return type.isOneOf( //
@@ -278,12 +279,12 @@ public class ObjectProperties {
      * @param include    0 = all, 1 = required, 2 = optional
      * @return the list of object property type definitions
      */
-    private static List<ObjectPropertyTypeDefinition> getObjectPropertyTypeDefinitions(final ObjectType objectType,
-            final int include) {
-        final List<ObjectPropertyTypeDefinition> result = new ArrayList<>();
-        final Map<PropertyIdentifier, ObjectPropertyTypeDefinition> props = objectPropertyTypes.get(objectType);
+    private static List<ObjectPropertyTypeDefinition> getObjectPropertyTypeDefinitions(ObjectType objectType,
+            int include) {
+        List<ObjectPropertyTypeDefinition> result = new ArrayList<>();
+        Map<PropertyIdentifier, ObjectPropertyTypeDefinition> props = objectPropertyTypes.get(objectType);
         if (props != null) {
-            for (final ObjectPropertyTypeDefinition def : props.values()) {
+            for (ObjectPropertyTypeDefinition def : props.values()) {
                 if (include == 0 || include == 1 && def.isRequired() || include == 2 && def.isOptional())
                     result.add(def);
             }
@@ -294,34 +295,34 @@ public class ObjectProperties {
     /**
      * Add a scalar property
      */
-    private static void add(final ObjectType type, final PropertyIdentifier pid, final Class<? extends Encodable> clazz,
-            final boolean required) {
+    private static void add(ObjectType type, PropertyIdentifier pid, Class<? extends Encodable> clazz,
+            boolean required) {
         add(type, required, new PropertyTypeDefinition(pid, clazz));
     }
 
     /**
      * Add a list property
      */
-    private static void add(final ObjectType type, final PropertyIdentifier pid, final Class<? extends Encodable> clazz,
-            final boolean required, final boolean isList) {
+    private static void add(ObjectType type, PropertyIdentifier pid, Class<? extends Encodable> clazz,
+            boolean required, boolean isList) {
         add(type, required, new PropertyTypeDefinition(pid, clazz, isList));
     }
 
     /**
      * Add an array property. If the array length is n, use 0.
      */
-    private static void add(final ObjectType type, final PropertyIdentifier pid, final Class<? extends Encodable> clazz,
-            final boolean required, final int arrayLength) {
+    private static void add(ObjectType type, PropertyIdentifier pid, Class<? extends Encodable> clazz,
+            boolean required, int arrayLength) {
         add(type, required, new PropertyTypeDefinition(pid, clazz, arrayLength));
     }
 
-    private static void add(final ObjectType type, final boolean required, final PropertyTypeDefinition ptd) {
+    private static void add(ObjectType type, boolean required, PropertyTypeDefinition ptd) {
         // Add to the object property types
         Map<PropertyIdentifier, ObjectPropertyTypeDefinition> props = objectPropertyTypes
                 .computeIfAbsent(type, key -> new HashMap<>());
 
         // Check for existing entries.
-        final PropertyIdentifier pid = ptd.getPropertyIdentifier();
+        PropertyIdentifier pid = ptd.getPropertyIdentifier();
         if (props.containsKey(pid))
             throw new RuntimeException("Found an existing entry for " + type + "/" + pid);
 
@@ -330,7 +331,7 @@ public class ObjectProperties {
         // Add to the property types. If an entry already exists, then replace it with null. In the end, only
         // properties that have a single type will remain.
         if (propertyTypes.containsKey(pid)) {
-            final PropertyTypeDefinition existing = propertyTypes.get(pid);
+            PropertyTypeDefinition existing = propertyTypes.get(pid);
             if (existing != null && !existing.equals(ptd)) {
                 propertyTypes.put(pid, null);
             }
@@ -345,7 +346,7 @@ public class ObjectProperties {
         add(ObjectType.accessCredential, PropertyIdentifier.objectName, CharacterString.class, true);
         add(ObjectType.accessCredential, PropertyIdentifier.objectType, ObjectType.class, true);
         add(ObjectType.accessCredential, PropertyIdentifier.description, CharacterString.class, false);
-        add(ObjectType.accessCredential, PropertyIdentifier.globalIdentifier, Unsigned32.class, false);
+        add(ObjectType.accessCredential, PropertyIdentifier.globalIdentifier, Unsigned32.class, true);
         add(ObjectType.accessCredential, PropertyIdentifier.statusFlags, StatusFlags.class, true);
         add(ObjectType.accessCredential, PropertyIdentifier.reliability, Reliability.class, true);
         add(ObjectType.accessCredential, PropertyIdentifier.credentialStatus, BinaryPV.class, true);
@@ -358,7 +359,7 @@ public class ObjectProperties {
         add(ObjectType.accessCredential, PropertyIdentifier.credentialDisable, AccessCredentialDisable.class, true);
         add(ObjectType.accessCredential, PropertyIdentifier.daysRemaining, SignedInteger.class, false);
         add(ObjectType.accessCredential, PropertyIdentifier.usesRemaining, SignedInteger.class, false);
-        add(ObjectType.accessCredential, PropertyIdentifier.absenteeLimit, UnsignedInteger.class, false);
+        add(ObjectType.accessCredential, PropertyIdentifier.absenteeLimit, Unsigned16.class, false);
         add(ObjectType.accessCredential, PropertyIdentifier.belongsTo, DeviceObjectReference.class, false);
         add(ObjectType.accessCredential, PropertyIdentifier.assignedAccessRights, AssignedAccessRights.class, true, 0);
         add(ObjectType.accessCredential, PropertyIdentifier.lastAccessPoint, DeviceObjectReference.class, false);
@@ -492,7 +493,7 @@ public class ObjectProperties {
         add(ObjectType.accessRights, PropertyIdentifier.objectName, CharacterString.class, true);
         add(ObjectType.accessRights, PropertyIdentifier.objectType, ObjectType.class, true);
         add(ObjectType.accessRights, PropertyIdentifier.description, CharacterString.class, false);
-        add(ObjectType.accessRights, PropertyIdentifier.globalIdentifier, Unsigned32.class, false);
+        add(ObjectType.accessRights, PropertyIdentifier.globalIdentifier, Unsigned32.class, true);
         add(ObjectType.accessRights, PropertyIdentifier.statusFlags, StatusFlags.class, true);
         add(ObjectType.accessRights, PropertyIdentifier.reliability, Reliability.class, true);
         add(ObjectType.accessRights, PropertyIdentifier.enable, Boolean.class, true);
@@ -512,7 +513,7 @@ public class ObjectProperties {
         add(ObjectType.accessUser, PropertyIdentifier.objectName, CharacterString.class, true);
         add(ObjectType.accessUser, PropertyIdentifier.objectType, ObjectType.class, true);
         add(ObjectType.accessUser, PropertyIdentifier.description, CharacterString.class, false);
-        add(ObjectType.accessUser, PropertyIdentifier.globalIdentifier, Unsigned32.class, false);
+        add(ObjectType.accessUser, PropertyIdentifier.globalIdentifier, Unsigned32.class, true);
         add(ObjectType.accessUser, PropertyIdentifier.statusFlags, StatusFlags.class, true);
         add(ObjectType.accessUser, PropertyIdentifier.reliability, Reliability.class, true);
         add(ObjectType.accessUser, PropertyIdentifier.userType, AccessUserType.class, true);
@@ -535,7 +536,7 @@ public class ObjectProperties {
         add(ObjectType.accessZone, PropertyIdentifier.objectName, CharacterString.class, true);
         add(ObjectType.accessZone, PropertyIdentifier.objectType, ObjectType.class, true);
         add(ObjectType.accessZone, PropertyIdentifier.description, CharacterString.class, false);
-        add(ObjectType.accessZone, PropertyIdentifier.globalIdentifier, Unsigned32.class, false);
+        add(ObjectType.accessZone, PropertyIdentifier.globalIdentifier, Unsigned32.class, true);
         add(ObjectType.accessZone, PropertyIdentifier.occupancyState, AccessZoneOccupancyState.class, true);
         add(ObjectType.accessZone, PropertyIdentifier.statusFlags, StatusFlags.class, true);
         add(ObjectType.accessZone, PropertyIdentifier.eventState, EventState.class, true);
@@ -615,8 +616,8 @@ public class ObjectProperties {
         add(ObjectType.accumulator, PropertyIdentifier.timeDelayNormal, UnsignedInteger.class, false);
         add(ObjectType.accumulator, PropertyIdentifier.reliabilityEvaluationInhibit, Boolean.class, false);
         add(ObjectType.accumulator, PropertyIdentifier.propertyList, PropertyIdentifier.class, true, 0);
-        add(ObjectType.accumulator, PropertyIdentifier.faultHighLimit, Real.class, false);
-        add(ObjectType.accumulator, PropertyIdentifier.faultLowLimit, Real.class, false);
+        add(ObjectType.accumulator, PropertyIdentifier.faultHighLimit, UnsignedInteger.class, false);
+        add(ObjectType.accumulator, PropertyIdentifier.faultLowLimit, UnsignedInteger.class, false);
         add(ObjectType.accumulator, PropertyIdentifier.auditLevel, AuditLevel.class, false);
         add(ObjectType.accumulator, PropertyIdentifier.auditableOperations, AuditOperationFlags.class, false);
         add(ObjectType.accumulator, PropertyIdentifier.tags, NameValue.class, false, 0);
@@ -631,11 +632,11 @@ public class ObjectProperties {
         add(ObjectType.alertEnrollment, PropertyIdentifier.presentValue, ObjectIdentifier.class, true);
         add(ObjectType.alertEnrollment, PropertyIdentifier.eventState, EventState.class, true);
         add(ObjectType.alertEnrollment, PropertyIdentifier.eventDetectionEnable, Boolean.class, true);
-        add(ObjectType.alertEnrollment, PropertyIdentifier.notificationClass, UnsignedInteger.class, false);
+        add(ObjectType.alertEnrollment, PropertyIdentifier.notificationClass, UnsignedInteger.class, true);
         add(ObjectType.alertEnrollment, PropertyIdentifier.eventEnable, EventTransitionBits.class, true);
         add(ObjectType.alertEnrollment, PropertyIdentifier.ackedTransitions, EventTransitionBits.class, true);
         add(ObjectType.alertEnrollment, PropertyIdentifier.notifyType, NotifyType.class, true);
-        add(ObjectType.alertEnrollment, PropertyIdentifier.eventTimeStamps, TimeStamp.class, false, 3);
+        add(ObjectType.alertEnrollment, PropertyIdentifier.eventTimeStamps, TimeStamp.class, true, 3);
         add(ObjectType.alertEnrollment, PropertyIdentifier.eventMessageTexts, CharacterString.class, false, 3);
         add(ObjectType.alertEnrollment, PropertyIdentifier.eventMessageTextsConfig, CharacterString.class, false, 3);
         add(ObjectType.alertEnrollment, PropertyIdentifier.eventAlgorithmInhibitRef, ObjectPropertyReference.class,
@@ -778,7 +779,7 @@ public class ObjectProperties {
         add(ObjectType.analogValue, PropertyIdentifier.propertyList, PropertyIdentifier.class, true, 0);
         add(ObjectType.analogValue, PropertyIdentifier.faultHighLimit, Real.class, false);
         add(ObjectType.analogValue, PropertyIdentifier.faultLowLimit, Real.class, false);
-        add(ObjectType.analogValue, PropertyIdentifier.currentCommandPriority, OptionalUnsigned.class, true);
+        add(ObjectType.analogValue, PropertyIdentifier.currentCommandPriority, OptionalUnsigned.class, false);
         add(ObjectType.analogValue, PropertyIdentifier.valueSource, ValueSource.class, false);
         add(ObjectType.analogValue, PropertyIdentifier.valueSourceArray, ValueSource.class, false, 16);
         add(ObjectType.analogValue, PropertyIdentifier.lastCommandTime, TimeStamp.class, false);
@@ -828,7 +829,7 @@ public class ObjectProperties {
         add(ObjectType.auditReporter, PropertyIdentifier.objectType, ObjectType.class, true);
         add(ObjectType.auditReporter, PropertyIdentifier.description, CharacterString.class, false);
         add(ObjectType.auditReporter, PropertyIdentifier.statusFlags, StatusFlags.class, true);
-        add(ObjectType.auditReporter, PropertyIdentifier.reliability, Reliability.class, false);
+        add(ObjectType.auditReporter, PropertyIdentifier.reliability, Reliability.class, true);
         add(ObjectType.auditReporter, PropertyIdentifier.eventState, EventState.class, true);
         add(ObjectType.auditReporter, PropertyIdentifier.auditLevel, AuditLevel.class, true);
         add(ObjectType.auditReporter, PropertyIdentifier.auditSourceReporter, Boolean.class, true);
@@ -893,7 +894,7 @@ public class ObjectProperties {
         add(ObjectType.binaryInput, PropertyIdentifier.changeOfStateTime, DateTime.class, false);
         add(ObjectType.binaryInput, PropertyIdentifier.changeOfStateCount, UnsignedInteger.class, false);
         add(ObjectType.binaryInput, PropertyIdentifier.timeOfStateCountReset, DateTime.class, false);
-        add(ObjectType.binaryInput, PropertyIdentifier.elapsedActiveTime, UnsignedInteger.class, false);
+        add(ObjectType.binaryInput, PropertyIdentifier.elapsedActiveTime, Unsigned32.class, false);
         add(ObjectType.binaryInput, PropertyIdentifier.timeOfActiveTimeReset, DateTime.class, false);
         add(ObjectType.binaryInput, PropertyIdentifier.timeDelay, UnsignedInteger.class, false);
         add(ObjectType.binaryInput, PropertyIdentifier.notificationClass, UnsignedInteger.class, false);
@@ -932,10 +933,10 @@ public class ObjectProperties {
         add(ObjectType.binaryLightingOutput, PropertyIdentifier.egressActive, Boolean.class, true);
         add(ObjectType.binaryLightingOutput, PropertyIdentifier.feedbackValue, BinaryLightingPV.class, false);
         add(ObjectType.binaryLightingOutput, PropertyIdentifier.priorityArray, PriorityArray.class, true);
-        add(ObjectType.binaryLightingOutput, PropertyIdentifier.relinquishDefault, Real.class, true);
+        add(ObjectType.binaryLightingOutput, PropertyIdentifier.relinquishDefault, BinaryLightingPV.class, true);
         add(ObjectType.binaryLightingOutput, PropertyIdentifier.power, Real.class, false);
         add(ObjectType.binaryLightingOutput, PropertyIdentifier.polarity, Polarity.class, false);
-        add(ObjectType.binaryLightingOutput, PropertyIdentifier.elapsedActiveTime, UnsignedInteger.class, false);
+        add(ObjectType.binaryLightingOutput, PropertyIdentifier.elapsedActiveTime, Unsigned32.class, false);
         add(ObjectType.binaryLightingOutput, PropertyIdentifier.timeOfActiveTimeReset, DateTime.class, false);
         add(ObjectType.binaryLightingOutput, PropertyIdentifier.strikeCount, UnsignedInteger.class, false);
         add(ObjectType.binaryLightingOutput, PropertyIdentifier.timeOfStrikeCountReset, DateTime.class, false);
@@ -983,10 +984,10 @@ public class ObjectProperties {
         add(ObjectType.binaryOutput, PropertyIdentifier.changeOfStateTime, DateTime.class, false);
         add(ObjectType.binaryOutput, PropertyIdentifier.changeOfStateCount, UnsignedInteger.class, false);
         add(ObjectType.binaryOutput, PropertyIdentifier.timeOfStateCountReset, DateTime.class, false);
-        add(ObjectType.binaryOutput, PropertyIdentifier.elapsedActiveTime, UnsignedInteger.class, false);
+        add(ObjectType.binaryOutput, PropertyIdentifier.elapsedActiveTime, Unsigned32.class, false);
         add(ObjectType.binaryOutput, PropertyIdentifier.timeOfActiveTimeReset, DateTime.class, false);
-        add(ObjectType.binaryOutput, PropertyIdentifier.minimumOffTime, UnsignedInteger.class, false);
-        add(ObjectType.binaryOutput, PropertyIdentifier.minimumOnTime, UnsignedInteger.class, false);
+        add(ObjectType.binaryOutput, PropertyIdentifier.minimumOffTime, Unsigned32.class, false);
+        add(ObjectType.binaryOutput, PropertyIdentifier.minimumOnTime, Unsigned32.class, false);
         add(ObjectType.binaryOutput, PropertyIdentifier.priorityArray, PriorityArray.class, true);
         add(ObjectType.binaryOutput, PropertyIdentifier.relinquishDefault, BinaryPV.class, true);
         add(ObjectType.binaryOutput, PropertyIdentifier.timeDelay, UnsignedInteger.class, false);
@@ -1026,16 +1027,16 @@ public class ObjectProperties {
         add(ObjectType.binaryValue, PropertyIdentifier.statusFlags, StatusFlags.class, true);
         add(ObjectType.binaryValue, PropertyIdentifier.eventState, EventState.class, true);
         add(ObjectType.binaryValue, PropertyIdentifier.reliability, Reliability.class, false);
-        add(ObjectType.binaryValue, PropertyIdentifier.outOfService, Boolean.class, false);
+        add(ObjectType.binaryValue, PropertyIdentifier.outOfService, Boolean.class, true);
         add(ObjectType.binaryValue, PropertyIdentifier.inactiveText, CharacterString.class, false);
         add(ObjectType.binaryValue, PropertyIdentifier.activeText, CharacterString.class, false);
         add(ObjectType.binaryValue, PropertyIdentifier.changeOfStateTime, DateTime.class, false);
         add(ObjectType.binaryValue, PropertyIdentifier.changeOfStateCount, UnsignedInteger.class, false);
         add(ObjectType.binaryValue, PropertyIdentifier.timeOfStateCountReset, DateTime.class, false);
-        add(ObjectType.binaryValue, PropertyIdentifier.elapsedActiveTime, UnsignedInteger.class, false);
+        add(ObjectType.binaryValue, PropertyIdentifier.elapsedActiveTime, Unsigned32.class, false);
         add(ObjectType.binaryValue, PropertyIdentifier.timeOfActiveTimeReset, DateTime.class, false);
-        add(ObjectType.binaryValue, PropertyIdentifier.minimumOffTime, UnsignedInteger.class, false);
-        add(ObjectType.binaryValue, PropertyIdentifier.minimumOnTime, UnsignedInteger.class, false);
+        add(ObjectType.binaryValue, PropertyIdentifier.minimumOffTime, Unsigned32.class, false);
+        add(ObjectType.binaryValue, PropertyIdentifier.minimumOnTime, Unsigned32.class, false);
         add(ObjectType.binaryValue, PropertyIdentifier.priorityArray, PriorityArray.class, false);
         add(ObjectType.binaryValue, PropertyIdentifier.relinquishDefault, BinaryPV.class, false);
         add(ObjectType.binaryValue, PropertyIdentifier.timeDelay, UnsignedInteger.class, false);
@@ -1053,7 +1054,7 @@ public class ObjectProperties {
         add(ObjectType.binaryValue, PropertyIdentifier.timeDelayNormal, UnsignedInteger.class, false);
         add(ObjectType.binaryValue, PropertyIdentifier.reliabilityEvaluationInhibit, Boolean.class, false);
         add(ObjectType.binaryValue, PropertyIdentifier.propertyList, PropertyIdentifier.class, true, 0);
-        add(ObjectType.binaryValue, PropertyIdentifier.currentCommandPriority, OptionalUnsigned.class, true);
+        add(ObjectType.binaryValue, PropertyIdentifier.currentCommandPriority, OptionalUnsigned.class, false);
         add(ObjectType.binaryValue, PropertyIdentifier.valueSource, ValueSource.class, false);
         add(ObjectType.binaryValue, PropertyIdentifier.valueSourceArray, ValueSource.class, false, 16);
         add(ObjectType.binaryValue, PropertyIdentifier.lastCommandTime, TimeStamp.class, false);
@@ -1073,9 +1074,9 @@ public class ObjectProperties {
         add(ObjectType.bitstringValue, PropertyIdentifier.presentValue, BitString.class, true);
         add(ObjectType.bitstringValue, PropertyIdentifier.bitText, CharacterString.class, false, 0);
         add(ObjectType.bitstringValue, PropertyIdentifier.statusFlags, StatusFlags.class, true);
-        add(ObjectType.bitstringValue, PropertyIdentifier.eventState, EventState.class, true);
+        add(ObjectType.bitstringValue, PropertyIdentifier.eventState, EventState.class, false);
         add(ObjectType.bitstringValue, PropertyIdentifier.reliability, Reliability.class, false);
-        add(ObjectType.bitstringValue, PropertyIdentifier.outOfService, Boolean.class, true);
+        add(ObjectType.bitstringValue, PropertyIdentifier.outOfService, Boolean.class, false);
         add(ObjectType.bitstringValue, PropertyIdentifier.priorityArray, PriorityArray.class, false);
         add(ObjectType.bitstringValue, PropertyIdentifier.relinquishDefault, BitString.class, false);
         add(ObjectType.bitstringValue, PropertyIdentifier.timeDelay, UnsignedInteger.class, false);
@@ -1095,7 +1096,7 @@ public class ObjectProperties {
         add(ObjectType.bitstringValue, PropertyIdentifier.timeDelayNormal, UnsignedInteger.class, false);
         add(ObjectType.bitstringValue, PropertyIdentifier.reliabilityEvaluationInhibit, Boolean.class, false);
         add(ObjectType.bitstringValue, PropertyIdentifier.propertyList, PropertyIdentifier.class, true, 0);
-        add(ObjectType.bitstringValue, PropertyIdentifier.currentCommandPriority, OptionalUnsigned.class, true);
+        add(ObjectType.bitstringValue, PropertyIdentifier.currentCommandPriority, OptionalUnsigned.class, false);
         add(ObjectType.bitstringValue, PropertyIdentifier.valueSource, ValueSource.class, false);
         add(ObjectType.bitstringValue, PropertyIdentifier.valueSourceArray, ValueSource.class, false, 16);
         add(ObjectType.bitstringValue, PropertyIdentifier.lastCommandTime, TimeStamp.class, false);
@@ -1141,7 +1142,7 @@ public class ObjectProperties {
         add(ObjectType.channel, PropertyIdentifier.eventDetectionEnable, Boolean.class, false);
         add(ObjectType.channel, PropertyIdentifier.notificationClass, UnsignedInteger.class, false);
         add(ObjectType.channel, PropertyIdentifier.eventEnable, EventTransitionBits.class, false);
-        add(ObjectType.channel, PropertyIdentifier.eventState, EventState.class, true);
+        add(ObjectType.channel, PropertyIdentifier.eventState, EventState.class, false);
         add(ObjectType.channel, PropertyIdentifier.ackedTransitions, EventTransitionBits.class, false);
         add(ObjectType.channel, PropertyIdentifier.notifyType, NotifyType.class, false);
         add(ObjectType.channel, PropertyIdentifier.eventTimeStamps, TimeStamp.class, false, 3);
@@ -1164,7 +1165,7 @@ public class ObjectProperties {
         add(ObjectType.characterstringValue, PropertyIdentifier.description, CharacterString.class, false);
         add(ObjectType.characterstringValue, PropertyIdentifier.presentValue, CharacterString.class, true);
         add(ObjectType.characterstringValue, PropertyIdentifier.statusFlags, StatusFlags.class, true);
-        add(ObjectType.characterstringValue, PropertyIdentifier.eventState, EventState.class, true);
+        add(ObjectType.characterstringValue, PropertyIdentifier.eventState, EventState.class, false);
         add(ObjectType.characterstringValue, PropertyIdentifier.reliability, Reliability.class, false);
         add(ObjectType.characterstringValue, PropertyIdentifier.outOfService, Boolean.class, false);
         add(ObjectType.characterstringValue, PropertyIdentifier.priorityArray, PriorityArray.class, false);
@@ -1187,7 +1188,7 @@ public class ObjectProperties {
         add(ObjectType.characterstringValue, PropertyIdentifier.timeDelayNormal, UnsignedInteger.class, false);
         add(ObjectType.characterstringValue, PropertyIdentifier.reliabilityEvaluationInhibit, Boolean.class, false);
         add(ObjectType.characterstringValue, PropertyIdentifier.propertyList, PropertyIdentifier.class, true, 0);
-        add(ObjectType.characterstringValue, PropertyIdentifier.currentCommandPriority, OptionalUnsigned.class, true);
+        add(ObjectType.characterstringValue, PropertyIdentifier.currentCommandPriority, OptionalUnsigned.class, false);
         add(ObjectType.characterstringValue, PropertyIdentifier.valueSource, ValueSource.class, false);
         add(ObjectType.characterstringValue, PropertyIdentifier.valueSourceArray, ValueSource.class, false, 16);
         add(ObjectType.characterstringValue, PropertyIdentifier.lastCommandTime, TimeStamp.class, false);
@@ -1255,8 +1256,8 @@ public class ObjectProperties {
         add(ObjectType.command, PropertyIdentifier.action, ActionList.class, true, 0);
         add(ObjectType.command, PropertyIdentifier.actionText, CharacterString.class, false, 0);
         add(ObjectType.command, PropertyIdentifier.propertyList, PropertyIdentifier.class, true, 0);
-        add(ObjectType.command, PropertyIdentifier.statusFlags, StatusFlags.class, true);
-        add(ObjectType.command, PropertyIdentifier.eventState, EventState.class, true);
+        add(ObjectType.command, PropertyIdentifier.statusFlags, StatusFlags.class, false);
+        add(ObjectType.command, PropertyIdentifier.eventState, EventState.class, false);
         add(ObjectType.command, PropertyIdentifier.reliability, Reliability.class, false);
         add(ObjectType.command, PropertyIdentifier.eventDetectionEnable, Boolean.class, false);
         add(ObjectType.command, PropertyIdentifier.notificationClass, UnsignedInteger.class, false);
@@ -1281,7 +1282,7 @@ public class ObjectProperties {
         add(ObjectType.credentialDataInput, PropertyIdentifier.presentValue, AuthenticationFactor.class, true);
         add(ObjectType.credentialDataInput, PropertyIdentifier.description, CharacterString.class, false);
         add(ObjectType.credentialDataInput, PropertyIdentifier.statusFlags, StatusFlags.class, true);
-        add(ObjectType.credentialDataInput, PropertyIdentifier.reliability, Reliability.class, false);
+        add(ObjectType.credentialDataInput, PropertyIdentifier.reliability, Reliability.class, true);
         add(ObjectType.credentialDataInput, PropertyIdentifier.outOfService, Boolean.class, true);
         add(ObjectType.credentialDataInput, PropertyIdentifier.supportedFormats, AuthenticationFactorFormat.class, true,
                 0);
@@ -1312,7 +1313,7 @@ public class ObjectProperties {
         add(ObjectType.dateValue, PropertyIdentifier.description, CharacterString.class, false);
         add(ObjectType.dateValue, PropertyIdentifier.presentValue, Date.class, true);
         add(ObjectType.dateValue, PropertyIdentifier.statusFlags, StatusFlags.class, true);
-        add(ObjectType.dateValue, PropertyIdentifier.eventState, EventState.class, true);
+        add(ObjectType.dateValue, PropertyIdentifier.eventState, EventState.class, false);
         add(ObjectType.dateValue, PropertyIdentifier.reliability, Reliability.class, false);
         add(ObjectType.dateValue, PropertyIdentifier.outOfService, Boolean.class, false);
         add(ObjectType.dateValue, PropertyIdentifier.priorityArray, PriorityArray.class, false);
@@ -1327,7 +1328,7 @@ public class ObjectProperties {
         add(ObjectType.dateValue, PropertyIdentifier.eventTimeStamps, TimeStamp.class, false, 3);
         add(ObjectType.dateValue, PropertyIdentifier.eventMessageTexts, CharacterString.class, false, 3);
         add(ObjectType.dateValue, PropertyIdentifier.eventMessageTextsConfig, CharacterString.class, false, 3);
-        add(ObjectType.dateValue, PropertyIdentifier.currentCommandPriority, OptionalUnsigned.class, true);
+        add(ObjectType.dateValue, PropertyIdentifier.currentCommandPriority, OptionalUnsigned.class, false);
         add(ObjectType.dateValue, PropertyIdentifier.valueSource, ValueSource.class, false);
         add(ObjectType.dateValue, PropertyIdentifier.valueSourceArray, ValueSource.class, false, 16);
         add(ObjectType.dateValue, PropertyIdentifier.lastCommandTime, TimeStamp.class, false);
@@ -1346,7 +1347,7 @@ public class ObjectProperties {
         add(ObjectType.datePatternValue, PropertyIdentifier.description, CharacterString.class, false);
         add(ObjectType.datePatternValue, PropertyIdentifier.presentValue, Date.class, true);
         add(ObjectType.datePatternValue, PropertyIdentifier.statusFlags, StatusFlags.class, true);
-        add(ObjectType.datePatternValue, PropertyIdentifier.eventState, EventState.class, true);
+        add(ObjectType.datePatternValue, PropertyIdentifier.eventState, EventState.class, false);
         add(ObjectType.datePatternValue, PropertyIdentifier.reliability, Reliability.class, false);
         add(ObjectType.datePatternValue, PropertyIdentifier.outOfService, Boolean.class, false);
         add(ObjectType.datePatternValue, PropertyIdentifier.priorityArray, PriorityArray.class, false);
@@ -1361,7 +1362,7 @@ public class ObjectProperties {
         add(ObjectType.datePatternValue, PropertyIdentifier.eventTimeStamps, TimeStamp.class, false, 3);
         add(ObjectType.datePatternValue, PropertyIdentifier.eventMessageTexts, CharacterString.class, false, 3);
         add(ObjectType.datePatternValue, PropertyIdentifier.eventMessageTextsConfig, CharacterString.class, false, 3);
-        add(ObjectType.datePatternValue, PropertyIdentifier.currentCommandPriority, OptionalUnsigned.class, true);
+        add(ObjectType.datePatternValue, PropertyIdentifier.currentCommandPriority, OptionalUnsigned.class, false);
         add(ObjectType.datePatternValue, PropertyIdentifier.valueSource, ValueSource.class, false);
         add(ObjectType.datePatternValue, PropertyIdentifier.valueSourceArray, ValueSource.class, false, 16);
         add(ObjectType.datePatternValue, PropertyIdentifier.lastCommandTime, TimeStamp.class, false);
@@ -1381,7 +1382,7 @@ public class ObjectProperties {
         add(ObjectType.datetimeValue, PropertyIdentifier.description, CharacterString.class, false);
         add(ObjectType.datetimeValue, PropertyIdentifier.presentValue, DateTime.class, true);
         add(ObjectType.datetimeValue, PropertyIdentifier.statusFlags, StatusFlags.class, true);
-        add(ObjectType.datetimeValue, PropertyIdentifier.eventState, EventState.class, true);
+        add(ObjectType.datetimeValue, PropertyIdentifier.eventState, EventState.class, false);
         add(ObjectType.datetimeValue, PropertyIdentifier.reliability, Reliability.class, false);
         add(ObjectType.datetimeValue, PropertyIdentifier.outOfService, Boolean.class, false);
         add(ObjectType.datetimeValue, PropertyIdentifier.priorityArray, PriorityArray.class, false);
@@ -1397,7 +1398,7 @@ public class ObjectProperties {
         add(ObjectType.datetimeValue, PropertyIdentifier.eventTimeStamps, TimeStamp.class, false, 3);
         add(ObjectType.datetimeValue, PropertyIdentifier.eventMessageTexts, CharacterString.class, false, 3);
         add(ObjectType.datetimeValue, PropertyIdentifier.eventMessageTextsConfig, CharacterString.class, false, 3);
-        add(ObjectType.datetimeValue, PropertyIdentifier.currentCommandPriority, OptionalUnsigned.class, true);
+        add(ObjectType.datetimeValue, PropertyIdentifier.currentCommandPriority, OptionalUnsigned.class, false);
         add(ObjectType.datetimeValue, PropertyIdentifier.valueSource, ValueSource.class, false);
         add(ObjectType.datetimeValue, PropertyIdentifier.valueSourceArray, ValueSource.class, false, 16);
         add(ObjectType.datetimeValue, PropertyIdentifier.lastCommandTime, TimeStamp.class, false);
@@ -1416,7 +1417,7 @@ public class ObjectProperties {
         add(ObjectType.datetimePatternValue, PropertyIdentifier.description, CharacterString.class, false);
         add(ObjectType.datetimePatternValue, PropertyIdentifier.presentValue, DateTime.class, true);
         add(ObjectType.datetimePatternValue, PropertyIdentifier.statusFlags, StatusFlags.class, true);
-        add(ObjectType.datetimePatternValue, PropertyIdentifier.eventState, EventState.class, true);
+        add(ObjectType.datetimePatternValue, PropertyIdentifier.eventState, EventState.class, false);
         add(ObjectType.datetimePatternValue, PropertyIdentifier.reliability, Reliability.class, false);
         add(ObjectType.datetimePatternValue, PropertyIdentifier.outOfService, Boolean.class, false);
         add(ObjectType.datetimePatternValue, PropertyIdentifier.isUtc, Boolean.class, false);
@@ -1433,7 +1434,7 @@ public class ObjectProperties {
         add(ObjectType.datetimePatternValue, PropertyIdentifier.eventMessageTexts, CharacterString.class, false, 3);
         add(ObjectType.datetimePatternValue, PropertyIdentifier.eventMessageTextsConfig, CharacterString.class, false,
                 3);
-        add(ObjectType.datetimePatternValue, PropertyIdentifier.currentCommandPriority, OptionalUnsigned.class, true);
+        add(ObjectType.datetimePatternValue, PropertyIdentifier.currentCommandPriority, OptionalUnsigned.class, false);
         add(ObjectType.datetimePatternValue, PropertyIdentifier.valueSource, ValueSource.class, false);
         add(ObjectType.datetimePatternValue, PropertyIdentifier.valueSourceArray, ValueSource.class, false, 16);
         add(ObjectType.datetimePatternValue, PropertyIdentifier.lastCommandTime, TimeStamp.class, false);
@@ -1498,8 +1499,8 @@ public class ObjectProperties {
         add(ObjectType.device, PropertyIdentifier.intervalOffset, UnsignedInteger.class, false);
         add(ObjectType.device, PropertyIdentifier.serialNumber, CharacterString.class, false);
         add(ObjectType.device, PropertyIdentifier.propertyList, PropertyIdentifier.class, true, 0);
-        add(ObjectType.device, PropertyIdentifier.statusFlags, StatusFlags.class, true);
-        add(ObjectType.device, PropertyIdentifier.eventState, EventState.class, true);
+        add(ObjectType.device, PropertyIdentifier.statusFlags, StatusFlags.class, false);
+        add(ObjectType.device, PropertyIdentifier.eventState, EventState.class, false);
         add(ObjectType.device, PropertyIdentifier.reliability, Reliability.class, false);
         add(ObjectType.device, PropertyIdentifier.eventDetectionEnable, Boolean.class, false);
         add(ObjectType.device, PropertyIdentifier.notificationClass, UnsignedInteger.class, false);
@@ -1518,8 +1519,8 @@ public class ObjectProperties {
         add(ObjectType.device, PropertyIdentifier.deviceUuid, OctetString.class, false);
         add(ObjectType.device, PropertyIdentifier.authorizationServer, AuthorizationServer.class, false);
         add(ObjectType.device, PropertyIdentifier.authorizationStatus, AuthorizationStatus.class, false);
-        add(ObjectType.device, PropertyIdentifier.authorizationPolicy, AuthorizationStatus.class, false, 0);
-        add(ObjectType.device, PropertyIdentifier.authorizationScope, AuthorizationScope.class, false, 0);
+        add(ObjectType.device, PropertyIdentifier.authorizationPolicy, AuthorizationPolicy.class, false, 0);
+        add(ObjectType.device, PropertyIdentifier.authorizationScope, AuthorizationScopeDescription.class, false, 0);
         add(ObjectType.device, PropertyIdentifier.authorizationCache, AccessToken.class, false, true);
         add(ObjectType.device, PropertyIdentifier.authorizationGroups, UnsignedInteger.class, false, 0);
         add(ObjectType.device, PropertyIdentifier.maxProxiedIAmsPerSecond, UnsignedInteger.class, false);
@@ -1571,7 +1572,7 @@ public class ObjectProperties {
         add(ObjectType.escalator, PropertyIdentifier.eventDetectionEnable, Boolean.class, false);
         add(ObjectType.escalator, PropertyIdentifier.notificationClass, UnsignedInteger.class, false);
         add(ObjectType.escalator, PropertyIdentifier.eventEnable, EventTransitionBits.class, false);
-        add(ObjectType.escalator, PropertyIdentifier.eventState, EventState.class, true);
+        add(ObjectType.escalator, PropertyIdentifier.eventState, EventState.class, false);
         add(ObjectType.escalator, PropertyIdentifier.ackedTransitions, EventTransitionBits.class, false);
         add(ObjectType.escalator, PropertyIdentifier.notifyType, NotifyType.class, false);
         add(ObjectType.escalator, PropertyIdentifier.eventTimeStamps, TimeStamp.class, false, 3);
@@ -1600,11 +1601,11 @@ public class ObjectProperties {
         add(ObjectType.eventEnrollment, PropertyIdentifier.eventState, EventState.class, true);
         add(ObjectType.eventEnrollment, PropertyIdentifier.eventEnable, EventTransitionBits.class, true);
         add(ObjectType.eventEnrollment, PropertyIdentifier.ackedTransitions, EventTransitionBits.class, true);
-        add(ObjectType.eventEnrollment, PropertyIdentifier.notificationClass, UnsignedInteger.class, false);
-        add(ObjectType.eventEnrollment, PropertyIdentifier.eventTimeStamps, TimeStamp.class, false, 3);
+        add(ObjectType.eventEnrollment, PropertyIdentifier.notificationClass, UnsignedInteger.class, true);
+        add(ObjectType.eventEnrollment, PropertyIdentifier.eventTimeStamps, TimeStamp.class, true, 3);
         add(ObjectType.eventEnrollment, PropertyIdentifier.eventMessageTexts, CharacterString.class, false, 3);
         add(ObjectType.eventEnrollment, PropertyIdentifier.eventMessageTextsConfig, CharacterString.class, false, 3);
-        add(ObjectType.eventEnrollment, PropertyIdentifier.eventDetectionEnable, Boolean.class, false);
+        add(ObjectType.eventEnrollment, PropertyIdentifier.eventDetectionEnable, Boolean.class, true);
         add(ObjectType.eventEnrollment, PropertyIdentifier.eventAlgorithmInhibitRef, ObjectPropertyReference.class,
                 false);
         add(ObjectType.eventEnrollment, PropertyIdentifier.eventAlgorithmInhibit, Boolean.class, false);
@@ -1634,13 +1635,13 @@ public class ObjectProperties {
         add(ObjectType.eventLog, PropertyIdentifier.startTime, DateTime.class, false);
         add(ObjectType.eventLog, PropertyIdentifier.stopTime, DateTime.class, false);
         add(ObjectType.eventLog, PropertyIdentifier.stopWhenFull, Boolean.class, true);
-        add(ObjectType.eventLog, PropertyIdentifier.bufferSize, UnsignedInteger.class, true);
+        add(ObjectType.eventLog, PropertyIdentifier.bufferSize, Unsigned32.class, true);
         add(ObjectType.eventLog, PropertyIdentifier.logBuffer, EventLogRecord.class, true, true);
-        add(ObjectType.eventLog, PropertyIdentifier.recordCount, UnsignedInteger.class, true);
-        add(ObjectType.eventLog, PropertyIdentifier.totalRecordCount, UnsignedInteger.class, true);
-        add(ObjectType.eventLog, PropertyIdentifier.notificationThreshold, UnsignedInteger.class, false);
-        add(ObjectType.eventLog, PropertyIdentifier.recordsSinceNotification, UnsignedInteger.class, false);
-        add(ObjectType.eventLog, PropertyIdentifier.lastNotifyRecord, UnsignedInteger.class, false);
+        add(ObjectType.eventLog, PropertyIdentifier.recordCount, Unsigned32.class, true);
+        add(ObjectType.eventLog, PropertyIdentifier.totalRecordCount, Unsigned32.class, true);
+        add(ObjectType.eventLog, PropertyIdentifier.notificationThreshold, Unsigned32.class, false);
+        add(ObjectType.eventLog, PropertyIdentifier.recordsSinceNotification, Unsigned32.class, false);
+        add(ObjectType.eventLog, PropertyIdentifier.lastNotifyRecord, Unsigned32.class, false);
         add(ObjectType.eventLog, PropertyIdentifier.notificationClass, UnsignedInteger.class, false);
         add(ObjectType.eventLog, PropertyIdentifier.eventEnable, EventTransitionBits.class, false);
         add(ObjectType.eventLog, PropertyIdentifier.ackedTransitions, EventTransitionBits.class, false);
@@ -1737,7 +1738,7 @@ public class ObjectProperties {
         add(ObjectType.integerValue, PropertyIdentifier.description, CharacterString.class, false);
         add(ObjectType.integerValue, PropertyIdentifier.presentValue, SignedInteger.class, true);
         add(ObjectType.integerValue, PropertyIdentifier.statusFlags, StatusFlags.class, true);
-        add(ObjectType.integerValue, PropertyIdentifier.eventState, EventState.class, true);
+        add(ObjectType.integerValue, PropertyIdentifier.eventState, EventState.class, false);
         add(ObjectType.integerValue, PropertyIdentifier.reliability, Reliability.class, false);
         add(ObjectType.integerValue, PropertyIdentifier.outOfService, Boolean.class, false);
         add(ObjectType.integerValue, PropertyIdentifier.units, EngineeringUnits.class, true);
@@ -1786,7 +1787,7 @@ public class ObjectProperties {
         add(ObjectType.largeAnalogValue, PropertyIdentifier.description, CharacterString.class, false);
         add(ObjectType.largeAnalogValue, PropertyIdentifier.presentValue, Double.class, true);
         add(ObjectType.largeAnalogValue, PropertyIdentifier.statusFlags, StatusFlags.class, true);
-        add(ObjectType.largeAnalogValue, PropertyIdentifier.eventState, EventState.class, true);
+        add(ObjectType.largeAnalogValue, PropertyIdentifier.eventState, EventState.class, false);
         add(ObjectType.largeAnalogValue, PropertyIdentifier.reliability, Reliability.class, false);
         add(ObjectType.largeAnalogValue, PropertyIdentifier.outOfService, Boolean.class, false);
         add(ObjectType.largeAnalogValue, PropertyIdentifier.units, EngineeringUnits.class, true);
@@ -1863,9 +1864,9 @@ public class ObjectProperties {
         add(ObjectType.lifeSafetyPoint, PropertyIdentifier.silenced, SilencedState.class, true);
         add(ObjectType.lifeSafetyPoint, PropertyIdentifier.operationExpected, LifeSafetyOperation.class, true);
         add(ObjectType.lifeSafetyPoint, PropertyIdentifier.maintenanceRequired, Maintenance.class, false);
-        add(ObjectType.lifeSafetyPoint, PropertyIdentifier.setting, UnsignedInteger.class, false);
+        add(ObjectType.lifeSafetyPoint, PropertyIdentifier.setting, Unsigned8.class, false);
         add(ObjectType.lifeSafetyPoint, PropertyIdentifier.directReading, Real.class, false);
-        add(ObjectType.lifeSafetyPoint, PropertyIdentifier.units, EngineeringUnits.class, true);
+        add(ObjectType.lifeSafetyPoint, PropertyIdentifier.units, EngineeringUnits.class, false);
         add(ObjectType.lifeSafetyPoint, PropertyIdentifier.memberOf, DeviceObjectReference.class, false, true);
         add(ObjectType.lifeSafetyPoint, PropertyIdentifier.floorNumber, Unsigned8.class, false);
         add(ObjectType.lifeSafetyPoint, PropertyIdentifier.propertyList, PropertyIdentifier.class, true, 0);
@@ -1909,7 +1910,7 @@ public class ObjectProperties {
         add(ObjectType.lifeSafetyZone, PropertyIdentifier.reliabilityEvaluationInhibit, Boolean.class, false);
         add(ObjectType.lifeSafetyZone, PropertyIdentifier.silenced, SilencedState.class, true);
         add(ObjectType.lifeSafetyZone, PropertyIdentifier.operationExpected, LifeSafetyOperation.class, true);
-        add(ObjectType.lifeSafetyZone, PropertyIdentifier.maintenanceRequired, Maintenance.class, false);
+        add(ObjectType.lifeSafetyZone, PropertyIdentifier.maintenanceRequired, Boolean.class, false);
         add(ObjectType.lifeSafetyZone, PropertyIdentifier.zoneMembers, DeviceObjectReference.class, true, true);
         add(ObjectType.lifeSafetyZone, PropertyIdentifier.memberOf, DeviceObjectReference.class, false, true);
         add(ObjectType.lifeSafetyZone, PropertyIdentifier.floorNumber, Unsigned8.class, false);
@@ -2044,7 +2045,7 @@ public class ObjectProperties {
         add(ObjectType.loadControl, PropertyIdentifier.stateDescription, CharacterString.class, false);
         add(ObjectType.loadControl, PropertyIdentifier.statusFlags, StatusFlags.class, true);
         add(ObjectType.loadControl, PropertyIdentifier.eventState, EventState.class, true);
-        add(ObjectType.loadControl, PropertyIdentifier.reliability, Reliability.class, true);
+        add(ObjectType.loadControl, PropertyIdentifier.reliability, Reliability.class, false);
         add(ObjectType.loadControl, PropertyIdentifier.requestedShedLevel, ShedLevel.class, true);
         add(ObjectType.loadControl, PropertyIdentifier.startTime, DateTime.class, true);
         add(ObjectType.loadControl, PropertyIdentifier.shedDuration, UnsignedInteger.class, true);
@@ -2072,7 +2073,6 @@ public class ObjectProperties {
         add(ObjectType.loadControl, PropertyIdentifier.valueSource, ValueSource.class, false);
         add(ObjectType.loadControl, PropertyIdentifier.auditLevel, AuditLevel.class, false);
         add(ObjectType.loadControl, PropertyIdentifier.auditableOperations, AuditOperationFlags.class, false);
-        add(ObjectType.loadControl, PropertyIdentifier.auditPriorityFilter, OptionalPriorityFilter.class, false);
         add(ObjectType.loadControl, PropertyIdentifier.tags, NameValue.class, false, 0);
         add(ObjectType.loadControl, PropertyIdentifier.profileLocation, CharacterString.class, false);
         add(ObjectType.loadControl, PropertyIdentifier.profileName, CharacterString.class, false);
@@ -2242,7 +2242,7 @@ public class ObjectProperties {
         add(ObjectType.multiStateValue, PropertyIdentifier.timeDelayNormal, UnsignedInteger.class, false);
         add(ObjectType.multiStateValue, PropertyIdentifier.reliabilityEvaluationInhibit, Boolean.class, false);
         add(ObjectType.multiStateValue, PropertyIdentifier.propertyList, PropertyIdentifier.class, true, 0);
-        add(ObjectType.multiStateValue, PropertyIdentifier.currentCommandPriority, OptionalUnsigned.class, true);
+        add(ObjectType.multiStateValue, PropertyIdentifier.currentCommandPriority, OptionalUnsigned.class, false);
         add(ObjectType.multiStateValue, PropertyIdentifier.valueSource, ValueSource.class, false);
         add(ObjectType.multiStateValue, PropertyIdentifier.valueSourceArray, ValueSource.class, false, 16);
         add(ObjectType.multiStateValue, PropertyIdentifier.lastCommandTime, TimeStamp.class, false);
@@ -2260,7 +2260,7 @@ public class ObjectProperties {
         add(ObjectType.networkPort, PropertyIdentifier.objectType, ObjectType.class, true);
         add(ObjectType.networkPort, PropertyIdentifier.description, CharacterString.class, false);
         add(ObjectType.networkPort, PropertyIdentifier.statusFlags, StatusFlags.class, true);
-        add(ObjectType.networkPort, PropertyIdentifier.reliability, Reliability.class, false);
+        add(ObjectType.networkPort, PropertyIdentifier.reliability, Reliability.class, true);
         add(ObjectType.networkPort, PropertyIdentifier.outOfService, Boolean.class, true);
         add(ObjectType.networkPort, PropertyIdentifier.networkType, NetworkType.class, true);
         add(ObjectType.networkPort, PropertyIdentifier.protocolLevel, ProtocolLevel.class, true);
@@ -2292,7 +2292,7 @@ public class ObjectProperties {
         add(ObjectType.networkPort, PropertyIdentifier.apduLength, UnsignedInteger.class, false);
         add(ObjectType.networkPort, PropertyIdentifier.routingTable, RouterEntry.class, false, true);
         add(ObjectType.networkPort, PropertyIdentifier.macAddress, OctetString.class, false);
-        add(ObjectType.networkPort, PropertyIdentifier.linkSpeed, Real.class, true);
+        add(ObjectType.networkPort, PropertyIdentifier.linkSpeed, Real.class, false);
         add(ObjectType.networkPort, PropertyIdentifier.linkSpeeds, Real.class, false, 0);
         add(ObjectType.networkPort, PropertyIdentifier.linkSpeedAutonegotiate, Boolean.class, false);
         add(ObjectType.networkPort, PropertyIdentifier.networkInterfaceName, CharacterString.class, false);
@@ -2370,13 +2370,13 @@ public class ObjectProperties {
         add(ObjectType.notificationClass, PropertyIdentifier.objectName, CharacterString.class, true);
         add(ObjectType.notificationClass, PropertyIdentifier.objectType, ObjectType.class, true);
         add(ObjectType.notificationClass, PropertyIdentifier.description, CharacterString.class, false);
-        add(ObjectType.notificationClass, PropertyIdentifier.notificationClass, UnsignedInteger.class, true);
+        add(ObjectType.notificationClass, PropertyIdentifier.notificationClass, UnsignedInteger.class, false);
         add(ObjectType.notificationClass, PropertyIdentifier.priority, UnsignedInteger.class, true, 3);
         add(ObjectType.notificationClass, PropertyIdentifier.ackRequired, EventTransitionBits.class, true);
         add(ObjectType.notificationClass, PropertyIdentifier.recipientList, Destination.class, true, true);
         add(ObjectType.notificationClass, PropertyIdentifier.propertyList, PropertyIdentifier.class, true, 0);
-        add(ObjectType.notificationClass, PropertyIdentifier.statusFlags, StatusFlags.class, true);
-        add(ObjectType.notificationClass, PropertyIdentifier.eventState, EventState.class, true);
+        add(ObjectType.notificationClass, PropertyIdentifier.statusFlags, StatusFlags.class, false);
+        add(ObjectType.notificationClass, PropertyIdentifier.eventState, EventState.class, false);
         add(ObjectType.notificationClass, PropertyIdentifier.reliability, Reliability.class, false);
         add(ObjectType.notificationClass, PropertyIdentifier.eventDetectionEnable, Boolean.class, false);
         add(ObjectType.notificationClass, PropertyIdentifier.eventEnable, EventTransitionBits.class, false);
@@ -2422,14 +2422,14 @@ public class ObjectProperties {
         add(ObjectType.octetstringValue, PropertyIdentifier.description, CharacterString.class, false);
         add(ObjectType.octetstringValue, PropertyIdentifier.presentValue, OctetString.class, true);
         add(ObjectType.octetstringValue, PropertyIdentifier.statusFlags, StatusFlags.class, true);
-        add(ObjectType.octetstringValue, PropertyIdentifier.eventState, EventState.class, true);
+        add(ObjectType.octetstringValue, PropertyIdentifier.eventState, EventState.class, false);
         add(ObjectType.octetstringValue, PropertyIdentifier.reliability, Reliability.class, false);
         add(ObjectType.octetstringValue, PropertyIdentifier.outOfService, Boolean.class, false);
         add(ObjectType.octetstringValue, PropertyIdentifier.priorityArray, PriorityArray.class, false);
         add(ObjectType.octetstringValue, PropertyIdentifier.relinquishDefault, OctetString.class, false);
         add(ObjectType.octetstringValue, PropertyIdentifier.reliabilityEvaluationInhibit, Boolean.class, false);
         add(ObjectType.octetstringValue, PropertyIdentifier.propertyList, PropertyIdentifier.class, true, 0);
-        add(ObjectType.octetstringValue, PropertyIdentifier.currentCommandPriority, OptionalUnsigned.class, true);
+        add(ObjectType.octetstringValue, PropertyIdentifier.currentCommandPriority, OptionalUnsigned.class, false);
         add(ObjectType.octetstringValue, PropertyIdentifier.valueSource, ValueSource.class, false);
         add(ObjectType.octetstringValue, PropertyIdentifier.valueSourceArray, ValueSource.class, false, 16);
         add(ObjectType.octetstringValue, PropertyIdentifier.lastCommandTime, TimeStamp.class, false);
@@ -2448,7 +2448,7 @@ public class ObjectProperties {
         add(ObjectType.positiveIntegerValue, PropertyIdentifier.description, CharacterString.class, false);
         add(ObjectType.positiveIntegerValue, PropertyIdentifier.presentValue, UnsignedInteger.class, true);
         add(ObjectType.positiveIntegerValue, PropertyIdentifier.statusFlags, StatusFlags.class, true);
-        add(ObjectType.positiveIntegerValue, PropertyIdentifier.eventState, EventState.class, true);
+        add(ObjectType.positiveIntegerValue, PropertyIdentifier.eventState, EventState.class, false);
         add(ObjectType.positiveIntegerValue, PropertyIdentifier.reliability, Reliability.class, false);
         add(ObjectType.positiveIntegerValue, PropertyIdentifier.outOfService, Boolean.class, false);
         add(ObjectType.positiveIntegerValue, PropertyIdentifier.units, EngineeringUnits.class, true);
@@ -2480,7 +2480,7 @@ public class ObjectProperties {
         add(ObjectType.positiveIntegerValue, PropertyIdentifier.propertyList, PropertyIdentifier.class, true, 0);
         add(ObjectType.positiveIntegerValue, PropertyIdentifier.faultHighLimit, UnsignedInteger.class, false);
         add(ObjectType.positiveIntegerValue, PropertyIdentifier.faultLowLimit, UnsignedInteger.class, false);
-        add(ObjectType.positiveIntegerValue, PropertyIdentifier.currentCommandPriority, OptionalUnsigned.class, true);
+        add(ObjectType.positiveIntegerValue, PropertyIdentifier.currentCommandPriority, OptionalUnsigned.class, false);
         add(ObjectType.positiveIntegerValue, PropertyIdentifier.valueSource, ValueSource.class, false);
         add(ObjectType.positiveIntegerValue, PropertyIdentifier.valueSourceArray, ValueSource.class, false, 16);
         add(ObjectType.positiveIntegerValue, PropertyIdentifier.lastCommandTime, TimeStamp.class, false);
@@ -2500,19 +2500,19 @@ public class ObjectProperties {
         add(ObjectType.program, PropertyIdentifier.programState, ProgramState.class, true);
         add(ObjectType.program, PropertyIdentifier.programChange, ProgramRequest.class, true);
         add(ObjectType.program, PropertyIdentifier.reasonForHalt, ProgramError.class, false);
-        add(ObjectType.program, PropertyIdentifier.descriptionOfHalt, CharacterString.class, true);
+        add(ObjectType.program, PropertyIdentifier.descriptionOfHalt, CharacterString.class, false);
         add(ObjectType.program, PropertyIdentifier.programLocation, CharacterString.class, false);
         add(ObjectType.program, PropertyIdentifier.description, CharacterString.class, false);
         add(ObjectType.program, PropertyIdentifier.instanceOf, CharacterString.class, false);
         add(ObjectType.program, PropertyIdentifier.statusFlags, StatusFlags.class, true);
         add(ObjectType.program, PropertyIdentifier.reliability, Reliability.class, false);
         add(ObjectType.program, PropertyIdentifier.outOfService, Boolean.class, true);
-        add(ObjectType.program, PropertyIdentifier.eventDetectionEnable, Boolean.class, true);
-        add(ObjectType.program, PropertyIdentifier.notificationClass, UnsignedInteger.class, true);
-        add(ObjectType.program, PropertyIdentifier.eventEnable, EventTransitionBits.class, true);
-        add(ObjectType.program, PropertyIdentifier.eventState, EventState.class, true);
-        add(ObjectType.program, PropertyIdentifier.ackedTransitions, EventTransitionBits.class, true);
-        add(ObjectType.program, PropertyIdentifier.notifyType, NotifyType.class, true);
+        add(ObjectType.program, PropertyIdentifier.eventDetectionEnable, Boolean.class, false);
+        add(ObjectType.program, PropertyIdentifier.notificationClass, UnsignedInteger.class, false);
+        add(ObjectType.program, PropertyIdentifier.eventEnable, EventTransitionBits.class, false);
+        add(ObjectType.program, PropertyIdentifier.eventState, EventState.class, false);
+        add(ObjectType.program, PropertyIdentifier.ackedTransitions, EventTransitionBits.class, false);
+        add(ObjectType.program, PropertyIdentifier.notifyType, NotifyType.class, false);
         add(ObjectType.program, PropertyIdentifier.eventTimeStamps, TimeStamp.class, false, 3);
         add(ObjectType.program, PropertyIdentifier.eventMessageTexts, CharacterString.class, false, 3);
         add(ObjectType.program, PropertyIdentifier.eventMessageTextsConfig, CharacterString.class, false, 3);
@@ -2607,7 +2607,7 @@ public class ObjectProperties {
         add(ObjectType.staging, PropertyIdentifier.objectIdentifier, ObjectIdentifier.class, true);
         add(ObjectType.staging, PropertyIdentifier.objectName, CharacterString.class, true);
         add(ObjectType.staging, PropertyIdentifier.objectType, ObjectType.class, true);
-        add(ObjectType.staging, PropertyIdentifier.presentValue, Primitive.class, true);
+        add(ObjectType.staging, PropertyIdentifier.presentValue, Real.class, true);
         add(ObjectType.staging, PropertyIdentifier.presentStage, UnsignedInteger.class, true);
         add(ObjectType.staging, PropertyIdentifier.stages, StageLimitValue.class, true, 0);
         add(ObjectType.staging, PropertyIdentifier.stageNames, CharacterString.class, false, 0);
@@ -2645,7 +2645,7 @@ public class ObjectProperties {
         add(ObjectType.structuredView, PropertyIdentifier.objectName, CharacterString.class, true);
         add(ObjectType.structuredView, PropertyIdentifier.objectType, ObjectType.class, true);
         add(ObjectType.structuredView, PropertyIdentifier.description, CharacterString.class, false);
-        add(ObjectType.structuredView, PropertyIdentifier.nodeType, NodeType.class, false);
+        add(ObjectType.structuredView, PropertyIdentifier.nodeType, NodeType.class, true);
         add(ObjectType.structuredView, PropertyIdentifier.nodeSubtype, CharacterString.class, false);
         add(ObjectType.structuredView, PropertyIdentifier.subordinateList, DeviceObjectReference.class, true, 0);
         add(ObjectType.structuredView, PropertyIdentifier.subordinateAnnotations, CharacterString.class, false, 0);
@@ -2668,7 +2668,7 @@ public class ObjectProperties {
         add(ObjectType.timeValue, PropertyIdentifier.description, CharacterString.class, false);
         add(ObjectType.timeValue, PropertyIdentifier.presentValue, Time.class, true);
         add(ObjectType.timeValue, PropertyIdentifier.statusFlags, StatusFlags.class, true);
-        add(ObjectType.timeValue, PropertyIdentifier.eventState, EventState.class, true);
+        add(ObjectType.timeValue, PropertyIdentifier.eventState, EventState.class, false);
         add(ObjectType.timeValue, PropertyIdentifier.reliability, Reliability.class, false);
         add(ObjectType.timeValue, PropertyIdentifier.outOfService, Boolean.class, false);
         add(ObjectType.timeValue, PropertyIdentifier.priorityArray, PriorityArray.class, false);
@@ -2683,7 +2683,7 @@ public class ObjectProperties {
         add(ObjectType.timeValue, PropertyIdentifier.eventTimeStamps, TimeStamp.class, false, 3);
         add(ObjectType.timeValue, PropertyIdentifier.eventMessageTexts, CharacterString.class, false, 3);
         add(ObjectType.timeValue, PropertyIdentifier.eventMessageTextsConfig, CharacterString.class, false, 3);
-        add(ObjectType.timeValue, PropertyIdentifier.currentCommandPriority, OptionalUnsigned.class, true);
+        add(ObjectType.timeValue, PropertyIdentifier.currentCommandPriority, OptionalUnsigned.class, false);
         add(ObjectType.timeValue, PropertyIdentifier.valueSource, ValueSource.class, false);
         add(ObjectType.timeValue, PropertyIdentifier.valueSourceArray, ValueSource.class, false, 16);
         add(ObjectType.timeValue, PropertyIdentifier.lastCommandTime, TimeStamp.class, false);
@@ -2702,7 +2702,7 @@ public class ObjectProperties {
         add(ObjectType.timePatternValue, PropertyIdentifier.description, CharacterString.class, false);
         add(ObjectType.timePatternValue, PropertyIdentifier.presentValue, Time.class, true);
         add(ObjectType.timePatternValue, PropertyIdentifier.statusFlags, StatusFlags.class, true);
-        add(ObjectType.timePatternValue, PropertyIdentifier.eventState, EventState.class, true);
+        add(ObjectType.timePatternValue, PropertyIdentifier.eventState, EventState.class, false);
         add(ObjectType.timePatternValue, PropertyIdentifier.reliability, Reliability.class, false);
         add(ObjectType.timePatternValue, PropertyIdentifier.outOfService, Boolean.class, false);
         add(ObjectType.timePatternValue, PropertyIdentifier.priorityArray, PriorityArray.class, false);
@@ -2717,7 +2717,7 @@ public class ObjectProperties {
         add(ObjectType.timePatternValue, PropertyIdentifier.eventTimeStamps, TimeStamp.class, false, 3);
         add(ObjectType.timePatternValue, PropertyIdentifier.eventMessageTexts, CharacterString.class, false, 3);
         add(ObjectType.timePatternValue, PropertyIdentifier.eventMessageTextsConfig, CharacterString.class, false, 3);
-        add(ObjectType.timePatternValue, PropertyIdentifier.currentCommandPriority, OptionalUnsigned.class, true);
+        add(ObjectType.timePatternValue, PropertyIdentifier.currentCommandPriority, OptionalUnsigned.class, false);
         add(ObjectType.timePatternValue, PropertyIdentifier.valueSource, ValueSource.class, false);
         add(ObjectType.timePatternValue, PropertyIdentifier.valueSourceArray, ValueSource.class, false, 16);
         add(ObjectType.timePatternValue, PropertyIdentifier.lastCommandTime, TimeStamp.class, false);
@@ -2734,9 +2734,9 @@ public class ObjectProperties {
         add(ObjectType.timer, PropertyIdentifier.objectName, CharacterString.class, true);
         add(ObjectType.timer, PropertyIdentifier.objectType, ObjectType.class, true);
         add(ObjectType.timer, PropertyIdentifier.description, CharacterString.class, false);
-        add(ObjectType.timer, PropertyIdentifier.presentValue, Time.class, true);
+        add(ObjectType.timer, PropertyIdentifier.presentValue, UnsignedInteger.class, true);
         add(ObjectType.timer, PropertyIdentifier.statusFlags, StatusFlags.class, true);
-        add(ObjectType.timer, PropertyIdentifier.eventState, EventState.class, true);
+        add(ObjectType.timer, PropertyIdentifier.eventState, EventState.class, false);
         add(ObjectType.timer, PropertyIdentifier.reliability, Reliability.class, false);
         add(ObjectType.timer, PropertyIdentifier.outOfService, Boolean.class, false);
         add(ObjectType.timer, PropertyIdentifier.timerState, TimerState.class, true);
@@ -2752,7 +2752,7 @@ public class ObjectProperties {
         add(ObjectType.timer, PropertyIdentifier.stateChangeValues, TimerStateChangeValue.class, false, 7);
         add(ObjectType.timer, PropertyIdentifier.listOfObjectPropertyReferences, DeviceObjectPropertyReference.class,
                 false, true);
-        add(ObjectType.timer, PropertyIdentifier.priorityForWriting, UnsignedInteger.class, true);
+        add(ObjectType.timer, PropertyIdentifier.priorityForWriting, UnsignedInteger.class, false);
         add(ObjectType.timer, PropertyIdentifier.eventDetectionEnable, Boolean.class, false);
         add(ObjectType.timer, PropertyIdentifier.notificationClass, UnsignedInteger.class, false);
         add(ObjectType.timer, PropertyIdentifier.timeDelay, UnsignedInteger.class, false);
@@ -2788,19 +2788,19 @@ public class ObjectProperties {
         add(ObjectType.trendLog, PropertyIdentifier.covResubscriptionInterval, UnsignedInteger.class, false);
         add(ObjectType.trendLog, PropertyIdentifier.clientCovIncrement, ClientCov.class, false);
         add(ObjectType.trendLog, PropertyIdentifier.stopWhenFull, Boolean.class, true);
-        add(ObjectType.trendLog, PropertyIdentifier.bufferSize, UnsignedInteger.class, true);
+        add(ObjectType.trendLog, PropertyIdentifier.bufferSize, Unsigned32.class, true);
         add(ObjectType.trendLog, PropertyIdentifier.logBuffer, LogRecord.class, true, true);
-        add(ObjectType.trendLog, PropertyIdentifier.recordCount, UnsignedInteger.class, true);
-        add(ObjectType.trendLog, PropertyIdentifier.totalRecordCount, UnsignedInteger.class, true);
+        add(ObjectType.trendLog, PropertyIdentifier.recordCount, Unsigned32.class, true);
+        add(ObjectType.trendLog, PropertyIdentifier.totalRecordCount, Unsigned32.class, true);
         add(ObjectType.trendLog, PropertyIdentifier.loggingType, LoggingType.class, true);
-        add(ObjectType.trendLog, PropertyIdentifier.alignIntervals, Boolean.class, true);
-        add(ObjectType.trendLog, PropertyIdentifier.intervalOffset, UnsignedInteger.class, true);
-        add(ObjectType.trendLog, PropertyIdentifier.trigger, Boolean.class, true);
+        add(ObjectType.trendLog, PropertyIdentifier.alignIntervals, Boolean.class, false);
+        add(ObjectType.trendLog, PropertyIdentifier.intervalOffset, UnsignedInteger.class, false);
+        add(ObjectType.trendLog, PropertyIdentifier.trigger, Boolean.class, false);
         add(ObjectType.trendLog, PropertyIdentifier.statusFlags, StatusFlags.class, true);
-        add(ObjectType.trendLog, PropertyIdentifier.reliability, Reliability.class, true);
-        add(ObjectType.trendLog, PropertyIdentifier.notificationThreshold, UnsignedInteger.class, false);
-        add(ObjectType.trendLog, PropertyIdentifier.recordsSinceNotification, UnsignedInteger.class, false);
-        add(ObjectType.trendLog, PropertyIdentifier.lastNotifyRecord, UnsignedInteger.class, false);
+        add(ObjectType.trendLog, PropertyIdentifier.reliability, Reliability.class, false);
+        add(ObjectType.trendLog, PropertyIdentifier.notificationThreshold, Unsigned32.class, false);
+        add(ObjectType.trendLog, PropertyIdentifier.recordsSinceNotification, Unsigned32.class, false);
+        add(ObjectType.trendLog, PropertyIdentifier.lastNotifyRecord, Unsigned32.class, false);
         add(ObjectType.trendLog, PropertyIdentifier.eventState, EventState.class, true);
         add(ObjectType.trendLog, PropertyIdentifier.notificationClass, UnsignedInteger.class, false);
         add(ObjectType.trendLog, PropertyIdentifier.eventEnable, EventTransitionBits.class, false);
@@ -2839,13 +2839,13 @@ public class ObjectProperties {
         add(ObjectType.trendLogMultiple, PropertyIdentifier.intervalOffset, UnsignedInteger.class, false);
         add(ObjectType.trendLogMultiple, PropertyIdentifier.trigger, Boolean.class, false);
         add(ObjectType.trendLogMultiple, PropertyIdentifier.stopWhenFull, Boolean.class, true);
-        add(ObjectType.trendLogMultiple, PropertyIdentifier.bufferSize, UnsignedInteger.class, true);
+        add(ObjectType.trendLogMultiple, PropertyIdentifier.bufferSize, Unsigned32.class, true);
         add(ObjectType.trendLogMultiple, PropertyIdentifier.logBuffer, LogMultipleRecord.class, true, true);
-        add(ObjectType.trendLogMultiple, PropertyIdentifier.recordCount, UnsignedInteger.class, true);
-        add(ObjectType.trendLogMultiple, PropertyIdentifier.totalRecordCount, UnsignedInteger.class, true);
-        add(ObjectType.trendLogMultiple, PropertyIdentifier.notificationThreshold, UnsignedInteger.class, false);
-        add(ObjectType.trendLogMultiple, PropertyIdentifier.recordsSinceNotification, UnsignedInteger.class, false);
-        add(ObjectType.trendLogMultiple, PropertyIdentifier.lastNotifyRecord, UnsignedInteger.class, false);
+        add(ObjectType.trendLogMultiple, PropertyIdentifier.recordCount, Unsigned32.class, true);
+        add(ObjectType.trendLogMultiple, PropertyIdentifier.totalRecordCount, Unsigned32.class, true);
+        add(ObjectType.trendLogMultiple, PropertyIdentifier.notificationThreshold, Unsigned32.class, false);
+        add(ObjectType.trendLogMultiple, PropertyIdentifier.recordsSinceNotification, Unsigned32.class, false);
+        add(ObjectType.trendLogMultiple, PropertyIdentifier.lastNotifyRecord, Unsigned32.class, false);
         add(ObjectType.trendLogMultiple, PropertyIdentifier.notificationClass, UnsignedInteger.class, false);
         add(ObjectType.trendLogMultiple, PropertyIdentifier.eventEnable, EventTransitionBits.class, false);
         add(ObjectType.trendLogMultiple, PropertyIdentifier.ackedTransitions, EventTransitionBits.class, false);

--- a/src/main/java/com/serotonin/bacnet4j/obj/TrendLogBase.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/TrendLogBase.java
@@ -93,6 +93,43 @@ public abstract class TrendLogBase extends LogBase {
 
     protected abstract void updateLoggingType();
 
+    protected void updatePolledLoggingType() {
+        UnsignedInteger logInterval = get(PropertyIdentifier.logInterval);
+        Boolean alignIntervals = get(PropertyIdentifier.alignIntervals);
+        UnsignedInteger intervalOffset = get(PropertyIdentifier.intervalOffset);
+
+        long period = logInterval.longValue() * 10;
+        if (period == 0)
+            // 0 is a poor value. Default to 5 minutes in this case, since it "is a local matter".
+            period = TimeUnit.MINUTES.toMillis(5);
+
+        long initialDelay = 0;
+        int offsetToUse = 0;
+        if (alignIntervals.booleanValue()) {
+            long now = getLocalDevice().getClock().millis();
+
+            // Find the largest time period to which the period aligns.
+            if (period % TimeUnit.DAYS.toMillis(1) == 0) {
+                initialDelay = TimeUnit.DAYS.toMillis(1) - now % TimeUnit.DAYS.toMillis(1);
+            } else if (period % TimeUnit.HOURS.toMillis(1) == 0) {
+                initialDelay = TimeUnit.HOURS.toMillis(1) - now % TimeUnit.HOURS.toMillis(1);
+            } else if (period % TimeUnit.MINUTES.toMillis(1) == 0) {
+                initialDelay = TimeUnit.MINUTES.toMillis(1) - now % TimeUnit.MINUTES.toMillis(1);
+            } else if (period % TimeUnit.SECONDS.toMillis(1) == 0) {
+                initialDelay = TimeUnit.SECONDS.toMillis(1) - now % TimeUnit.SECONDS.toMillis(1);
+            }
+
+            offsetToUse = intervalOffset.intValue() * 10;
+            offsetToUse %= (int) period;
+        }
+
+        initialDelay += offsetToUse;
+        initialDelay %= period;
+
+        pollingFuture = getLocalDevice().scheduleAtFixedRate(this::doPoll, initialDelay, period,
+                TimeUnit.MILLISECONDS);
+    }
+
     /**
      * Locally trigger a poll.
      *

--- a/src/main/java/com/serotonin/bacnet4j/obj/TrendLogBase.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/TrendLogBase.java
@@ -55,9 +55,10 @@ import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
 import com.serotonin.bacnet4j.type.enumerated.Reliability;
 import com.serotonin.bacnet4j.type.notificationParameters.BufferReadyNotif;
 import com.serotonin.bacnet4j.type.primitive.Boolean;
+import com.serotonin.bacnet4j.type.primitive.Unsigned32;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
-abstract class TrendLogBase extends BACnetObject {
+public abstract class TrendLogBase extends BACnetObject {
     protected boolean logDisabled;
     protected ScheduledFuture<?> startTimeFuture;
     protected ScheduledFuture<?> stopTimeFuture;
@@ -79,9 +80,9 @@ abstract class TrendLogBase extends BACnetObject {
         set(PropertyIdentifier.stopTime, stopTime);
         set(PropertyIdentifier.logInterval, new UnsignedInteger(logInterval));
         set(PropertyIdentifier.stopWhenFull, Boolean.valueOf(stopWhenFull));
-        set(PropertyIdentifier.bufferSize, new UnsignedInteger(bufferSize));
-        set(PropertyIdentifier.recordCount, UnsignedInteger.ZERO);
-        set(PropertyIdentifier.totalRecordCount, UnsignedInteger.ZERO);
+        set(PropertyIdentifier.bufferSize, new Unsigned32(bufferSize));
+        set(PropertyIdentifier.recordCount, Unsigned32.ZERO);
+        set(PropertyIdentifier.totalRecordCount, Unsigned32.ZERO);
         set(PropertyIdentifier.alignIntervals, Boolean.TRUE);
         set(PropertyIdentifier.intervalOffset, UnsignedInteger.ZERO);
         set(PropertyIdentifier.trigger, Boolean.FALSE);
@@ -117,9 +118,9 @@ abstract class TrendLogBase extends BACnetObject {
 
         // Prepare the object with all the properties that intrinsic reporting will need.
         // User-defined properties
-        writePropertyInternal(PropertyIdentifier.notificationThreshold, new UnsignedInteger(notificationThreshold));
-        writePropertyInternal(PropertyIdentifier.recordsSinceNotification, UnsignedInteger.ZERO);
-        writePropertyInternal(PropertyIdentifier.lastNotifyRecord, UnsignedInteger.ZERO);
+        writePropertyInternal(PropertyIdentifier.notificationThreshold, new Unsigned32(notificationThreshold));
+        writePropertyInternal(PropertyIdentifier.recordsSinceNotification, Unsigned32.ZERO);
+        writePropertyInternal(PropertyIdentifier.lastNotifyRecord, Unsigned32.ZERO);
         writePropertyInternal(PropertyIdentifier.eventState, EventState.normal);
         writePropertyInternal(PropertyIdentifier.notificationClass, new UnsignedInteger(notificationClass));
         writePropertyInternal(PropertyIdentifier.eventEnable, eventEnable);
@@ -140,8 +141,9 @@ abstract class TrendLogBase extends BACnetObject {
                 .withPostNotificationAction(notifParams -> {
                     if (notifParams.getParameter() instanceof BufferReadyNotif brn) {
                         // After a notification has been sent, a couple values need to be updated.
-                        writePropertyInternal(PropertyIdentifier.lastNotifyRecord, brn.getCurrentNotification());
-                        writePropertyInternal(PropertyIdentifier.recordsSinceNotification, UnsignedInteger.ZERO);
+                        writePropertyInternal(PropertyIdentifier.lastNotifyRecord,
+                                new Unsigned32(brn.getCurrentNotification()));
+                        writePropertyInternal(PropertyIdentifier.recordsSinceNotification, Unsigned32.ZERO);
                     }
                 }));
 
@@ -232,7 +234,7 @@ abstract class TrendLogBase extends BACnetObject {
         if (PropertyIdentifier.enable.equals(value.getPropertyIdentifier())) {
             Boolean enable = value.getValue();
             Boolean stopWhenFull = get(PropertyIdentifier.stopWhenFull);
-            UnsignedInteger bufferSize = get(PropertyIdentifier.bufferSize);
+            Unsigned32 bufferSize = get(PropertyIdentifier.bufferSize);
 
             if (enable.booleanValue() && stopWhenFull.booleanValue() && bufferSize.intValue() == bufferSize()) {
                 throw new BACnetServiceException(ErrorClass.object, ErrorCode.logBufferFull);
@@ -253,7 +255,7 @@ abstract class TrendLogBase extends BACnetObject {
             }
         } else if (PropertyIdentifier.recordCount.equals(value.getPropertyIdentifier())) {
             // Only allowed to write a zero to this record. What would any other value do?
-            UnsignedInteger recordCount = value.getValue();
+            Unsigned32 recordCount = value.getValue();
             if (recordCount.intValue() != 0)
                 throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
         }
@@ -272,7 +274,7 @@ abstract class TrendLogBase extends BACnetObject {
             purge();
             updateMonitoredProperty();
         } else if (PropertyIdentifier.recordCount.equals(pid)) {
-            UnsignedInteger recordCount = (UnsignedInteger) newValue;
+            Unsigned32 recordCount = (Unsigned32) newValue;
             if (recordCount.intValue() == 0)
                 purge();
         } else if (PropertyIdentifier.loggingType.equals(pid)) {
@@ -318,7 +320,7 @@ abstract class TrendLogBase extends BACnetObject {
 
     protected void fullCheck() {
         Boolean stopWhenFull = get(PropertyIdentifier.stopWhenFull);
-        UnsignedInteger bufferSize = get(PropertyIdentifier.bufferSize);
+        Unsigned32 bufferSize = get(PropertyIdentifier.bufferSize);
         if (stopWhenFull.booleanValue() && bufferSize() == bufferSize.intValue() - 1) {
             // There is only one spot left in the buffer, and StopWhenFull is true. Set Enable to false.
             writePropertyInternal(PropertyIdentifier.enable, Boolean.FALSE);
@@ -353,6 +355,6 @@ abstract class TrendLogBase extends BACnetObject {
     }
 
     protected void updateRecordCount() {
-        writePropertyInternal(PropertyIdentifier.recordCount, new UnsignedInteger(bufferSize()));
+        writePropertyInternal(PropertyIdentifier.recordCount, new Unsigned32(bufferSize()));
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/obj/TrendLogBase.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/TrendLogBase.java
@@ -27,67 +27,35 @@
 
 package com.serotonin.bacnet4j.obj;
 
-import java.util.Objects;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import com.serotonin.bacnet4j.LocalDevice;
-import com.serotonin.bacnet4j.exception.BACnetServiceException;
-import com.serotonin.bacnet4j.obj.mixin.HasStatusFlagsMixin;
 import com.serotonin.bacnet4j.obj.mixin.PollingDelegate;
-import com.serotonin.bacnet4j.obj.mixin.ReadOnlyPropertyMixin;
-import com.serotonin.bacnet4j.obj.mixin.event.IntrinsicReportingMixin;
-import com.serotonin.bacnet4j.obj.mixin.event.eventAlgo.BufferReadyAlgo;
 import com.serotonin.bacnet4j.type.Encodable;
 import com.serotonin.bacnet4j.type.constructed.DateTime;
-import com.serotonin.bacnet4j.type.constructed.DeviceObjectPropertyReference;
-import com.serotonin.bacnet4j.type.constructed.EventTransitionBits;
-import com.serotonin.bacnet4j.type.constructed.PropertyValue;
-import com.serotonin.bacnet4j.type.constructed.StatusFlags;
-import com.serotonin.bacnet4j.type.constructed.ValueSource;
-import com.serotonin.bacnet4j.type.enumerated.ErrorClass;
-import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
-import com.serotonin.bacnet4j.type.enumerated.EventState;
 import com.serotonin.bacnet4j.type.enumerated.LoggingType;
-import com.serotonin.bacnet4j.type.enumerated.NotifyType;
 import com.serotonin.bacnet4j.type.enumerated.ObjectType;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
-import com.serotonin.bacnet4j.type.enumerated.Reliability;
-import com.serotonin.bacnet4j.type.notificationParameters.BufferReadyNotif;
 import com.serotonin.bacnet4j.type.primitive.Boolean;
-import com.serotonin.bacnet4j.type.primitive.Unsigned32;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
-public abstract class TrendLogBase extends BACnetObject {
-    protected boolean logDisabled;
-    protected ScheduledFuture<?> startTimeFuture;
-    protected ScheduledFuture<?> stopTimeFuture;
-
+/**
+ * Base for the periodic-sampling log objects (Trend Log and Trend Log Multiple). Adds the polling
+ * / triggering / interval-alignment concerns on top of the buffer-and-schedule primitives provided
+ * by {@link LogBase}.
+ */
+public abstract class TrendLogBase extends LogBase {
     protected PollingDelegate pollingDelegate;
     protected ScheduledFuture<?> pollingFuture;
 
     protected TrendLogBase(LocalDevice localDevice, ObjectType type, int instanceNumber, String name, boolean enable,
             DateTime startTime, DateTime stopTime, int logInterval, boolean stopWhenFull, int bufferSize) {
-        super(localDevice, type, instanceNumber, name);
-
-        Objects.requireNonNull(localDevice);
-        Objects.requireNonNull(name);
-        Objects.requireNonNull(startTime);
-        Objects.requireNonNull(stopTime);
-
-        set(PropertyIdentifier.enable, Boolean.valueOf(enable));
-        set(PropertyIdentifier.startTime, startTime);
-        set(PropertyIdentifier.stopTime, stopTime);
+        super(localDevice, type, instanceNumber, name, enable, startTime, stopTime, stopWhenFull, bufferSize);
         set(PropertyIdentifier.logInterval, new UnsignedInteger(logInterval));
-        set(PropertyIdentifier.stopWhenFull, Boolean.valueOf(stopWhenFull));
-        set(PropertyIdentifier.bufferSize, new Unsigned32(bufferSize));
-        set(PropertyIdentifier.recordCount, Unsigned32.ZERO);
-        set(PropertyIdentifier.totalRecordCount, Unsigned32.ZERO);
         set(PropertyIdentifier.alignIntervals, Boolean.TRUE);
         set(PropertyIdentifier.intervalOffset, UnsignedInteger.ZERO);
         set(PropertyIdentifier.trigger, Boolean.FALSE);
-        set(PropertyIdentifier.statusFlags, new StatusFlags(false, false, false, false));
-        set(PropertyIdentifier.reliability, Reliability.noFaultDetected);
     }
 
     protected void postInitialize() {
@@ -96,10 +64,7 @@ public abstract class TrendLogBase extends BACnetObject {
         updateStopTime(get(PropertyIdentifier.stopTime));
         withTriggered();
 
-        // Mixins
-        addMixin(new HasStatusFlagsMixin(this));
-        addMixin(new ReadOnlyPropertyMixin(this, PropertyIdentifier.logBuffer, PropertyIdentifier.reliability,
-                PropertyIdentifier.totalRecordCount));
+        addLogMixins();
     }
 
     protected void baseWithPolled(int logInterval, TimeUnit logIntervalUnit, boolean alignIntervals,
@@ -111,99 +76,22 @@ public abstract class TrendLogBase extends BACnetObject {
         updateLoggingType();
     }
 
+    @Override
     protected void baseSupportIntrinsicReporting(int notificationThreshold, int notificationClass,
-            EventTransitionBits eventEnable, NotifyType notifyType) {
-        Objects.requireNonNull(eventEnable);
-        Objects.requireNonNull(notifyType);
-
-        // Prepare the object with all the properties that intrinsic reporting will need.
-        // User-defined properties
-        writePropertyInternal(PropertyIdentifier.notificationThreshold, new Unsigned32(notificationThreshold));
-        writePropertyInternal(PropertyIdentifier.recordsSinceNotification, Unsigned32.ZERO);
-        writePropertyInternal(PropertyIdentifier.lastNotifyRecord, Unsigned32.ZERO);
-        writePropertyInternal(PropertyIdentifier.eventState, EventState.normal);
-        writePropertyInternal(PropertyIdentifier.notificationClass, new UnsignedInteger(notificationClass));
-        writePropertyInternal(PropertyIdentifier.eventEnable, eventEnable);
-        writePropertyInternal(PropertyIdentifier.notifyType, notifyType);
-        writePropertyInternal(PropertyIdentifier.eventDetectionEnable, Boolean.TRUE);
-
-        BufferReadyAlgo algo = new BufferReadyAlgo(PropertyIdentifier.totalRecordCount,
-                new DeviceObjectPropertyReference(getId(), PropertyIdentifier.logBuffer, null,
-                        getLocalDevice().getId()),
-                PropertyIdentifier.notificationThreshold, PropertyIdentifier.lastNotifyRecord);
-
-        PropertyIdentifier[] triggerProps = new PropertyIdentifier[] { //
-                PropertyIdentifier.totalRecordCount, //
-                PropertyIdentifier.notificationThreshold};
-
-        // Now add the mixin.
-        addMixin(new IntrinsicReportingMixin(this, algo, null, PropertyIdentifier.totalRecordCount, triggerProps)
-                .withPostNotificationAction(notifParams -> {
-                    if (notifParams.getParameter() instanceof BufferReadyNotif brn) {
-                        // After a notification has been sent, a couple values need to be updated.
-                        writePropertyInternal(PropertyIdentifier.lastNotifyRecord,
-                                new Unsigned32(brn.getCurrentNotification()));
-                        writePropertyInternal(PropertyIdentifier.recordsSinceNotification, Unsigned32.ZERO);
-                    }
-                }));
-
+            com.serotonin.bacnet4j.type.constructed.EventTransitionBits eventEnable,
+            com.serotonin.bacnet4j.type.enumerated.NotifyType notifyType) {
+        super.baseSupportIntrinsicReporting(notificationThreshold, notificationClass, eventEnable, notifyType);
         updateMonitoredProperty();
     }
 
-    public boolean isLogDisabled() {
-        return logDisabled;
-    }
-
-    public void setEnabled(boolean enabled) {
-        writePropertyInternal(PropertyIdentifier.enable, Boolean.valueOf(enabled));
-    }
-
     protected abstract void updateMonitoredProperty();
-
-    protected void updateStartTime(DateTime startTime) {
-        cancelFuture(startTimeFuture);
-        if (!startTime.equals(DateTime.UNSPECIFIED)) {
-            DateTime now = getNow();
-            long diff = startTime.getGC().getTimeInMillis() - now.getGC().getTimeInMillis();
-            if (diff > 0) {
-                startTimeFuture = getLocalDevice().schedule(this::evaluateLogDisabled, diff, TimeUnit.MILLISECONDS);
-            }
-        }
-        evaluateLogDisabled();
-    }
-
-    protected void updateStopTime(DateTime stopTime) {
-        cancelFuture(stopTimeFuture);
-        if (!stopTime.equals(DateTime.UNSPECIFIED)) {
-            DateTime now = getNow();
-            long diff = stopTime.getGC().getTimeInMillis() - now.getGC().getTimeInMillis();
-            if (diff > 0) {
-                stopTimeFuture = getLocalDevice().schedule(this::evaluateLogDisabled, diff, TimeUnit.MILLISECONDS);
-            }
-        }
-        evaluateLogDisabled();
-    }
 
     protected void withTriggered() {
         set(PropertyIdentifier.loggingType, LoggingType.triggered);
         updateLoggingType();
     }
 
-    protected static void cancelFuture(ScheduledFuture<?> future) {
-        if (future != null)
-            future.cancel(false);
-    }
-
-    protected DateTime getNow() {
-        return new DateTime(getLocalDevice().getClock().millis());
-    }
-
-    protected abstract void evaluateLogDisabled();
-
     protected abstract void updateLoggingType();
-
-    protected abstract int bufferSize();
-
 
     /**
      * Locally trigger a poll.
@@ -222,61 +110,11 @@ public abstract class TrendLogBase extends BACnetObject {
     }
 
     @Override
-    protected void beforeReadProperty(PropertyIdentifier pid) throws BACnetServiceException {
-        if (PropertyIdentifier.logBuffer.equals(pid)) {
-            throw new BACnetServiceException(ErrorClass.property, ErrorCode.readAccessDenied);
-        }
-    }
-
-    @Override
-    protected boolean validateProperty(ValueSource valueSource, PropertyValue value)
-            throws BACnetServiceException {
-        if (PropertyIdentifier.enable.equals(value.getPropertyIdentifier())) {
-            Boolean enable = value.getValue();
-            Boolean stopWhenFull = get(PropertyIdentifier.stopWhenFull);
-            Unsigned32 bufferSize = get(PropertyIdentifier.bufferSize);
-
-            if (enable.booleanValue() && stopWhenFull.booleanValue() && bufferSize.intValue() == bufferSize()) {
-                throw new BACnetServiceException(ErrorClass.object, ErrorCode.logBufferFull);
-            }
-        } else if (PropertyIdentifier.startTime.equals(value.getPropertyIdentifier()) //
-                || PropertyIdentifier.stopTime.equals(value.getPropertyIdentifier())) {
-            // Ensure that the date time is either entirely unspecified or entirely specified.
-            DateTime dt = value.getValue();
-            if (dt.equals(DateTime.UNSPECIFIED))
-                return false;
-
-            if (!dt.isFullySpecified())
-                throw new BACnetServiceException(ErrorClass.property, ErrorCode.parameterOutOfRange);
-        } else if (PropertyIdentifier.bufferSize.equals(value.getPropertyIdentifier())) {
-            Boolean enable = get(PropertyIdentifier.enable);
-            if (enable.booleanValue()) {
-                throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
-            }
-        } else if (PropertyIdentifier.recordCount.equals(value.getPropertyIdentifier())) {
-            // Only allowed to write a zero to this record. What would any other value do?
-            Unsigned32 recordCount = value.getValue();
-            if (recordCount.intValue() != 0)
-                throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
-        }
-        return false;
-    }
-
-    @Override
     protected void afterWriteProperty(PropertyIdentifier pid, Encodable oldValue, Encodable newValue) {
-        if (PropertyIdentifier.enable.equals(pid)) {
-            evaluateLogDisabled();
-        } else if (PropertyIdentifier.startTime.equals(pid)) {
-            updateStartTime((DateTime) newValue);
-        } else if (PropertyIdentifier.stopTime.equals(pid)) {
-            updateStopTime((DateTime) newValue);
-        } else if (PropertyIdentifier.logDeviceObjectProperty.equals(pid)) {
+        super.afterWriteProperty(pid, oldValue, newValue);
+        if (PropertyIdentifier.logDeviceObjectProperty.equals(pid)) {
             purge();
             updateMonitoredProperty();
-        } else if (PropertyIdentifier.recordCount.equals(pid)) {
-            Unsigned32 recordCount = (Unsigned32) newValue;
-            if (recordCount.intValue() == 0)
-                purge();
         } else if (PropertyIdentifier.loggingType.equals(pid)) {
             updateLoggingType();
         } else if (pid.isOneOf(PropertyIdentifier.alignIntervals, PropertyIdentifier.intervalOffset)) {
@@ -296,65 +134,19 @@ public abstract class TrendLogBase extends BACnetObject {
         // Perform the trigger asynchronously
         getLocalDevice().execute(() -> {
             try {
-                // Do the poll.
                 doPoll();
                 LOG.debug("Trigger complete");
             } finally {
-                // Set the trigger value back to false.
                 writePropertyInternal(PropertyIdentifier.trigger, Boolean.FALSE);
             }
         });
     }
 
-    protected abstract void purge();
-
     protected abstract void doPoll();
 
     @Override
     protected void terminateImpl() {
-        super.terminate();
-        cancelFuture(startTimeFuture);
-        cancelFuture(stopTimeFuture);
+        super.terminateImpl();
         cancelFuture(pollingFuture);
-    }
-
-    protected void fullCheck() {
-        Boolean stopWhenFull = get(PropertyIdentifier.stopWhenFull);
-        Unsigned32 bufferSize = get(PropertyIdentifier.bufferSize);
-        if (stopWhenFull.booleanValue() && bufferSize() == bufferSize.intValue() - 1) {
-            // There is only one spot left in the buffer, and StopWhenFull is true. Set Enable to false.
-            writePropertyInternal(PropertyIdentifier.enable, Boolean.FALSE);
-        }
-    }
-
-
-    /**
-     * Determines whether logging should be performed based upon Enable, StartTime, and StopTime.
-     */
-    protected boolean allowLogging(DateTime now) {
-        Boolean enabled = get(PropertyIdentifier.enable);
-        if (!enabled.booleanValue())
-            return false;
-
-        DateTime start = get(PropertyIdentifier.startTime);
-        DateTime stop = get(PropertyIdentifier.stopTime);
-
-        if (!start.equals(DateTime.UNSPECIFIED)) {
-            LOG.debug("Checking start time");
-            if (now.compareTo(start) < 0)
-                return false;
-        }
-
-        if (!stop.equals(DateTime.UNSPECIFIED)) {
-            LOG.debug("Checking stop time, now={}, stop={}", now, stop);
-            if (now.compareTo(stop) >= 0)
-                return false;
-        }
-
-        return true;
-    }
-
-    protected void updateRecordCount() {
-        writePropertyInternal(PropertyIdentifier.recordCount, new Unsigned32(bufferSize()));
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/obj/TrendLogMultipleObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/TrendLogMultipleObject.java
@@ -62,6 +62,7 @@ import com.serotonin.bacnet4j.type.enumerated.ObjectType;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
 import com.serotonin.bacnet4j.type.error.ErrorClassAndCode;
 import com.serotonin.bacnet4j.type.primitive.Boolean;
+import com.serotonin.bacnet4j.type.primitive.Unsigned32;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 import com.serotonin.bacnet4j.util.DeviceObjectPropertyReferences;
 import com.serotonin.bacnet4j.util.DeviceObjectPropertyValues;
@@ -71,7 +72,7 @@ public class TrendLogMultipleObject extends TrendLogBase {
     static final Logger LOG = LoggerFactory.getLogger(TrendLogMultipleObject.class);
 
     // CreateObject constructor
-    public static TrendLogMultipleObject create(final LocalDevice localDevice, final int instanceNumber) {
+    public static TrendLogMultipleObject create(LocalDevice localDevice, int instanceNumber) {
         return new TrendLogMultipleObject(localDevice, instanceNumber,
                 ObjectType.trendLogMultiple + " " + instanceNumber, new LinkedListLogBuffer<>(), false,
                 DateTime.UNSPECIFIED, DateTime.UNSPECIFIED, new BACnetArray<>(), 60, false, 100) //
@@ -79,12 +80,12 @@ public class TrendLogMultipleObject extends TrendLogBase {
                         NotifyType.event);
     }
 
-    private final LogBuffer<LogMultipleRecord> buffer;
+    private LogBuffer<LogMultipleRecord> buffer;
 
-    public TrendLogMultipleObject(final LocalDevice localDevice, final int instanceNumber, final String name,
-            final LogBuffer<LogMultipleRecord> buffer, final boolean enable, final DateTime startTime,
-            final DateTime stopTime, final BACnetArray<DeviceObjectPropertyReference> logDeviceObjectProperty,
-            final int logInterval, final boolean stopWhenFull, final int bufferSize) {
+    public TrendLogMultipleObject(LocalDevice localDevice, int instanceNumber, String name,
+            LogBuffer<LogMultipleRecord> buffer, boolean enable, DateTime startTime,
+            DateTime stopTime, BACnetArray<DeviceObjectPropertyReference> logDeviceObjectProperty,
+            int logInterval, boolean stopWhenFull, int bufferSize) {
         super(localDevice, ObjectType.trendLogMultiple, instanceNumber, name, enable, startTime, stopTime, logInterval,
                 stopWhenFull, bufferSize);
 
@@ -145,23 +146,23 @@ public class TrendLogMultipleObject extends TrendLogBase {
     }
 
     @Override
-    protected boolean validateProperty(final ValueSource valueSource, final PropertyValue value)
+    protected boolean validateProperty(ValueSource valueSource, PropertyValue value)
             throws BACnetServiceException {
         super.validateProperty(valueSource, value);
         if (PropertyIdentifier.loggingType.equals(value.getPropertyIdentifier())) {
-            final LoggingType loggingType = value.getValue();
+            LoggingType loggingType = value.getValue();
             if (loggingType.equals(LoggingType.cov))
                 throw new BACnetServiceException(ErrorClass.property, ErrorCode.valueOutOfRange);
         } else if (PropertyIdentifier.logDeviceObjectProperty.equals(value.getPropertyIdentifier())) {
-            final BACnetArray<DeviceObjectPropertyReference> refs = value.getValue();
-            for (final DeviceObjectPropertyReference ref : refs) {
+            BACnetArray<DeviceObjectPropertyReference> refs = value.getValue();
+            for (DeviceObjectPropertyReference ref : refs) {
                 if (ref.getPropertyIdentifier().isOneOf(PropertyIdentifier.all, PropertyIdentifier.required,
                         PropertyIdentifier.optional)) {
                     throw new BACnetServiceException(ErrorClass.property, ErrorCode.parameterOutOfRange);
                 }
             }
         } else if (PropertyIdentifier.logInterval.equals(value.getPropertyIdentifier())) {
-            final LoggingType loggingType = get(PropertyIdentifier.loggingType);
+            LoggingType loggingType = get(PropertyIdentifier.loggingType);
             if (!loggingType.equals(LoggingType.polled)) {
                 throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
             }
@@ -176,11 +177,11 @@ public class TrendLogMultipleObject extends TrendLogBase {
         if (PropertyIdentifier.logInterval.equals(pid)) {
             updateLoggingType();
         } else if (PropertyIdentifier.stopWhenFull.equals(pid)) {
-            final Boolean oldStopWhenFull = (Boolean) oldValue;
-            final Boolean stopWhenFull = (Boolean) newValue;
+            Boolean oldStopWhenFull = (Boolean) oldValue;
+            Boolean stopWhenFull = (Boolean) newValue;
             if (!oldStopWhenFull.booleanValue() && stopWhenFull.booleanValue()) {
                 // Turning StopWhenFull on.
-                final UnsignedInteger bufferSize = get(PropertyIdentifier.bufferSize);
+                Unsigned32 bufferSize = get(PropertyIdentifier.bufferSize);
                 if (buffer.size() >= bufferSize.intValue()) {
                     synchronized (buffer) {
                         while (buffer.size() >= bufferSize.intValue())
@@ -191,7 +192,7 @@ public class TrendLogMultipleObject extends TrendLogBase {
                 }
             }
         } else if (PropertyIdentifier.bufferSize.equals(pid)) {
-            final UnsignedInteger bufferSize = (UnsignedInteger) newValue;
+            Unsigned32 bufferSize = (Unsigned32) newValue;
             // In case the buffer size was reduced, remove extra entries in the buffer.
             synchronized (buffer) {
                 while (buffer.size() >= bufferSize.intValue())
@@ -206,17 +207,17 @@ public class TrendLogMultipleObject extends TrendLogBase {
         synchronized (buffer) {
             buffer.clear();
         }
-        writePropertyInternal(PropertyIdentifier.recordsSinceNotification, UnsignedInteger.ZERO);
+        writePropertyInternal(PropertyIdentifier.recordsSinceNotification, Unsigned32.ZERO);
         addLogRecordImpl(new LogMultipleRecord(getNow(), new LogData(new LogStatus(logDisabled, true, false))));
     }
 
     @Override
     protected void updateMonitoredProperty() {
-        final BACnetArray<DeviceObjectPropertyReference> props = get(PropertyIdentifier.logDeviceObjectProperty);
+        BACnetArray<DeviceObjectPropertyReference> props = get(PropertyIdentifier.logDeviceObjectProperty);
 
         // Add the monitored property.
-        final DeviceObjectPropertyReferences refs = new DeviceObjectPropertyReferences();
-        for (final DeviceObjectPropertyReference prop : props) {
+        DeviceObjectPropertyReferences refs = new DeviceObjectPropertyReferences();
+        for (DeviceObjectPropertyReference prop : props) {
             if (prop.getDeviceIdentifier().isUninitialized() || prop.getObjectIdentifier().isUninitialized())
                 // Don't ask for properties that are not initialized.
                 continue;
@@ -233,14 +234,14 @@ public class TrendLogMultipleObject extends TrendLogBase {
      */
     @Override
     protected void updateLoggingType() {
-        final LoggingType loggingType = get(PropertyIdentifier.loggingType);
+        LoggingType loggingType = get(PropertyIdentifier.loggingType);
 
         cancelFuture(pollingFuture);
 
         if (loggingType.equals(LoggingType.polled)) {
-            final UnsignedInteger logInterval = get(PropertyIdentifier.logInterval);
-            final Boolean alignIntervals = get(PropertyIdentifier.alignIntervals);
-            final UnsignedInteger intervalOffset = get(PropertyIdentifier.intervalOffset);
+            UnsignedInteger logInterval = get(PropertyIdentifier.logInterval);
+            Boolean alignIntervals = get(PropertyIdentifier.alignIntervals);
+            UnsignedInteger intervalOffset = get(PropertyIdentifier.intervalOffset);
 
             long period = logInterval.longValue() * 10;
             if (period == 0)
@@ -250,7 +251,7 @@ public class TrendLogMultipleObject extends TrendLogBase {
             long initialDelay = 0;
             int offsetToUse = 0;
             if (alignIntervals.booleanValue()) {
-                final long now = getLocalDevice().getClock().millis();
+                long now = getLocalDevice().getClock().millis();
 
                 // Find the largest time period to which the period aligns.
                 if (period % TimeUnit.DAYS.toMillis(1) == 0) {
@@ -286,37 +287,37 @@ public class TrendLogMultipleObject extends TrendLogBase {
             return;
 
         // Get the time before the poll, so that alignment looks right.
-        final DateTime now = getNow();
+        DateTime now = getNow();
 
         // Call the delegate to perform the poll.
-        final DeviceObjectPropertyValues result = pollingDelegate.doPoll();
+        DeviceObjectPropertyValues result = pollingDelegate.doPoll();
 
         // Process the results.
-        final List<LogDataElement> elements = new ArrayList<>();
-        final BACnetArray<DeviceObjectPropertyReference> props = get(PropertyIdentifier.logDeviceObjectProperty);
-        for (final DeviceObjectPropertyReference prop : props) {
+        List<LogDataElement> elements = new ArrayList<>();
+        BACnetArray<DeviceObjectPropertyReference> props = get(PropertyIdentifier.logDeviceObjectProperty);
+        for (DeviceObjectPropertyReference prop : props) {
             LogDataElement element;
             if (prop.getDeviceIdentifier().isUninitialized() || prop.getObjectIdentifier().isUninitialized()) {
                 element = new LogDataElement(new ErrorClassAndCode(ErrorClass.property, ErrorCode.noPropertySpecified));
             } else {
-                final PropertyValues values = result.getPropertyValues(prop.getDeviceIdentifier().getInstanceNumber());
+                PropertyValues values = result.getPropertyValues(prop.getDeviceIdentifier().getInstanceNumber());
                 if (values == null) {
                     throw new NullPointerException("Didn't find device "
                             + prop.getDeviceIdentifier().getInstanceNumber() + " in results " + result
                             + ", polling delegate remote references: " + pollingDelegate.getRemoteReferences());
                 }
-                final Encodable value = values.getNoErrorCheck(prop.getObjectIdentifier(),
+                Encodable value = values.getNoErrorCheck(prop.getObjectIdentifier(),
                         new PropertyReference(prop.getPropertyIdentifier(), prop.getPropertyArrayIndex()));
                 element = LogDataElement.createFromMonitoredValue(value);
             }
             elements.add(element);
         }
 
-        final LogMultipleRecord rec = new LogMultipleRecord(now, new LogData(new SequenceOf<>(elements)));
+        LogMultipleRecord rec = new LogMultipleRecord(now, new LogData(new SequenceOf<>(elements)));
         addLogRecord(rec);
     }
 
-    private synchronized void addLogRecord(final LogMultipleRecord rec) {
+    private synchronized void addLogRecord(LogMultipleRecord rec) {
         // Check if logging is allowed.
         if (logDisabled)
             return;
@@ -327,8 +328,8 @@ public class TrendLogMultipleObject extends TrendLogBase {
         fullCheck();
     }
 
-    private void addLogRecordImpl(final LogMultipleRecord rec) {
-        final UnsignedInteger bufferSize = get(PropertyIdentifier.bufferSize);
+    private void addLogRecordImpl(LogMultipleRecord rec) {
+        Unsigned32 bufferSize = get(PropertyIdentifier.bufferSize);
 
         synchronized (buffer) {
             // Don't add more to the buffer than capacity.
@@ -342,17 +343,17 @@ public class TrendLogMultipleObject extends TrendLogBase {
 
         updateRecordCount();
 
-        final UnsignedInteger recordsSinceNotification = get(PropertyIdentifier.recordsSinceNotification);
+        Unsigned32 recordsSinceNotification = get(PropertyIdentifier.recordsSinceNotification);
         if (recordsSinceNotification != null) {
-            writePropertyInternal(PropertyIdentifier.recordsSinceNotification, recordsSinceNotification.increment32());
+            writePropertyInternal(PropertyIdentifier.recordsSinceNotification, recordsSinceNotification.increment());
         }
 
         // The total record count must be written last because it is the monitored property for intrinsic reporting.
-        UnsignedInteger totalRecordCount = get(PropertyIdentifier.totalRecordCount);
-        totalRecordCount = totalRecordCount.increment32();
+        Unsigned32 totalRecordCount = get(PropertyIdentifier.totalRecordCount);
+        totalRecordCount = totalRecordCount.increment();
         if (totalRecordCount.longValue() == 0)
             // Value overflowed. As per 12.30.21 set to 1.
-            totalRecordCount = new UnsignedInteger(1);
+            totalRecordCount = new Unsigned32(1);
         rec.setSequenceNumber(totalRecordCount.longValue());
         writePropertyInternal(PropertyIdentifier.totalRecordCount, totalRecordCount);
     }
@@ -361,8 +362,8 @@ public class TrendLogMultipleObject extends TrendLogBase {
     protected void evaluateLogDisabled() {
         // Don't evaluate until instantiation is complete.
         if (buffer != null) {
-            final DateTime now = getNow();
-            final boolean newValue = !allowLogging(now);
+            DateTime now = getNow();
+            boolean newValue = !allowLogging(now);
             if (logDisabled != newValue) {
                 logDisabled = newValue;
                 if (logDisabled)

--- a/src/main/java/com/serotonin/bacnet4j/obj/TrendLogMultipleObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/TrendLogMultipleObject.java
@@ -33,9 +33,6 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.serotonin.bacnet4j.LocalDevice;
 import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.obj.logBuffer.LinkedListLogBuffer;
@@ -69,8 +66,6 @@ import com.serotonin.bacnet4j.util.DeviceObjectPropertyValues;
 import com.serotonin.bacnet4j.util.PropertyValues;
 
 public class TrendLogMultipleObject extends TrendLogBase {
-    static final Logger LOG = LoggerFactory.getLogger(TrendLogMultipleObject.class);
-
     // CreateObject constructor
     public static TrendLogMultipleObject create(LocalDevice localDevice, int instanceNumber) {
         return new TrendLogMultipleObject(localDevice, instanceNumber,
@@ -80,7 +75,7 @@ public class TrendLogMultipleObject extends TrendLogBase {
                         NotifyType.event);
     }
 
-    private LogBuffer<LogMultipleRecord> buffer;
+    private final LogBuffer<LogMultipleRecord> buffer;
 
     public TrendLogMultipleObject(LocalDevice localDevice, int instanceNumber, String name,
             LogBuffer<LogMultipleRecord> buffer, boolean enable, DateTime startTime,
@@ -239,41 +234,7 @@ public class TrendLogMultipleObject extends TrendLogBase {
         cancelFuture(pollingFuture);
 
         if (loggingType.equals(LoggingType.polled)) {
-            UnsignedInteger logInterval = get(PropertyIdentifier.logInterval);
-            Boolean alignIntervals = get(PropertyIdentifier.alignIntervals);
-            UnsignedInteger intervalOffset = get(PropertyIdentifier.intervalOffset);
-
-            long period = logInterval.longValue() * 10;
-            if (period == 0)
-                // 0 is a poor value. Default to 5 minutes in this case, since it "is a local matter".
-                period = TimeUnit.MINUTES.toMillis(5);
-
-            long initialDelay = 0;
-            int offsetToUse = 0;
-            if (alignIntervals.booleanValue()) {
-                long now = getLocalDevice().getClock().millis();
-
-                // Find the largest time period to which the period aligns.
-                if (period % TimeUnit.DAYS.toMillis(1) == 0) {
-                    initialDelay = TimeUnit.DAYS.toMillis(1) - now % TimeUnit.DAYS.toMillis(1);
-                } else if (period % TimeUnit.HOURS.toMillis(1) == 0) {
-                    initialDelay = TimeUnit.HOURS.toMillis(1) - now % TimeUnit.HOURS.toMillis(1);
-                } else if (period % TimeUnit.MINUTES.toMillis(1) == 0) {
-                    initialDelay = TimeUnit.MINUTES.toMillis(1) - now % TimeUnit.MINUTES.toMillis(1);
-                } else if (period % TimeUnit.SECONDS.toMillis(1) == 0) {
-                    initialDelay = TimeUnit.SECONDS.toMillis(1) - now % TimeUnit.SECONDS.toMillis(1);
-                }
-
-                offsetToUse = intervalOffset.intValue() * 10;
-                offsetToUse %= (int) period;
-            }
-
-            initialDelay += offsetToUse;
-            initialDelay %= period;
-
-            pollingFuture = getLocalDevice().scheduleAtFixedRate(this::doPoll, initialDelay, period,
-                    TimeUnit.MILLISECONDS);
-
+            updatePolledLoggingType();
         } else if (loggingType.equals(LoggingType.triggered)) {
             set(PropertyIdentifier.logInterval, UnsignedInteger.ZERO);
         }

--- a/src/main/java/com/serotonin/bacnet4j/obj/TrendLogMultipleObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/TrendLogMultipleObject.java
@@ -35,6 +35,7 @@ import java.util.function.Consumer;
 
 import com.serotonin.bacnet4j.LocalDevice;
 import com.serotonin.bacnet4j.exception.BACnetServiceException;
+import com.serotonin.bacnet4j.obj.logBuffer.ILogRecord;
 import com.serotonin.bacnet4j.obj.logBuffer.LinkedListLogBuffer;
 import com.serotonin.bacnet4j.obj.logBuffer.LogBuffer;
 import com.serotonin.bacnet4j.obj.mixin.PollingDelegate;
@@ -113,9 +114,10 @@ public class TrendLogMultipleObject extends TrendLogBase {
      *
      * @param consumer the work to do while synchronized.
      */
-    public void doWithBuffer(Consumer<LogBuffer<LogMultipleRecord>> consumer) {
+    @SuppressWarnings("unchecked")
+    public <E extends ILogRecord> void doWithBuffer(Consumer<LogBuffer<E>> consumer) {
         synchronized (buffer) {
-            consumer.accept(buffer);
+            consumer.accept((LogBuffer<E>) buffer);
         }
     }
 
@@ -287,36 +289,6 @@ public class TrendLogMultipleObject extends TrendLogBase {
         addLogRecordImpl(rec);
 
         fullCheck();
-    }
-
-    private void addLogRecordImpl(LogMultipleRecord rec) {
-        Unsigned32 bufferSize = get(PropertyIdentifier.bufferSize);
-
-        synchronized (buffer) {
-            // Don't add more to the buffer than capacity.
-            if (buffer.size() == bufferSize.intValue()) {
-                // Buffer is already full. Drop the oldest record.
-                buffer.remove();
-            }
-
-            buffer.add(rec);
-        }
-
-        updateRecordCount();
-
-        Unsigned32 recordsSinceNotification = get(PropertyIdentifier.recordsSinceNotification);
-        if (recordsSinceNotification != null) {
-            writePropertyInternal(PropertyIdentifier.recordsSinceNotification, recordsSinceNotification.increment());
-        }
-
-        // The total record count must be written last because it is the monitored property for intrinsic reporting.
-        Unsigned32 totalRecordCount = get(PropertyIdentifier.totalRecordCount);
-        totalRecordCount = totalRecordCount.increment();
-        if (totalRecordCount.longValue() == 0)
-            // Value overflowed. As per 12.30.21 set to 1.
-            totalRecordCount = new Unsigned32(1);
-        rec.setSequenceNumber(totalRecordCount.longValue());
-        writePropertyInternal(PropertyIdentifier.totalRecordCount, totalRecordCount);
     }
 
     @Override

--- a/src/main/java/com/serotonin/bacnet4j/obj/TrendLogObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/TrendLogObject.java
@@ -84,7 +84,7 @@ public class TrendLogObject extends TrendLogBase {
 
     // CreateObject constructor
     public static TrendLogObject create(LocalDevice localDevice, int instanceNumber) {
-        return new TrendLogObject(localDevice, instanceNumber, ObjectType.trendLog.toString() + " " + instanceNumber,
+        return new TrendLogObject(localDevice, instanceNumber, ObjectType.trendLog + " " + instanceNumber,
                 new LinkedListLogBuffer<>(), false, DateTime.UNSPECIFIED, DateTime.UNSPECIFIED,
                 new DeviceObjectPropertyReference(localDevice.getInstanceNumber(), localDevice.getId(),
                         PropertyIdentifier.databaseRevision),
@@ -318,41 +318,7 @@ public class TrendLogObject extends TrendLogBase {
         cancelCov();
 
         if (loggingType.equals(LoggingType.polled)) {
-            UnsignedInteger logInterval = get(PropertyIdentifier.logInterval);
-            Boolean alignIntervals = get(PropertyIdentifier.alignIntervals);
-            UnsignedInteger intervalOffset = get(PropertyIdentifier.intervalOffset);
-
-            long period = logInterval.longValue() * 10;
-            if (period == 0)
-                // 0 is a poor value. Default to 5 minutes in this case, since it "is a local matter".
-                period = TimeUnit.MINUTES.toMillis(5);
-
-            long initialDelay = 0;
-            int offsetToUse = 0;
-            if (alignIntervals.booleanValue()) {
-                long now = getLocalDevice().getClock().millis();
-
-                // Find the largest time period to which the period aligns.
-                if (period % TimeUnit.DAYS.toMillis(1) == 0) {
-                    initialDelay = TimeUnit.DAYS.toMillis(1) - now % TimeUnit.DAYS.toMillis(1);
-                } else if (period % TimeUnit.HOURS.toMillis(1) == 0) {
-                    initialDelay = TimeUnit.HOURS.toMillis(1) - now % TimeUnit.HOURS.toMillis(1);
-                } else if (period % TimeUnit.MINUTES.toMillis(1) == 0) {
-                    initialDelay = TimeUnit.MINUTES.toMillis(1) - now % TimeUnit.MINUTES.toMillis(1);
-                } else if (period % TimeUnit.SECONDS.toMillis(1) == 0) {
-                    initialDelay = TimeUnit.SECONDS.toMillis(1) - now % TimeUnit.SECONDS.toMillis(1);
-                }
-
-                offsetToUse = intervalOffset.intValue() * 10;
-                offsetToUse %= (int) period;
-            }
-
-            initialDelay += offsetToUse;
-            initialDelay %= period;
-
-            pollingFuture = getLocalDevice().scheduleAtFixedRate(this::doPoll, initialDelay, period,
-                    TimeUnit.MILLISECONDS);
-
+            updatePolledLoggingType();
         } else if (loggingType.equals(LoggingType.cov)) {
             DeviceObjectPropertyReference monitored = get(PropertyIdentifier.logDeviceObjectProperty);
             set(PropertyIdentifier.logInterval, UnsignedInteger.ZERO);
@@ -390,7 +356,7 @@ public class TrendLogObject extends TrendLogBase {
                             if (pv.getPropertyIdentifier().equals(monitored.getPropertyIdentifier())) {
                                 value = pv.getValue();
                             } else if (pv.getPropertyIdentifier().equals(PropertyIdentifier.statusFlags)) {
-                                statusFlags = (StatusFlags) pv.getValue();
+                                statusFlags = pv.getValue();
                             }
                         }
 
@@ -416,7 +382,6 @@ public class TrendLogObject extends TrendLogBase {
                     } catch (BACnetException e) {
                         LOG.warn("COV subscription failed", e);
                         updateConfigurationError(true);
-                        return;
                     }
                 }, 0, resubscribeSeconds, TimeUnit.SECONDS);
 
@@ -439,7 +404,6 @@ public class TrendLogObject extends TrendLogBase {
                     } catch (BACnetException e) {
                         LOG.warn("COV subscription failed", e);
                         updateConfigurationError(true);
-                        return;
                     }
                 }, 0, resubscribeSeconds, TimeUnit.SECONDS);
             }

--- a/src/main/java/com/serotonin/bacnet4j/obj/TrendLogObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/TrendLogObject.java
@@ -40,6 +40,7 @@ import com.serotonin.bacnet4j.RemoteDevice;
 import com.serotonin.bacnet4j.event.DeviceEventAdapter;
 import com.serotonin.bacnet4j.exception.BACnetException;
 import com.serotonin.bacnet4j.exception.BACnetServiceException;
+import com.serotonin.bacnet4j.obj.logBuffer.ILogRecord;
 import com.serotonin.bacnet4j.obj.logBuffer.LinkedListLogBuffer;
 import com.serotonin.bacnet4j.obj.logBuffer.LogBuffer;
 import com.serotonin.bacnet4j.obj.mixin.PollingDelegate;
@@ -145,9 +146,15 @@ public class TrendLogObject extends TrendLogBase {
         return this;
     }
 
-    public void doWithBuffer(Consumer<LogBuffer<LogRecord>> consumer) {
+    /**
+     * Allows the consumer to work with the buffer in a thread-safe manner.
+     *
+     * @param consumer the work to do while synchronized.
+     */
+    @SuppressWarnings("unchecked")
+    public <E extends ILogRecord> void doWithBuffer(Consumer<LogBuffer<E>> consumer) {
         synchronized (buffer) {
-            consumer.accept(buffer);
+            consumer.accept((LogBuffer<E>) buffer);
         }
     }
 
@@ -478,36 +485,6 @@ public class TrendLogObject extends TrendLogBase {
         addLogRecordImpl(rec);
 
         fullCheck();
-    }
-
-    private void addLogRecordImpl(LogRecord rec) {
-        Unsigned32 bufferSize = get(PropertyIdentifier.bufferSize);
-
-        synchronized (buffer) {
-            // Don't add more to the buffer than capacity.
-            if (buffer.size() == bufferSize.intValue()) {
-                // Buffer is already full. Drop the oldest record.
-                buffer.remove();
-            }
-
-            buffer.add(rec);
-        }
-
-        updateRecordCount();
-
-        Unsigned32 recordsSinceNotification = get(PropertyIdentifier.recordsSinceNotification);
-        if (recordsSinceNotification != null) {
-            writePropertyInternal(PropertyIdentifier.recordsSinceNotification, recordsSinceNotification.increment());
-        }
-
-        // The total record count must be written last because it is the monitored property for intrinsic reporting.
-        Unsigned32 totalRecordCount = get(PropertyIdentifier.totalRecordCount);
-        totalRecordCount = totalRecordCount.increment();
-        if (totalRecordCount.longValue() == 0)
-            // Value overflowed. As per 12.25.16 set to 1.
-            totalRecordCount = new Unsigned32(1);
-        rec.setSequenceNumber(totalRecordCount.longValue());
-        writePropertyInternal(PropertyIdentifier.totalRecordCount, totalRecordCount);
     }
 
     @Override

--- a/src/main/java/com/serotonin/bacnet4j/obj/TrendLogObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/TrendLogObject.java
@@ -66,6 +66,7 @@ import com.serotonin.bacnet4j.type.enumerated.Reliability;
 import com.serotonin.bacnet4j.type.error.ErrorClassAndCode;
 import com.serotonin.bacnet4j.type.primitive.Boolean;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
+import com.serotonin.bacnet4j.type.primitive.Unsigned32;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 import com.serotonin.bacnet4j.util.DeviceObjectPropertyReferences;
 import com.serotonin.bacnet4j.util.DeviceObjectPropertyValues;
@@ -82,7 +83,7 @@ public class TrendLogObject extends TrendLogBase {
     static final Logger LOG = LoggerFactory.getLogger(TrendLogObject.class);
 
     // CreateObject constructor
-    public static TrendLogObject create(final LocalDevice localDevice, final int instanceNumber) {
+    public static TrendLogObject create(LocalDevice localDevice, int instanceNumber) {
         return new TrendLogObject(localDevice, instanceNumber, ObjectType.trendLog.toString() + " " + instanceNumber,
                 new LinkedListLogBuffer<>(), false, DateTime.UNSPECIFIED, DateTime.UNSPECIFIED,
                 new DeviceObjectPropertyReference(localDevice.getInstanceNumber(), localDevice.getId(),
@@ -103,10 +104,10 @@ public class TrendLogObject extends TrendLogBase {
     /**
      * Log buffers are expected to have been initialized to their buffer size.
      */
-    public TrendLogObject(final LocalDevice localDevice, final int instanceNumber, final String name,
-            final LogBuffer<LogRecord> buffer, final boolean enable, final DateTime startTime, final DateTime stopTime,
-            final DeviceObjectPropertyReference logDeviceObjectProperty, final int logInterval,
-            final boolean stopWhenFull, final int bufferSize) {
+    public TrendLogObject(LocalDevice localDevice, int instanceNumber, String name, LogBuffer<LogRecord> buffer,
+            boolean enable, DateTime startTime, DateTime stopTime,
+            DeviceObjectPropertyReference logDeviceObjectProperty, int logInterval, boolean stopWhenFull,
+            int bufferSize) {
         super(localDevice, ObjectType.trendLog, instanceNumber, name, enable, startTime, stopTime, logInterval,
                 stopWhenFull, bufferSize);
 
@@ -133,7 +134,7 @@ public class TrendLogObject extends TrendLogBase {
         return this;
     }
 
-    public TrendLogObject withCov(final int covResubscriptionIntervalSeconds, final ClientCov clientCovIncrement) {
+    public TrendLogObject withCov(int covResubscriptionIntervalSeconds, ClientCov clientCovIncrement) {
         Objects.requireNonNull(clientCovIncrement);
 
         set(PropertyIdentifier.covResubscriptionInterval, new UnsignedInteger(covResubscriptionIntervalSeconds));
@@ -176,13 +177,13 @@ public class TrendLogObject extends TrendLogBase {
             throws BACnetServiceException {
         super.validateProperty(valueSource, value);
         if (PropertyIdentifier.logDeviceObjectProperty.equals(value.getPropertyIdentifier())) {
-            final DeviceObjectPropertyReference logDeviceObjectProperty = value.getValue();
+            DeviceObjectPropertyReference logDeviceObjectProperty = value.getValue();
             if (logDeviceObjectProperty.getPropertyIdentifier().isOneOf(PropertyIdentifier.all,
                     PropertyIdentifier.required, PropertyIdentifier.optional)) {
                 throw new BACnetServiceException(ErrorClass.property, ErrorCode.parameterOutOfRange);
             }
         } else if (PropertyIdentifier.logInterval.equals(value.getPropertyIdentifier())) {
-            final LoggingType loggingType = get(PropertyIdentifier.loggingType);
+            LoggingType loggingType = get(PropertyIdentifier.loggingType);
             if (!loggingType.isOneOf(LoggingType.polled, LoggingType.cov)) {
                 throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
             }
@@ -194,9 +195,9 @@ public class TrendLogObject extends TrendLogBase {
     protected void afterWriteProperty(PropertyIdentifier pid, Encodable oldValue, Encodable newValue) {
         super.afterWriteProperty(pid, oldValue, newValue);
         if (PropertyIdentifier.logInterval.equals(pid)) {
-            final int oldLogInterval = ((UnsignedInteger) oldValue).intValue();
-            final int logInterval = ((UnsignedInteger) newValue).intValue();
-            final LoggingType loggingType = get(PropertyIdentifier.loggingType);
+            int oldLogInterval = ((UnsignedInteger) oldValue).intValue();
+            int logInterval = ((UnsignedInteger) newValue).intValue();
+            LoggingType loggingType = get(PropertyIdentifier.loggingType);
 
             if (loggingType.equals(LoggingType.polled) && oldLogInterval != 0 && logInterval == 0) {
                 set(PropertyIdentifier.loggingType, LoggingType.cov);
@@ -206,11 +207,11 @@ public class TrendLogObject extends TrendLogBase {
 
             updateLoggingType();
         } else if (PropertyIdentifier.stopWhenFull.equals(pid)) {
-            final Boolean oldStopWhenFull = (Boolean) oldValue;
-            final Boolean stopWhenFull = (Boolean) newValue;
+            Boolean oldStopWhenFull = (Boolean) oldValue;
+            Boolean stopWhenFull = (Boolean) newValue;
             if (!oldStopWhenFull.booleanValue() && stopWhenFull.booleanValue()) {
                 // Turning StopWhenFull on.
-                final UnsignedInteger bufferSize = get(PropertyIdentifier.bufferSize);
+                Unsigned32 bufferSize = get(PropertyIdentifier.bufferSize);
                 if (buffer.size() >= bufferSize.intValue()) {
                     synchronized (buffer) {
                         while (buffer.size() >= bufferSize.intValue())
@@ -221,7 +222,7 @@ public class TrendLogObject extends TrendLogBase {
                 }
             }
         } else if (PropertyIdentifier.bufferSize.equals(pid)) {
-            final UnsignedInteger bufferSize = (UnsignedInteger) newValue;
+            Unsigned32 bufferSize = (Unsigned32) newValue;
             // In case the buffer size was reduced, remove extra entries in the buffer.
             synchronized (buffer) {
                 while (buffer.size() >= bufferSize.intValue())
@@ -229,7 +230,7 @@ public class TrendLogObject extends TrendLogBase {
             }
             updateRecordCount();
         } else if (pid.isOneOf(PropertyIdentifier.covResubscriptionInterval, PropertyIdentifier.clientCovIncrement)) {
-            final LoggingType loggingType = get(PropertyIdentifier.loggingType);
+            LoggingType loggingType = get(PropertyIdentifier.loggingType);
             if (loggingType.equals(LoggingType.cov)) {
                 updateLoggingType();
             }
@@ -241,7 +242,7 @@ public class TrendLogObject extends TrendLogBase {
         synchronized (buffer) {
             buffer.clear();
         }
-        writePropertyInternal(PropertyIdentifier.recordsSinceNotification, UnsignedInteger.ZERO);
+        writePropertyInternal(PropertyIdentifier.recordsSinceNotification, Unsigned32.ZERO);
         addLogRecordImpl(new LogRecord(getNow(), new LogStatus(logDisabled, true, false), null));
     }
 
@@ -253,14 +254,14 @@ public class TrendLogObject extends TrendLogBase {
 
     private void cancelCov() {
         if (covSubscription != null) {
-            final DeviceObjectPropertyReference monitored = get(PropertyIdentifier.logDeviceObjectProperty);
+            DeviceObjectPropertyReference monitored = get(PropertyIdentifier.logDeviceObjectProperty);
 
             // Cancel the subscription
-            final SubscribeCOVPropertyRequest cancellation = new SubscribeCOVPropertyRequest(covSubscription);
+            SubscribeCOVPropertyRequest cancellation = new SubscribeCOVPropertyRequest(covSubscription);
             if (monitored.getDeviceIdentifier().getInstanceNumber() == getLocalDevice().getInstanceNumber()) {
                 try {
                     cancellation.handle(getLocalDevice(), getLocalDevice().getLoopbackAddress());
-                } catch (final BACnetException e) {
+                } catch (BACnetException e) {
                     // Shouldn't really happen, but note it anyway.
                     LOG.error("Failed to unsubscribe locally", e);
                 }
@@ -268,7 +269,7 @@ public class TrendLogObject extends TrendLogBase {
                 RemoteDevice rd;
                 try {
                     rd = getLocalDevice().getRemoteDeviceBlocking(monitored.getDeviceIdentifier().getInstanceNumber());
-                } catch (final BACnetException e) {
+                } catch (BACnetException e) {
                     LOG.warn("Failed to find remote device to which to send unsubscribe", e);
                     updateConfigurationError(true);
                     return;
@@ -288,15 +289,15 @@ public class TrendLogObject extends TrendLogBase {
 
     @Override
     protected void updateMonitoredProperty() {
-        final DeviceObjectPropertyReference monitored = get(PropertyIdentifier.logDeviceObjectProperty);
+        DeviceObjectPropertyReference monitored = get(PropertyIdentifier.logDeviceObjectProperty);
 
         // Add the monitored property.
-        final DeviceObjectPropertyReferences refs = new DeviceObjectPropertyReferences();
+        DeviceObjectPropertyReferences refs = new DeviceObjectPropertyReferences();
         refs.addIndex(monitored.getDeviceIdentifier().getInstanceNumber(), monitored.getObjectIdentifier(),
                 monitored.getPropertyIdentifier(), monitored.getPropertyArrayIndex());
 
         // Check if status flags exist for the object.
-        final ObjectPropertyTypeDefinition def = ObjectProperties.getObjectPropertyTypeDefinition(
+        ObjectPropertyTypeDefinition def = ObjectProperties.getObjectPropertyTypeDefinition(
                 monitored.getObjectIdentifier().getObjectType(), PropertyIdentifier.statusFlags);
         if (def != null) {
             refs.add(monitored.getDeviceIdentifier().getInstanceNumber(), monitored.getObjectIdentifier(),
@@ -311,15 +312,15 @@ public class TrendLogObject extends TrendLogBase {
      */
     @Override
     protected void updateLoggingType() {
-        final LoggingType loggingType = get(PropertyIdentifier.loggingType);
+        LoggingType loggingType = get(PropertyIdentifier.loggingType);
 
         cancelFuture(pollingFuture);
         cancelCov();
 
         if (loggingType.equals(LoggingType.polled)) {
-            final UnsignedInteger logInterval = get(PropertyIdentifier.logInterval);
-            final Boolean alignIntervals = get(PropertyIdentifier.alignIntervals);
-            final UnsignedInteger intervalOffset = get(PropertyIdentifier.intervalOffset);
+            UnsignedInteger logInterval = get(PropertyIdentifier.logInterval);
+            Boolean alignIntervals = get(PropertyIdentifier.alignIntervals);
+            UnsignedInteger intervalOffset = get(PropertyIdentifier.intervalOffset);
 
             long period = logInterval.longValue() * 10;
             if (period == 0)
@@ -329,7 +330,7 @@ public class TrendLogObject extends TrendLogBase {
             long initialDelay = 0;
             int offsetToUse = 0;
             if (alignIntervals.booleanValue()) {
-                final long now = getLocalDevice().getClock().millis();
+                long now = getLocalDevice().getClock().millis();
 
                 // Find the largest time period to which the period aligns.
                 if (period % TimeUnit.DAYS.toMillis(1) == 0) {
@@ -353,16 +354,16 @@ public class TrendLogObject extends TrendLogBase {
                     TimeUnit.MILLISECONDS);
 
         } else if (loggingType.equals(LoggingType.cov)) {
-            final DeviceObjectPropertyReference monitored = get(PropertyIdentifier.logDeviceObjectProperty);
+            DeviceObjectPropertyReference monitored = get(PropertyIdentifier.logDeviceObjectProperty);
             set(PropertyIdentifier.logInterval, UnsignedInteger.ZERO);
 
-            final UnsignedInteger covResubscriptionInterval = get(PropertyIdentifier.covResubscriptionInterval);
-            final int resubscribeSeconds = covResubscriptionInterval.intValue();
-            final ClientCov clientCovIncrement = get(PropertyIdentifier.clientCovIncrement);
+            UnsignedInteger covResubscriptionInterval = get(PropertyIdentifier.covResubscriptionInterval);
+            int resubscribeSeconds = covResubscriptionInterval.intValue();
+            ClientCov clientCovIncrement = get(PropertyIdentifier.clientCovIncrement);
 
             // Create the subscription
-            final ObjectIdentifier deviceIdentifier = monitored.getDeviceIdentifier();
-            final SubscribeCOVPropertyRequest localCovSubscription = new SubscribeCOVPropertyRequest(
+            ObjectIdentifier deviceIdentifier = monitored.getDeviceIdentifier();
+            SubscribeCOVPropertyRequest localCovSubscription = new SubscribeCOVPropertyRequest(
                     new UnsignedInteger(getLocalDevice().getNextProcessId()), monitored.getObjectIdentifier(),
                     Boolean.TRUE, new UnsignedInteger(resubscribeSeconds * 2),
                     new PropertyReference(monitored.getPropertyIdentifier(), monitored.getPropertyArrayIndex()),
@@ -372,10 +373,10 @@ public class TrendLogObject extends TrendLogBase {
             // Create the listener that will catch the COV notifications.
             covListener = new DeviceEventAdapter() {
                 @Override
-                public void covNotificationReceived(final UnsignedInteger subscriberProcessIdentifier,
-                        final ObjectIdentifier initiatingDeviceIdentifier,
-                        final ObjectIdentifier monitoredObjectIdentifier, final UnsignedInteger timeRemaining,
-                        final SequenceOf<PropertyValue> listOfValues) {
+                public void covNotificationReceived(UnsignedInteger subscriberProcessIdentifier,
+                        ObjectIdentifier initiatingDeviceIdentifier,
+                        ObjectIdentifier monitoredObjectIdentifier, UnsignedInteger timeRemaining,
+                        SequenceOf<PropertyValue> listOfValues) {
                     LOG.debug("Received COV notification");
 
                     // Handle the COV subscription. Check if it matches the subscription.
@@ -385,7 +386,7 @@ public class TrendLogObject extends TrendLogBase {
                         // Looks like this is for us.
                         Encodable value = null;
                         StatusFlags statusFlags = null;
-                        for (final PropertyValue pv : listOfValues) {
+                        for (PropertyValue pv : listOfValues) {
                             if (pv.getPropertyIdentifier().equals(monitored.getPropertyIdentifier())) {
                                 value = pv.getValue();
                             } else if (pv.getPropertyIdentifier().equals(PropertyIdentifier.statusFlags)) {
@@ -412,7 +413,7 @@ public class TrendLogObject extends TrendLogBase {
                     try {
                         covSubscription.handle(getLocalDevice(), getLocalDevice().getLoopbackAddress());
                         LOG.debug("COV subscription successful");
-                    } catch (final BACnetException e) {
+                    } catch (BACnetException e) {
                         LOG.warn("COV subscription failed", e);
                         updateConfigurationError(true);
                         return;
@@ -424,7 +425,7 @@ public class TrendLogObject extends TrendLogBase {
                 RemoteDevice rd;
                 try {
                     rd = getLocalDevice().getRemoteDeviceBlocking(monitored.getDeviceIdentifier().getInstanceNumber());
-                } catch (final BACnetException e) {
+                } catch (BACnetException e) {
                     LOG.warn("Failed to find remote device to which to send unsubscribe", e);
                     updateConfigurationError(true);
                     return;
@@ -435,7 +436,7 @@ public class TrendLogObject extends TrendLogBase {
                     try {
                         getLocalDevice().send(rd, covSubscription).get();
                         LOG.debug("COV subscription successful");
-                    } catch (final BACnetException e) {
+                    } catch (BACnetException e) {
                         LOG.warn("COV subscription failed", e);
                         updateConfigurationError(true);
                         return;
@@ -458,15 +459,15 @@ public class TrendLogObject extends TrendLogBase {
             return;
 
         // Get the time before the poll, so that alignment looks right.
-        final DateTime now = getNow();
+        DateTime now = getNow();
 
         // Call the delegate to perform the poll.
-        final DeviceObjectPropertyValues result = pollingDelegate.doPoll();
+        DeviceObjectPropertyValues result = pollingDelegate.doPoll();
 
         // Check the result.
-        final DeviceObjectPropertyReference monitored = get(PropertyIdentifier.logDeviceObjectProperty);
-        final PropertyValues values = result.getPropertyValues(monitored.getDeviceIdentifier().getInstanceNumber());
-        final Encodable value = values.getNoErrorCheck(monitored.getObjectIdentifier(),
+        DeviceObjectPropertyReference monitored = get(PropertyIdentifier.logDeviceObjectProperty);
+        PropertyValues values = result.getPropertyValues(monitored.getDeviceIdentifier().getInstanceNumber());
+        Encodable value = values.getNoErrorCheck(monitored.getObjectIdentifier(),
                 new PropertyReference(monitored.getPropertyIdentifier(), monitored.getPropertyArrayIndex()));
 
         LogRecord rec;
@@ -477,7 +478,7 @@ public class TrendLogObject extends TrendLogBase {
             LOG.warn("Error returned for value from poll: {}", value);
         } else {
             // Get the status flags
-            final Encodable statusFlags = values.getNoErrorCheck(monitored.getObjectIdentifier(),
+            Encodable statusFlags = values.getNoErrorCheck(monitored.getObjectIdentifier(),
                     PropertyIdentifier.statusFlags);
             if (statusFlags instanceof ErrorClassAndCode) {
                 error = true;
@@ -493,7 +494,7 @@ public class TrendLogObject extends TrendLogBase {
         addLogRecord(rec);
     }
 
-    private void updateConfigurationError(final boolean error) {
+    private void updateConfigurationError(boolean error) {
         if (configurationError != error) {
             configurationError = error;
             if (error) {
@@ -504,7 +505,7 @@ public class TrendLogObject extends TrendLogBase {
         }
     }
 
-    private synchronized void addLogRecord(final LogRecord rec) {
+    private synchronized void addLogRecord(LogRecord rec) {
         // Check if logging is allowed.
         if (logDisabled)
             return;
@@ -515,8 +516,8 @@ public class TrendLogObject extends TrendLogBase {
         fullCheck();
     }
 
-    private void addLogRecordImpl(final LogRecord rec) {
-        final UnsignedInteger bufferSize = get(PropertyIdentifier.bufferSize);
+    private void addLogRecordImpl(LogRecord rec) {
+        Unsigned32 bufferSize = get(PropertyIdentifier.bufferSize);
 
         synchronized (buffer) {
             // Don't add more to the buffer than capacity.
@@ -530,17 +531,17 @@ public class TrendLogObject extends TrendLogBase {
 
         updateRecordCount();
 
-        final UnsignedInteger recordsSinceNotification = get(PropertyIdentifier.recordsSinceNotification);
+        Unsigned32 recordsSinceNotification = get(PropertyIdentifier.recordsSinceNotification);
         if (recordsSinceNotification != null) {
-            writePropertyInternal(PropertyIdentifier.recordsSinceNotification, recordsSinceNotification.increment32());
+            writePropertyInternal(PropertyIdentifier.recordsSinceNotification, recordsSinceNotification.increment());
         }
 
         // The total record count must be written last because it is the monitored property for intrinsic reporting.
-        UnsignedInteger totalRecordCount = get(PropertyIdentifier.totalRecordCount);
-        totalRecordCount = totalRecordCount.increment32();
+        Unsigned32 totalRecordCount = get(PropertyIdentifier.totalRecordCount);
+        totalRecordCount = totalRecordCount.increment();
         if (totalRecordCount.longValue() == 0)
             // Value overflowed. As per 12.25.16 set to 1.
-            totalRecordCount = new UnsignedInteger(1);
+            totalRecordCount = new Unsigned32(1);
         rec.setSequenceNumber(totalRecordCount.longValue());
         writePropertyInternal(PropertyIdentifier.totalRecordCount, totalRecordCount);
     }
@@ -549,8 +550,8 @@ public class TrendLogObject extends TrendLogBase {
     protected void evaluateLogDisabled() {
         // Don't evaluate until instantiation is complete.
         if (buffer != null) {
-            final DateTime now = getNow();
-            final boolean newValue = !allowLogging(now);
+            DateTime now = getNow();
+            boolean newValue = !allowLogging(now);
             if (logDisabled != newValue) {
                 logDisabled = newValue;
                 if (logDisabled)

--- a/src/main/java/com/serotonin/bacnet4j/obj/mixin/ActiveTimeMixin.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/mixin/ActiveTimeMixin.java
@@ -33,6 +33,7 @@ import com.serotonin.bacnet4j.type.Encodable;
 import com.serotonin.bacnet4j.type.constructed.DateTime;
 import com.serotonin.bacnet4j.type.enumerated.BinaryPV;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
+import com.serotonin.bacnet4j.type.primitive.Unsigned32;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
 /**
@@ -52,11 +53,11 @@ public class ActiveTimeMixin extends AbstractMixin {
      * @param useFeedback whether to use present-value (false) or feedback-value (true) as the indicator for the
      *                    calculations.
      */
-    public ActiveTimeMixin(final BACnetObject bo, final boolean useFeedback) {
+    public ActiveTimeMixin(BACnetObject bo, boolean useFeedback) {
         super(bo);
 
         // Default the values.
-        writePropertyInternal(PropertyIdentifier.elapsedActiveTime, UnsignedInteger.ZERO);
+        writePropertyInternal(PropertyIdentifier.elapsedActiveTime, Unsigned32.ZERO);
         writePropertyInternal(PropertyIdentifier.timeOfActiveTimeReset, new DateTime(getLocalDevice()));
 
         if (useFeedback) {
@@ -69,24 +70,23 @@ public class ActiveTimeMixin extends AbstractMixin {
     }
 
     @Override
-    protected void beforeReadProperty(final PropertyIdentifier pid) {
+    protected void beforeReadProperty(PropertyIdentifier pid) {
         if (pid.equals(PropertyIdentifier.elapsedActiveTime)) {
             synchronized (monitoredValue) {
                 long elapsed = accumulatedActiveTime;
                 if (lastActiveTime != -1) {
                     elapsed += getLocalDevice().getClock().millis() - lastActiveTime;
                 }
-                set(PropertyIdentifier.elapsedActiveTime, new UnsignedInteger(elapsed / 1000));
+                set(PropertyIdentifier.elapsedActiveTime, new Unsigned32(elapsed / 1000));
             }
         }
     }
 
     @Override
-    protected void afterWriteProperty(final PropertyIdentifier pid, final Encodable oldValue,
-            final Encodable newValue) {
+    protected void afterWriteProperty(PropertyIdentifier pid, Encodable oldValue, Encodable newValue) {
         if (pid.equals(monitoredValue)) {
             synchronized (monitoredValue) {
-                final BinaryPV presentValue = (BinaryPV) newValue;
+                BinaryPV presentValue = (BinaryPV) newValue;
                 if (presentValue.equals(BinaryPV.active)) {
                     if (lastActiveTime == -1) {
                         lastActiveTime = getLocalDevice().getClock().millis();
@@ -100,7 +100,7 @@ public class ActiveTimeMixin extends AbstractMixin {
             }
         } else if (pid.equals(PropertyIdentifier.elapsedActiveTime)) {
             synchronized (monitoredValue) {
-                final UnsignedInteger elapsedActiveTime = (UnsignedInteger) newValue;
+                UnsignedInteger elapsedActiveTime = (UnsignedInteger) newValue;
                 accumulatedActiveTime = elapsedActiveTime.longValue() * 1000;
                 resetLastActiveTime();
                 if (elapsedActiveTime.longValue() == 0) {
@@ -111,7 +111,7 @@ public class ActiveTimeMixin extends AbstractMixin {
     }
 
     private void resetLastActiveTime() {
-        final BinaryPV presentValue = get(monitoredValue);
+        BinaryPV presentValue = get(monitoredValue);
         if (presentValue.equals(BinaryPV.active)) {
             lastActiveTime = getLocalDevice().getClock().millis();
         } else {

--- a/src/main/java/com/serotonin/bacnet4j/obj/mixin/CommandableMixin.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/mixin/CommandableMixin.java
@@ -63,6 +63,7 @@ import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
 import com.serotonin.bacnet4j.type.primitive.Boolean;
 import com.serotonin.bacnet4j.type.primitive.Null;
+import com.serotonin.bacnet4j.type.primitive.Unsigned32;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
 public class CommandableMixin extends AbstractMixin {
@@ -85,7 +86,7 @@ public class CommandableMixin extends AbstractMixin {
     // Runtime
     private ScheduledFuture<?> minOnOffTimerTask;
 
-    public CommandableMixin(final BACnetObject bo, final PropertyIdentifier pvProperty) {
+    public CommandableMixin(BACnetObject bo, PropertyIdentifier pvProperty) {
         super(bo);
         this.pvProperty = pvProperty;
     }
@@ -94,7 +95,7 @@ public class CommandableMixin extends AbstractMixin {
         return overridden;
     }
 
-    public void setOverridden(final boolean overridden) {
+    public void setOverridden(boolean overridden) {
         this.overridden = overridden;
     }
 
@@ -106,7 +107,7 @@ public class CommandableMixin extends AbstractMixin {
         return supportsWritable;
     }
 
-    public void supportCommandable(final Encodable relqDefault) {
+    public void supportCommandable(Encodable relqDefault) {
         supportsCommandable = true;
 
         // If the object does not have a priority array and relinquish default, add them
@@ -141,13 +142,13 @@ public class CommandableMixin extends AbstractMixin {
     }
 
     @Override
-    synchronized protected boolean validateProperty(final ValueSource valueSource, final PropertyValue value)
+    synchronized protected boolean validateProperty(ValueSource valueSource, PropertyValue value)
             throws BACnetServiceException {
         if (pvProperty.equals(value.getPropertyIdentifier())) {
             if (overridden)
                 return false;
 
-            final Boolean oos = get(outOfService);
+            Boolean oos = get(outOfService);
             if (oos.booleanValue())
                 return false;
 
@@ -161,13 +162,13 @@ public class CommandableMixin extends AbstractMixin {
             if (!supportsValueSource)
                 throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
 
-            final ValueSource vs = get(PropertyIdentifier.valueSource);
+            ValueSource vs = get(PropertyIdentifier.valueSource);
             if (vs == null || !vs.isAddress())
                 throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
             if (!vs.getAddress().equals(valueSource.getAddress()))
                 throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
 
-            final ValueSource newVs = (ValueSource) value.getValue();
+            ValueSource newVs = (ValueSource) value.getValue();
             if (!newVs.isObject())
                 throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
 
@@ -180,7 +181,7 @@ public class CommandableMixin extends AbstractMixin {
     }
 
     @Override
-    synchronized protected boolean writeProperty(final ValueSource valueSource, final PropertyValue value)
+    synchronized protected boolean writeProperty(ValueSource valueSource, PropertyValue value)
             throws BACnetServiceException {
         if (pvProperty.equals(value.getPropertyIdentifier())) {
             if (overridden) {
@@ -188,7 +189,7 @@ public class CommandableMixin extends AbstractMixin {
                 throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
             }
 
-            final Boolean oos = get(outOfService);
+            Boolean oos = get(outOfService);
             if (oos.booleanValue()) {
                 // Writable while the object is out of service.
                 directPVWrite(valueSource, value);
@@ -218,15 +219,15 @@ public class CommandableMixin extends AbstractMixin {
         return false;
     }
 
-    private void directPVWrite(final ValueSource valueSource, final PropertyValue value) {
+    private void directPVWrite(ValueSource valueSource, PropertyValue value) {
         writePropertyInternal(pvProperty, value.getValue());
         if (supportsValueSource)
             writePropertyInternal(PropertyIdentifier.valueSource, valueSource);
     }
 
     @Override
-    synchronized protected void afterWriteProperty(final PropertyIdentifier pid, final Encodable oldValue,
-            final Encodable newValue) {
+    synchronized protected void afterWriteProperty(PropertyIdentifier pid, Encodable oldValue,
+            Encodable newValue) {
         if (relinquishDefault.equals(pid)) {
             // The relinquish default was changed. Ensure that the present value gets updated if necessary.
             updatePresentValue(null, new TimeStamp(new DateTime(getLocalDevice())));
@@ -236,7 +237,7 @@ public class CommandableMixin extends AbstractMixin {
         }
     }
 
-    private void command(final ValueSource valueSource, final Encodable value, final UnsignedInteger priority)
+    private void command(ValueSource valueSource, Encodable value, UnsignedInteger priority)
             throws BACnetServiceException {
         int pri = 16;
         if (priority != null)
@@ -250,10 +251,10 @@ public class CommandableMixin extends AbstractMixin {
             throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
 
         // Set the value in the priority array.
-        final PriorityArray priArr = get(priorityArray);
+        PriorityArray priArr = get(priorityArray);
         priArr.setBase1(pri, new PriorityValue(value));
 
-        final TimeStamp now = new TimeStamp(new DateTime(getLocalDevice()));
+        TimeStamp now = new TimeStamp(new DateTime(getLocalDevice()));
         if (supportsValueSource) {
             updateValueSourceArray(pri, valueSource);
             updateCommandTimeArray(pri, now);
@@ -264,19 +265,19 @@ public class CommandableMixin extends AbstractMixin {
 
     synchronized void minOnOffCompleted() {
         minOnOffTimerTask = null;
-        final PriorityArray priArr = get(priorityArray);
+        PriorityArray priArr = get(priorityArray);
         priArr.setBase1(MIN_OFF_ON_PRIORITY, new PriorityValue(Null.instance));
         updatePresentValue(priArr, new TimeStamp(new DateTime(getLocalDevice())));
     }
 
-    private void updatePresentValue(final PriorityArray priorityArray, final TimeStamp now) {
-        final PriorityArray pa = priorityArray == null ? get(PropertyIdentifier.priorityArray) : priorityArray;
+    private void updatePresentValue(PriorityArray priorityArray, TimeStamp now) {
+        PriorityArray pa = priorityArray == null ? get(PropertyIdentifier.priorityArray) : priorityArray;
 
         // Calculate from the priority array what are the current value and index.
         PriorityValue topValue = null;
         int topIndex = 17;
         for (int i = 1; i <= pa.getCount(); i++) {
-            final PriorityValue priv = pa.getBase1(i);
+            PriorityValue priv = pa.getBase1(i);
             if (!priv.isa(Null.class)) {
                 topValue = priv;
                 topIndex = i;
@@ -292,9 +293,9 @@ public class CommandableMixin extends AbstractMixin {
         }
 
         // Minimum on/off time. See 19.2.3.
-        final Encodable oldValue = get(pvProperty);
-        final UnsignedInteger minOff = get(minimumOffTime);
-        final UnsignedInteger minOn = get(minimumOnTime);
+        Encodable oldValue = get(pvProperty);
+        Unsigned32 minOff = get(minimumOffTime);
+        Unsigned32 minOn = get(minimumOnTime);
         if (minOff != null && minOn != null) {
             if (!newValue.equals(oldValue)) {
                 // The value has changed. Check for updates to the timer.
@@ -333,21 +334,21 @@ public class CommandableMixin extends AbstractMixin {
             }
         }
 
-        final OptionalUnsigned newIndex;
+        OptionalUnsigned newIndex;
         if (topValue == null) {
             newIndex = new OptionalUnsigned();
         } else {
             newIndex = new OptionalUnsigned(topIndex);
         }
 
-        final OptionalUnsigned oldIndex = get(currentCommandPriority);
+        OptionalUnsigned oldIndex = get(currentCommandPriority);
         writePropertyInternal(currentCommandPriority, newIndex);
         if (supportsValueSource) {
             ValueSource vs;
             if (topValue == null) {
                 vs = getLocalValueSource();
             } else {
-                final BACnetArray<ValueSource> vsa = get(valueSourceArray);
+                BACnetArray<ValueSource> vsa = get(valueSourceArray);
                 vs = vsa.getBase1(topIndex);
             }
             writePropertyInternal(PropertyIdentifier.valueSource, vs);
@@ -364,13 +365,13 @@ public class CommandableMixin extends AbstractMixin {
         return new ValueSource(new DeviceObjectReference(getLocalDevice().getId(), getId()));
     }
 
-    private void updateValueSourceArray(final int indexBase1, final ValueSource va) {
-        final BACnetArray<ValueSource> vsa = get(valueSourceArray);
+    private void updateValueSourceArray(int indexBase1, ValueSource va) {
+        BACnetArray<ValueSource> vsa = get(valueSourceArray);
         vsa.setBase1(indexBase1, va);
     }
 
-    private void updateCommandTimeArray(final int indexBase1, final TimeStamp ts) {
-        final BACnetArray<TimeStamp> cta = get(commandTimeArray);
+    private void updateCommandTimeArray(int indexBase1, TimeStamp ts) {
+        BACnetArray<TimeStamp> cta = get(commandTimeArray);
         cta.setBase1(indexBase1, ts);
     }
 

--- a/src/main/java/com/serotonin/bacnet4j/service/confirmed/ReadRangeRequest.java
+++ b/src/main/java/com/serotonin/bacnet4j/service/confirmed/ReadRangeRequest.java
@@ -473,6 +473,10 @@ public class ReadRangeRequest extends ConfirmedRequestService {
         default int compareSequenceNumbero(final Sequenced that) {
             return Long.compare(getSequenceNumber(), that.getSequenceNumber());
         }
+
+        default void setSequenceNumber(long num) {
+            // no op
+        }
     }
 
     @Override

--- a/src/main/java/com/serotonin/bacnet4j/type/constructed/AuthorizationPolicy.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/constructed/AuthorizationPolicy.java
@@ -1,0 +1,118 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2026 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
+package com.serotonin.bacnet4j.type.constructed;
+
+import java.util.Objects;
+
+import com.serotonin.bacnet4j.exception.BACnetException;
+import com.serotonin.bacnet4j.type.primitive.Unsigned32;
+import com.serotonin.bacnet4j.util.sero.ByteQueue;
+
+public class AuthorizationPolicy extends BaseType {
+    private final DateTime notBefore;
+    private final DateTime notAfter;
+    private final SequenceOf<Unsigned32> clients;
+    private final AuthorizationConstraint constraint;
+    private final AuthorizationScope scope;
+
+    public AuthorizationPolicy(
+            DateTime notBefore,
+            DateTime notAfter,
+            SequenceOf<Unsigned32> clients,
+            AuthorizationConstraint constraint,
+            AuthorizationScope scope) {
+        this.notBefore = notBefore;
+        this.notAfter = notAfter;
+        this.clients = clients;
+        this.constraint = constraint;
+        this.scope = scope;
+    }
+
+    @Override
+    public void write(ByteQueue queue) {
+        writeOptional(queue, notBefore, 0);
+        writeOptional(queue, notAfter, 1);
+        write(queue, clients, 2);
+        write(queue, constraint, 3);
+        write(queue, scope, 4);
+    }
+
+    @Override
+    public String toString() {
+        return "AuthorizationPolicy [" +
+                "notBefore=" + notBefore +
+                ", notAfter=" + notAfter +
+                ", clients=" + clients +
+                ", constraint=" + constraint +
+                ", scope=" + scope +
+                ']';
+    }
+
+    public DateTime getNotBefore() {
+        return notBefore;
+    }
+
+    public DateTime getNotAfter() {
+        return notAfter;
+    }
+
+    public SequenceOf<Unsigned32> getClients() {
+        return clients;
+    }
+
+    public AuthorizationConstraint getConstraint() {
+        return constraint;
+    }
+
+    public AuthorizationScope getScope() {
+        return scope;
+    }
+
+    public AuthorizationPolicy(ByteQueue queue) throws BACnetException {
+        notBefore = readOptional(queue, DateTime.class, 0);
+        notAfter = readOptional(queue, DateTime.class, 1);
+        clients = readSequenceOf(queue, Unsigned32.class, 2);
+        constraint = read(queue, AuthorizationConstraint.class, 3);
+        scope = read(queue, AuthorizationScope.class, 4);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass())
+            return false;
+        AuthorizationPolicy that = (AuthorizationPolicy) o;
+        return Objects.equals(notBefore, that.notBefore) && Objects.equals(notAfter,
+                that.notAfter) && Objects.equals(clients, that.clients) && Objects.equals(constraint,
+                that.constraint) && Objects.equals(scope, that.scope);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(notBefore, notAfter, clients, constraint, scope);
+    }
+}

--- a/src/main/java/com/serotonin/bacnet4j/type/constructed/AuthorizationScopeDescription.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/constructed/AuthorizationScopeDescription.java
@@ -1,0 +1,86 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2026 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
+package com.serotonin.bacnet4j.type.constructed;
+
+import java.util.Objects;
+
+import com.serotonin.bacnet4j.exception.BACnetException;
+import com.serotonin.bacnet4j.type.primitive.CharacterString;
+import com.serotonin.bacnet4j.util.sero.ByteQueue;
+
+public class AuthorizationScopeDescription extends BaseType {
+    private final CharacterString name;
+    private final CharacterString description;
+
+    public AuthorizationScopeDescription(
+            CharacterString name,
+            CharacterString description) {
+        this.name = name;
+        this.description = description;
+    }
+
+    @Override
+    public void write(ByteQueue queue) {
+        write(queue, name);
+        write(queue, description);
+    }
+
+    @Override
+    public String toString() {
+        return "AuthorizationScopeDescription [" +
+                "name=" + name +
+                ", description=" + description +
+                ']';
+    }
+
+    public CharacterString getName() {
+        return name;
+    }
+
+    public CharacterString getDescription() {
+        return description;
+    }
+
+    public AuthorizationScopeDescription(ByteQueue queue) throws BACnetException {
+        name = read(queue, CharacterString.class);
+        description = read(queue, CharacterString.class);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass())
+            return false;
+        AuthorizationScopeDescription that = (AuthorizationScopeDescription) o;
+        return Objects.equals(name, that.name) && Objects.equals(description, that.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, description);
+    }
+}

--- a/src/main/java/com/serotonin/bacnet4j/type/enumerated/SuccessFilter.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/enumerated/SuccessFilter.java
@@ -1,0 +1,101 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2026 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
+package com.serotonin.bacnet4j.type.enumerated;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.serotonin.bacnet4j.exception.BACnetErrorException;
+import com.serotonin.bacnet4j.type.primitive.Enumerated;
+import com.serotonin.bacnet4j.util.sero.ByteQueue;
+
+public class SuccessFilter extends Enumerated {
+    public static final SuccessFilter all = new SuccessFilter(0);
+    public static final SuccessFilter successesOnly = new SuccessFilter(1);
+    public static final SuccessFilter failuresOnly = new SuccessFilter(2);
+
+    private static final Map<Integer, Enumerated> idMap = new HashMap<>();
+    private static final Map<String, Enumerated> nameMap = new HashMap<>();
+    private static final Map<Integer, String> prettyMap = new HashMap<>();
+
+    static {
+        Enumerated.init(MethodHandles.lookup().lookupClass(), idMap, nameMap, prettyMap);
+    }
+
+    public static SuccessFilter forId(int id) {
+        SuccessFilter e = (SuccessFilter) idMap.get(id);
+        if (e == null)
+            e = new SuccessFilter(id);
+        return e;
+    }
+
+    public static String nameForId(int id) {
+        return prettyMap.get(id);
+    }
+
+    public static SuccessFilter forName(String name) {
+        return (SuccessFilter) Enumerated.forName(nameMap, name);
+    }
+
+    public static int size() {
+        return idMap.size();
+    }
+
+    private SuccessFilter(int value) {
+        super(value);
+    }
+
+    public SuccessFilter(ByteQueue queue) throws BACnetErrorException {
+        super(queue);
+    }
+
+    /**
+     * Returns a unmodifiable map.
+     *
+     * @return unmodifiable map
+     */
+    public static Map<Integer, String> getPrettyMap() {
+        return Collections.unmodifiableMap(prettyMap);
+    }
+
+    /**
+     * Returns a unmodifiable nameMap.
+     *
+     * @return unmodifiable map
+     */
+    public static Map<String, Enumerated> getNameMap() {
+        return Collections.unmodifiableMap(nameMap);
+    }
+
+    @Override
+    public String toString() {
+        return super.toString(prettyMap);
+    }
+}

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/Unsigned16.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/Unsigned16.java
@@ -41,15 +41,24 @@ public class Unsigned16 extends UnsignedInteger {
     private static final int MAX = 0xffff;
     private static final BigInteger BIGMAX = BigInteger.valueOf(MAX);
 
-    public Unsigned16(final int value) {
+    public Unsigned16(int value) {
         super(value);
         if (value > MAX)
             throw new IllegalArgumentException("Value cannot be greater than " + MAX);
     }
 
-    public Unsigned16(final ByteQueue queue) throws BACnetErrorException {
+    public Unsigned16(ByteQueue queue) throws BACnetErrorException {
         super(queue);
     }
+
+    public Unsigned16 increment() {
+        return increment(1);
+    }
+
+    public Unsigned16 increment(int amount) {
+        return new Unsigned16((intValue() + amount) % 0x10000);
+    }
+
 
     @Override
     public void validate() throws BACnetServiceException {

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/Unsigned32.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/Unsigned32.java
@@ -36,21 +36,39 @@ import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
 
 public class Unsigned32 extends UnsignedInteger {
-    private static final long MAX = 0xffffffffl;
+    public static final Unsigned32 ZERO = new Unsigned32(0);
+
+    private static final long MAX = 0xffffffffL;
     private static final BigInteger BIGMAX = BigInteger.valueOf(MAX);
 
-    public Unsigned32(final int value) {
+    public Unsigned32(int value) {
         super(value);
     }
 
-    public Unsigned32(final BigInteger value) {
+    public Unsigned32(long value) {
+        super(value);
+    }
+
+    public Unsigned32(UnsignedInteger value) {
+        super(value.bigIntegerValue());
+    }
+
+    public Unsigned32(BigInteger value) {
         super(value);
         if (value.longValue() > MAX)
             throw new IllegalArgumentException("Value cannot be greater than " + MAX);
     }
 
-    public Unsigned32(final ByteQueue queue) throws BACnetErrorException {
+    public Unsigned32(ByteQueue queue) throws BACnetErrorException {
         super(queue);
+    }
+
+    public Unsigned32 increment() {
+        return increment(1);
+    }
+
+    public Unsigned32 increment(long amount) {
+        return new Unsigned32((longValue() + amount) % 0x100000000L);
     }
 
     @Override

--- a/src/test/java/com/serotonin/bacnet4j/obj/BinaryInputObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/BinaryInputObjectTest.java
@@ -56,6 +56,7 @@ import com.serotonin.bacnet4j.type.eventParameter.EventParameter;
 import com.serotonin.bacnet4j.type.notificationParameters.ChangeOfStateNotif;
 import com.serotonin.bacnet4j.type.notificationParameters.NotificationParameters;
 import com.serotonin.bacnet4j.type.primitive.Boolean;
+import com.serotonin.bacnet4j.type.primitive.Unsigned32;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
 public class BinaryInputObjectTest extends AbstractTest {
@@ -77,12 +78,12 @@ public class BinaryInputObjectTest extends AbstractTest {
     @SuppressWarnings("unchecked")
     @Test
     public void intrinsicReporting() throws Exception {
-        final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
+        SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
         recipients.add(new Destination(new Recipient(rd2.getAddress()), new UnsignedInteger(10), Boolean.TRUE,
                 new EventTransitionBits(true, true, true)));
 
         // Create an event listener on d2 to catch the event notifications.
-        final EventNotifListener listener = new EventNotifListener();
+        EventNotifListener listener = new EventNotifListener();
         d2.getEventHandler().addListener(listener);
 
         bi.supportIntrinsicReporting(5, 17, BinaryPV.active, new EventTransitionBits(true, true, true),
@@ -156,21 +157,21 @@ public class BinaryInputObjectTest extends AbstractTest {
     @SuppressWarnings("unchecked")
     @Test
     public void algorithmicReporting() throws Exception {
-        final DeviceObjectPropertyReference ref =
+        DeviceObjectPropertyReference ref =
                 new DeviceObjectPropertyReference(1, bi.getId(), PropertyIdentifier.presentValue);
-        final EventEnrollmentObject ee = d1.addObject(new EventEnrollmentObject(
+        EventEnrollmentObject ee = d1.addObject(new EventEnrollmentObject(
                 d1, 0, "ee", ref, NotifyType.alarm,
                 new EventParameter(new ChangeOfState(new UnsignedInteger(30),
                         new SequenceOf<>(new PropertyStates(BinaryPV.active)))),
                 new EventTransitionBits(true, true, true), 17, 1000, null, null));
 
         // Set up the notification destination
-        final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
+        SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
         recipients.add(new Destination(new Recipient(rd2.getAddress()), new UnsignedInteger(10), Boolean.TRUE,
                 new EventTransitionBits(true, true, true)));
 
         // Create an event listener on d2 to catch the event notifications.
-        final EventNotifListener listener = new EventNotifListener();
+        EventNotifListener listener = new EventNotifListener();
         d2.getEventHandler().addListener(listener);
 
         // Ensure that initializing the event enrollment object didn't fire any notifications.
@@ -249,58 +250,58 @@ public class BinaryInputObjectTest extends AbstractTest {
 
     @Test
     public void activeTime() throws Exception {
-        final DateTime start = new DateTime(d1);
+        DateTime start = new DateTime(d1);
 
         bi.supportActiveTime();
 
         clock.plusMillis(3500);
-        assertEquals(UnsignedInteger.ZERO, bi.readProperty(PropertyIdentifier.elapsedActiveTime));
+        assertEquals(Unsigned32.ZERO, bi.readProperty(PropertyIdentifier.elapsedActiveTime));
         assertEquals(start, bi.readProperty(PropertyIdentifier.timeOfActiveTimeReset));
 
         bi.writePropertyInternal(PropertyIdentifier.presentValue, BinaryPV.active);
         clock.plusMillis(1600); // Total active time 1600ms
-        assertEquals(new UnsignedInteger(1), bi.readProperty(PropertyIdentifier.elapsedActiveTime));
+        assertEquals(new Unsigned32(1), bi.readProperty(PropertyIdentifier.elapsedActiveTime));
         assertEquals(start, bi.readProperty(PropertyIdentifier.timeOfActiveTimeReset));
 
         bi.writePropertyInternal(PropertyIdentifier.presentValue, BinaryPV.active);
         clock.plusMillis(1600); // Total active time 3200ms
-        assertEquals(new UnsignedInteger(3), bi.readProperty(PropertyIdentifier.elapsedActiveTime));
+        assertEquals(new Unsigned32(3), bi.readProperty(PropertyIdentifier.elapsedActiveTime));
         assertEquals(start, bi.readProperty(PropertyIdentifier.timeOfActiveTimeReset));
 
         bi.writePropertyInternal(PropertyIdentifier.presentValue, BinaryPV.inactive);
         clock.plusMillis(7000);
-        assertEquals(new UnsignedInteger(3), bi.readProperty(PropertyIdentifier.elapsedActiveTime));
+        assertEquals(new Unsigned32(3), bi.readProperty(PropertyIdentifier.elapsedActiveTime));
         assertEquals(start, bi.readProperty(PropertyIdentifier.timeOfActiveTimeReset));
 
         bi.writePropertyInternal(PropertyIdentifier.presentValue, BinaryPV.inactive);
         clock.plusMillis(500);
-        assertEquals(new UnsignedInteger(3), bi.readProperty(PropertyIdentifier.elapsedActiveTime));
+        assertEquals(new Unsigned32(3), bi.readProperty(PropertyIdentifier.elapsedActiveTime));
         assertEquals(start, bi.readProperty(PropertyIdentifier.timeOfActiveTimeReset));
 
         bi.writePropertyInternal(PropertyIdentifier.presentValue, BinaryPV.active);
         clock.plusMillis(4700); // Total active time 7900ms
-        assertEquals(new UnsignedInteger(7), bi.readProperty(PropertyIdentifier.elapsedActiveTime));
+        assertEquals(new Unsigned32(7), bi.readProperty(PropertyIdentifier.elapsedActiveTime));
         assertEquals(start, bi.readProperty(PropertyIdentifier.timeOfActiveTimeReset));
 
-        bi.writePropertyInternal(PropertyIdentifier.elapsedActiveTime, new UnsignedInteger(5));
-        assertEquals(new UnsignedInteger(5), bi.readProperty(PropertyIdentifier.elapsedActiveTime));
+        bi.writePropertyInternal(PropertyIdentifier.elapsedActiveTime, new Unsigned32(5));
+        assertEquals(new Unsigned32(5), bi.readProperty(PropertyIdentifier.elapsedActiveTime));
         assertEquals(start, bi.readProperty(PropertyIdentifier.timeOfActiveTimeReset));
 
         clock.plusMillis(1234);
-        bi.writePropertyInternal(PropertyIdentifier.elapsedActiveTime, UnsignedInteger.ZERO);
-        assertEquals(UnsignedInteger.ZERO, bi.readProperty(PropertyIdentifier.elapsedActiveTime));
+        bi.writePropertyInternal(PropertyIdentifier.elapsedActiveTime, Unsigned32.ZERO);
+        assertEquals(Unsigned32.ZERO, bi.readProperty(PropertyIdentifier.elapsedActiveTime));
         assertEquals(new DateTime(d1), bi.readProperty(PropertyIdentifier.timeOfActiveTimeReset));
     }
 
     @Test
     public void stateChanges() throws Exception {
-        final DateTime start = new DateTime(d1);
+        DateTime start = new DateTime(d1);
         assertEquals(DateTime.UNSPECIFIED, bi.readProperty(PropertyIdentifier.changeOfStateTime));
         assertEquals(UnsignedInteger.ZERO, bi.readProperty(PropertyIdentifier.changeOfStateCount));
         assertEquals(start, bi.readProperty(PropertyIdentifier.timeOfStateCountReset));
 
         clock.plusMinutes(4);
-        final DateTime t1 = new DateTime(d1);
+        DateTime t1 = new DateTime(d1);
         bi.writePropertyInternal(PropertyIdentifier.presentValue, BinaryPV.active);
         assertEquals(t1, bi.readProperty(PropertyIdentifier.changeOfStateTime));
         assertEquals(new UnsignedInteger(1), bi.readProperty(PropertyIdentifier.changeOfStateCount));
@@ -313,7 +314,7 @@ public class BinaryInputObjectTest extends AbstractTest {
         assertEquals(start, bi.readProperty(PropertyIdentifier.timeOfStateCountReset));
 
         clock.plusMinutes(6);
-        final DateTime t2 = new DateTime(d1);
+        DateTime t2 = new DateTime(d1);
         bi.writePropertyInternal(PropertyIdentifier.presentValue, BinaryPV.inactive);
         bi.writePropertyInternal(PropertyIdentifier.presentValue, BinaryPV.active);
         bi.writePropertyInternal(PropertyIdentifier.presentValue, BinaryPV.inactive);
@@ -328,7 +329,7 @@ public class BinaryInputObjectTest extends AbstractTest {
         assertEquals(start, bi.readProperty(PropertyIdentifier.timeOfStateCountReset));
 
         clock.plusMinutes(8);
-        final DateTime t3 = new DateTime(d1);
+        DateTime t3 = new DateTime(d1);
         bi.writePropertyInternal(PropertyIdentifier.changeOfStateCount, UnsignedInteger.ZERO);
         assertEquals(t2, bi.readProperty(PropertyIdentifier.changeOfStateTime));
         assertEquals(UnsignedInteger.ZERO, bi.readProperty(PropertyIdentifier.changeOfStateCount));

--- a/src/test/java/com/serotonin/bacnet4j/obj/BinaryOutputObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/BinaryOutputObjectTest.java
@@ -64,6 +64,7 @@ import com.serotonin.bacnet4j.type.eventParameter.EventParameter;
 import com.serotonin.bacnet4j.type.notificationParameters.CommandFailureNotif;
 import com.serotonin.bacnet4j.type.primitive.Boolean;
 import com.serotonin.bacnet4j.type.primitive.Null;
+import com.serotonin.bacnet4j.type.primitive.Unsigned32;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 import com.serotonin.bacnet4j.util.RequestUtils;
 
@@ -91,11 +92,11 @@ public class BinaryOutputObjectTest extends AbstractTest {
 
     @Test
     public void annexI() throws Exception {
-        obj.writePropertyInternal(PropertyIdentifier.minimumOnTime, new UnsignedInteger(1)); // 2 seconds
-        obj.writePropertyInternal(PropertyIdentifier.minimumOffTime, new UnsignedInteger(2)); // 4 seconds
+        obj.writePropertyInternal(PropertyIdentifier.minimumOnTime, new Unsigned32(1)); // 2 seconds
+        obj.writePropertyInternal(PropertyIdentifier.minimumOffTime, new Unsigned32(2)); // 4 seconds
         obj.writePropertyInternal(PropertyIdentifier.outOfService, Boolean.FALSE);
 
-        final PriorityArray pa = obj.readProperty(priorityArray);
+        PriorityArray pa = obj.readProperty(priorityArray);
 
         // See Annex I for a description of this process.
         // a)
@@ -183,12 +184,12 @@ public class BinaryOutputObjectTest extends AbstractTest {
     @SuppressWarnings("unchecked")
     @Test
     public void intrinsicReporting() throws Exception {
-        final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
+        SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
         recipients.add(new Destination(new Recipient(rd2.getAddress()), new UnsignedInteger(10), Boolean.TRUE,
                 new EventTransitionBits(true, true, true)));
 
         // Create an event listener on d2 to catch the event notifications.
-        final EventNotifListener listener = new EventNotifListener();
+        EventNotifListener listener = new EventNotifListener();
         d2.getEventHandler().addListener(listener);
 
         obj.supportIntrinsicReporting(5, 17, BinaryPV.inactive, new EventTransitionBits(true, true, true),
@@ -266,21 +267,21 @@ public class BinaryOutputObjectTest extends AbstractTest {
     @SuppressWarnings("unchecked")
     @Test
     public void algorithmicReporting() throws Exception {
-        final DeviceObjectPropertyReference ref =
+        DeviceObjectPropertyReference ref =
                 new DeviceObjectPropertyReference(1, obj.getId(), PropertyIdentifier.presentValue);
-        final EventEnrollmentObject ee = d1.addObject(new EventEnrollmentObject(
+        EventEnrollmentObject ee = d1.addObject(new EventEnrollmentObject(
                 d1, 0, "ee", ref, NotifyType.alarm,
                 new EventParameter(new CommandFailure(new UnsignedInteger(30),
                         new DeviceObjectPropertyReference(1, obj.getId(), PropertyIdentifier.feedbackValue))),
                 new EventTransitionBits(true, true, true), 17, 1000, null, null));
 
         // Set up the notification destination
-        final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
+        SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
         recipients.add(new Destination(new Recipient(rd2.getAddress()), new UnsignedInteger(10), Boolean.TRUE,
                 new EventTransitionBits(true, true, true)));
 
         // Create an event listener on d2 to catch the event notifications.
-        final EventNotifListener listener = new EventNotifListener();
+        EventNotifListener listener = new EventNotifListener();
         d2.getEventHandler().addListener(listener);
 
         // Ensure that initializing the event enrollment object didn't fire any notifications.
@@ -367,63 +368,63 @@ public class BinaryOutputObjectTest extends AbstractTest {
         try {
             obj.supportActiveTime(true);
             fail("Should have thrown an IllegalStateException");
-        } catch (@SuppressWarnings("unused") final IllegalStateException e) {
+        } catch (@SuppressWarnings("unused") IllegalStateException e) {
             // Expected
         }
 
-        final DateTime start = new DateTime(d1);
+        DateTime start = new DateTime(d1);
 
         obj.writePropertyInternal(PropertyIdentifier.feedbackValue, BinaryPV.inactive);
         obj.supportActiveTime(true);
 
         clock.plusMillis(3500);
-        assertEquals(UnsignedInteger.ZERO, obj.readProperty(PropertyIdentifier.elapsedActiveTime));
+        assertEquals(Unsigned32.ZERO, obj.readProperty(PropertyIdentifier.elapsedActiveTime));
         assertEquals(start, obj.readProperty(PropertyIdentifier.timeOfActiveTimeReset));
 
         obj.writePropertyInternal(PropertyIdentifier.feedbackValue, BinaryPV.active);
         clock.plusMillis(1600); // Total active time 1600ms
-        assertEquals(new UnsignedInteger(1), obj.readProperty(PropertyIdentifier.elapsedActiveTime));
+        assertEquals(new Unsigned32(1), obj.readProperty(PropertyIdentifier.elapsedActiveTime));
         assertEquals(start, obj.readProperty(PropertyIdentifier.timeOfActiveTimeReset));
 
         obj.writePropertyInternal(PropertyIdentifier.feedbackValue, BinaryPV.active);
         clock.plusMillis(1600); // Total active time 3200ms
-        assertEquals(new UnsignedInteger(3), obj.readProperty(PropertyIdentifier.elapsedActiveTime));
+        assertEquals(new Unsigned32(3), obj.readProperty(PropertyIdentifier.elapsedActiveTime));
         assertEquals(start, obj.readProperty(PropertyIdentifier.timeOfActiveTimeReset));
 
         obj.writePropertyInternal(PropertyIdentifier.feedbackValue, BinaryPV.inactive);
         clock.plusMillis(7000);
-        assertEquals(new UnsignedInteger(3), obj.readProperty(PropertyIdentifier.elapsedActiveTime));
+        assertEquals(new Unsigned32(3), obj.readProperty(PropertyIdentifier.elapsedActiveTime));
         assertEquals(start, obj.readProperty(PropertyIdentifier.timeOfActiveTimeReset));
 
         obj.writePropertyInternal(PropertyIdentifier.feedbackValue, BinaryPV.inactive);
         clock.plusMillis(500);
-        assertEquals(new UnsignedInteger(3), obj.readProperty(PropertyIdentifier.elapsedActiveTime));
+        assertEquals(new Unsigned32(3), obj.readProperty(PropertyIdentifier.elapsedActiveTime));
         assertEquals(start, obj.readProperty(PropertyIdentifier.timeOfActiveTimeReset));
 
         obj.writePropertyInternal(PropertyIdentifier.feedbackValue, BinaryPV.active);
         clock.plusMillis(4700); // Total active time 7900ms
-        assertEquals(new UnsignedInteger(7), obj.readProperty(PropertyIdentifier.elapsedActiveTime));
+        assertEquals(new Unsigned32(7), obj.readProperty(PropertyIdentifier.elapsedActiveTime));
         assertEquals(start, obj.readProperty(PropertyIdentifier.timeOfActiveTimeReset));
 
-        obj.writePropertyInternal(PropertyIdentifier.elapsedActiveTime, new UnsignedInteger(5));
-        assertEquals(new UnsignedInteger(5), obj.readProperty(PropertyIdentifier.elapsedActiveTime));
+        obj.writePropertyInternal(PropertyIdentifier.elapsedActiveTime, new Unsigned32(5));
+        assertEquals(new Unsigned32(5), obj.readProperty(PropertyIdentifier.elapsedActiveTime));
         assertEquals(start, obj.readProperty(PropertyIdentifier.timeOfActiveTimeReset));
 
         clock.plusMillis(1234);
-        obj.writePropertyInternal(PropertyIdentifier.elapsedActiveTime, UnsignedInteger.ZERO);
-        assertEquals(UnsignedInteger.ZERO, obj.readProperty(PropertyIdentifier.elapsedActiveTime));
+        obj.writePropertyInternal(PropertyIdentifier.elapsedActiveTime, Unsigned32.ZERO);
+        assertEquals(Unsigned32.ZERO, obj.readProperty(PropertyIdentifier.elapsedActiveTime));
         assertEquals(new DateTime(d1), obj.readProperty(PropertyIdentifier.timeOfActiveTimeReset));
     }
 
     @Test
     public void stateChanges() throws Exception {
-        final DateTime start = new DateTime(d1);
+        DateTime start = new DateTime(d1);
         assertEquals(DateTime.UNSPECIFIED, obj.readProperty(PropertyIdentifier.changeOfStateTime));
         assertEquals(UnsignedInteger.ZERO, obj.readProperty(PropertyIdentifier.changeOfStateCount));
         assertEquals(start, obj.readProperty(PropertyIdentifier.timeOfStateCountReset));
 
         clock.plusMinutes(4);
-        final DateTime t1 = new DateTime(d1);
+        DateTime t1 = new DateTime(d1);
         obj.writePropertyInternal(PropertyIdentifier.presentValue, BinaryPV.active);
         assertEquals(t1, obj.readProperty(PropertyIdentifier.changeOfStateTime));
         assertEquals(new UnsignedInteger(1), obj.readProperty(PropertyIdentifier.changeOfStateCount));
@@ -436,7 +437,7 @@ public class BinaryOutputObjectTest extends AbstractTest {
         assertEquals(start, obj.readProperty(PropertyIdentifier.timeOfStateCountReset));
 
         clock.plusMinutes(6);
-        final DateTime t2 = new DateTime(d1);
+        DateTime t2 = new DateTime(d1);
         obj.writePropertyInternal(PropertyIdentifier.presentValue, BinaryPV.inactive);
         obj.writePropertyInternal(PropertyIdentifier.presentValue, BinaryPV.active);
         obj.writePropertyInternal(PropertyIdentifier.presentValue, BinaryPV.inactive);
@@ -451,7 +452,7 @@ public class BinaryOutputObjectTest extends AbstractTest {
         assertEquals(start, obj.readProperty(PropertyIdentifier.timeOfStateCountReset));
 
         clock.plusMinutes(8);
-        final DateTime t3 = new DateTime(d1);
+        DateTime t3 = new DateTime(d1);
         obj.writePropertyInternal(PropertyIdentifier.changeOfStateCount, UnsignedInteger.ZERO);
         assertEquals(t2, obj.readProperty(PropertyIdentifier.changeOfStateTime));
         assertEquals(UnsignedInteger.ZERO, obj.readProperty(PropertyIdentifier.changeOfStateCount));

--- a/src/test/java/com/serotonin/bacnet4j/obj/EventLogObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/EventLogObjectTest.java
@@ -37,7 +37,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Calendar;
-import java.util.GregorianCalendar;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
@@ -444,16 +443,16 @@ public class EventLogObjectTest extends AbstractTest {
 
     @Test
     public void startStopTimes() throws Exception {
-        DateTime now = new DateTime(clock.millis());
-        GregorianCalendar nowgg = now.getGC();
+        var localNow = new DateTime(clock.millis());
+        var nowgg = localNow.getGC();
 
         // Set the start time to 5 minutes from now.
         nowgg.add(Calendar.MINUTE, 5);
-        DateTime startTime = new DateTime(nowgg);
+        var startTime = new DateTime(nowgg);
 
         // Set the stop time to 10 minutes from now.
         nowgg.add(Calendar.MINUTE, 5);
-        DateTime stopTime = new DateTime(nowgg);
+        var stopTime = new DateTime(nowgg);
 
         // Create a triggered trend log
         EventLogObject el = d1.addObject(new EventLogObject(

--- a/src/test/java/com/serotonin/bacnet4j/obj/EventLogObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/EventLogObjectTest.java
@@ -74,6 +74,7 @@ import com.serotonin.bacnet4j.type.primitive.Boolean;
 import com.serotonin.bacnet4j.type.primitive.CharacterString;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
 import com.serotonin.bacnet4j.type.primitive.Real;
+import com.serotonin.bacnet4j.type.primitive.Unsigned32;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
 public class EventLogObjectTest extends AbstractTest {
@@ -105,7 +106,7 @@ public class EventLogObjectTest extends AbstractTest {
 
     @Test
     public void logging() throws Exception {
-        final EventLogObject el = d1.addObject(new EventLogObject(
+        EventLogObject el = d1.addObject(new EventLogObject(
                 d1, 0, "el", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED, DateTime.UNSPECIFIED, false, 20));
 
         // The buffer should still be empty
@@ -116,7 +117,7 @@ public class EventLogObjectTest extends AbstractTest {
 
         // The log record should be there.
         assertEquals(1, el.getBuffer().size());
-        final EventLogRecord record0 = el.getBuffer().get(0);
+        EventLogRecord record0 = el.getBuffer().get(0);
         assertEquals(now, record0.getTimestamp());
         assertEquals(1, record0.getSequenceNumber());
         assertEquals(n1, record0.getNotification());
@@ -127,12 +128,12 @@ public class EventLogObjectTest extends AbstractTest {
 
         // The log record should be there.
         assertEquals(3, el.getBuffer().size());
-        final EventLogRecord record1 = el.getBuffer().get(1);
+        EventLogRecord record1 = el.getBuffer().get(1);
         assertEquals(now, record1.getTimestamp());
         assertEquals(2, record1.getSequenceNumber());
         assertEquals(n2, record1.getNotification());
 
-        final EventLogRecord record2 = el.getBuffer().get(2);
+        EventLogRecord record2 = el.getBuffer().get(2);
         assertEquals(now, record2.getTimestamp());
         assertEquals(3, record2.getSequenceNumber());
         assertEquals(n1, record2.getNotification());
@@ -142,18 +143,18 @@ public class EventLogObjectTest extends AbstractTest {
     @Test
     public void intrinsicReporting() throws Exception {
         // Create a triggered trend log with intrinsic reporting enabled.
-        final EventLogObject el = d1.addObject(new EventLogObject(
+        EventLogObject el = d1.addObject(new EventLogObject(
                 d1, 0, "el", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
                 DateTime.UNSPECIFIED, false, 20)
                 .supportIntrinsicReporting(5, 23, new EventTransitionBits(true, true, true), NotifyType.event));
 
         // Add d2 as an event recipient.
-        final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
+        SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
         recipients.add(new Destination(new Recipient(rd2.getAddress()), new UnsignedInteger(27), Boolean.TRUE,
                 new EventTransitionBits(true, true, true)));
 
         // Create an event listener on d2 to catch the event notifications.
-        final EventNotifListener listener = new EventNotifListener();
+        EventNotifListener listener = new EventNotifListener();
         d2.getEventHandler().addListener(listener);
 
         //
@@ -164,10 +165,10 @@ public class EventLogObjectTest extends AbstractTest {
         d2.send(rd1, n1).get();
         assertEquals(4, el.getBuffer().size());
         assertEquals(0, listener.getNotifCount());
-        assertEquals(new UnsignedInteger(4), el.get(PropertyIdentifier.recordCount));
-        assertEquals(new UnsignedInteger(4), el.get(PropertyIdentifier.totalRecordCount));
-        assertEquals(new UnsignedInteger(4), el.get(PropertyIdentifier.recordsSinceNotification));
-        assertEquals(UnsignedInteger.ZERO, el.get(PropertyIdentifier.lastNotifyRecord));
+        assertEquals(new Unsigned32(4), el.get(PropertyIdentifier.recordCount));
+        assertEquals(new Unsigned32(4), el.get(PropertyIdentifier.totalRecordCount));
+        assertEquals(new Unsigned32(4), el.get(PropertyIdentifier.recordsSinceNotification));
+        assertEquals(Unsigned32.ZERO, el.get(PropertyIdentifier.lastNotifyRecord));
 
         //
         // Write one more and make sure a notification was received.
@@ -193,10 +194,10 @@ public class EventLogObjectTest extends AbstractTest {
                         UnsignedInteger.ZERO, new UnsignedInteger(5))), notif.eventValues());
 
         // Validate the internally maintained values.
-        assertEquals(new UnsignedInteger(5), el.get(PropertyIdentifier.recordCount));
-        assertEquals(new UnsignedInteger(5), el.get(PropertyIdentifier.totalRecordCount));
-        assertEquals(UnsignedInteger.ZERO, el.get(PropertyIdentifier.recordsSinceNotification));
-        assertEquals(new UnsignedInteger(5), el.get(PropertyIdentifier.lastNotifyRecord));
+        assertEquals(new Unsigned32(5), el.get(PropertyIdentifier.recordCount));
+        assertEquals(new Unsigned32(5), el.get(PropertyIdentifier.totalRecordCount));
+        assertEquals(Unsigned32.ZERO, el.get(PropertyIdentifier.recordsSinceNotification));
+        assertEquals(new Unsigned32(5), el.get(PropertyIdentifier.lastNotifyRecord));
 
         //
         // Write another 5 triggers and ensure that the notification looks ok.
@@ -226,15 +227,15 @@ public class EventLogObjectTest extends AbstractTest {
                         new UnsignedInteger(5), new UnsignedInteger(10))), notif.eventValues());
 
         // Validate the internally maintained values.
-        assertEquals(new UnsignedInteger(10), el.get(PropertyIdentifier.recordCount));
-        assertEquals(new UnsignedInteger(10), el.get(PropertyIdentifier.totalRecordCount));
-        assertEquals(UnsignedInteger.ZERO, el.get(PropertyIdentifier.recordsSinceNotification));
-        assertEquals(new UnsignedInteger(10), el.get(PropertyIdentifier.lastNotifyRecord));
+        assertEquals(new Unsigned32(10), el.get(PropertyIdentifier.recordCount));
+        assertEquals(new Unsigned32(10), el.get(PropertyIdentifier.totalRecordCount));
+        assertEquals(Unsigned32.ZERO, el.get(PropertyIdentifier.recordsSinceNotification));
+        assertEquals(new Unsigned32(10), el.get(PropertyIdentifier.lastNotifyRecord));
 
         //
         // Update the values of the trend log such that we can trigger condition 2 in the buffer ready algo.
-        el.set(PropertyIdentifier.lastNotifyRecord, new UnsignedInteger(0xFFFFFFFDL));
-        el.set(PropertyIdentifier.totalRecordCount, new UnsignedInteger(0xFFFFFFFDL));
+        el.set(PropertyIdentifier.lastNotifyRecord, new Unsigned32(0xFFFFFFFDL));
+        el.set(PropertyIdentifier.totalRecordCount, new Unsigned32(0xFFFFFFFDL));
         d2.send(rd1, n1).get();
         d2.send(rd1, n1).get();
         d2.send(rd1, n1).get();
@@ -261,35 +262,35 @@ public class EventLogObjectTest extends AbstractTest {
                         new UnsignedInteger(0xFFFFFFFDL), new UnsignedInteger(3))), notif.eventValues());
 
         // Validate the internally maintained values.
-        assertEquals(new UnsignedInteger(15), el.get(PropertyIdentifier.recordCount));
-        assertEquals(new UnsignedInteger(3), el.get(PropertyIdentifier.totalRecordCount));
-        assertEquals(UnsignedInteger.ZERO, el.get(PropertyIdentifier.recordsSinceNotification));
-        assertEquals(new UnsignedInteger(3), el.get(PropertyIdentifier.lastNotifyRecord));
+        assertEquals(new Unsigned32(15), el.get(PropertyIdentifier.recordCount));
+        assertEquals(new Unsigned32(3), el.get(PropertyIdentifier.totalRecordCount));
+        assertEquals(Unsigned32.ZERO, el.get(PropertyIdentifier.recordsSinceNotification));
+        assertEquals(new Unsigned32(3), el.get(PropertyIdentifier.lastNotifyRecord));
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void eventReporting() throws Exception {
         // Create a triggered trend log
-        final EventLogObject el = d1.addObject(new EventLogObject(
+        EventLogObject el = d1.addObject(new EventLogObject(
                 d1, 0, "el", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
                 DateTime.UNSPECIFIED, false, 20));
 
         // Create the event enrollment.
-        final DeviceObjectPropertyReference ref =
+        DeviceObjectPropertyReference ref =
                 new DeviceObjectPropertyReference(el.getId(), PropertyIdentifier.totalRecordCount, null, d1.getId());
-        final EventEnrollmentObject ee = d1.addObject(new EventEnrollmentObject(
+        EventEnrollmentObject ee = d1.addObject(new EventEnrollmentObject(
                 d1, 0, "ee", ref, NotifyType.event,
                 new EventParameter(new BufferReady(new UnsignedInteger(3), UnsignedInteger.ZERO)),
                 new EventTransitionBits(true, true, true), 23, 1000, null, null));
 
         // Set d2 as an event recipient.
-        final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
+        SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
         recipients.add(new Destination(new Recipient(d2.getId()), new UnsignedInteger(28), Boolean.TRUE,
                 new EventTransitionBits(true, true, true)));
 
         // Create an event listener on d2 to catch the event notifications.
-        final EventNotifListener listener = new EventNotifListener();
+        EventNotifListener listener = new EventNotifListener();
         d2.getEventHandler().addListener(listener);
 
         // Trigger updates, but not enough to cause a notification.
@@ -357,7 +358,7 @@ public class EventLogObjectTest extends AbstractTest {
     @Test
     public void stopWhenFull() throws Exception {
         // Create a triggered trend log
-        final EventLogObject el = d1.addObject(new EventLogObject(
+        EventLogObject el = d1.addObject(new EventLogObject(
                 d1, 0, "el", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
                 DateTime.UNSPECIFIED, true, 4));
 
@@ -367,8 +368,8 @@ public class EventLogObjectTest extends AbstractTest {
         assertEquals(2, el.getBuffer().size());
         assertEquals(n1, el.getBuffer().get(0).getNotification());
         assertEquals(n1, el.getBuffer().get(1).getNotification());
-        assertEquals(new UnsignedInteger(2), el.get(PropertyIdentifier.recordCount));
-        assertEquals(new UnsignedInteger(2), el.get(PropertyIdentifier.totalRecordCount));
+        assertEquals(new Unsigned32(2), el.get(PropertyIdentifier.recordCount));
+        assertEquals(new Unsigned32(2), el.get(PropertyIdentifier.totalRecordCount));
 
         // Add another record. This will cause the buffer to be full after the buffer full notification is written.
         d2.send(rd1, n1).get();
@@ -377,8 +378,8 @@ public class EventLogObjectTest extends AbstractTest {
         assertEquals(n1, el.getBuffer().get(1).getNotification());
         assertEquals(n1, el.getBuffer().get(2).getNotification());
         assertEquals(new LogStatus(true, false, false), el.getBuffer().get(3).getLogStatus());
-        assertEquals(new UnsignedInteger(4), el.get(PropertyIdentifier.recordCount));
-        assertEquals(new UnsignedInteger(4), el.get(PropertyIdentifier.totalRecordCount));
+        assertEquals(new Unsigned32(4), el.get(PropertyIdentifier.recordCount));
+        assertEquals(new Unsigned32(4), el.get(PropertyIdentifier.totalRecordCount));
         assertTrue(el.isLogDisabled());
 
         // Add more records. The log should not change. Advance the time just to be sure.
@@ -390,8 +391,8 @@ public class EventLogObjectTest extends AbstractTest {
         assertEquals(n1, el.getBuffer().get(1).getNotification());
         assertEquals(n1, el.getBuffer().get(2).getNotification());
         assertEquals(new LogStatus(true, false, false), el.getBuffer().get(3).getLogStatus());
-        assertEquals(new UnsignedInteger(4), el.get(PropertyIdentifier.recordCount));
-        assertEquals(new UnsignedInteger(4), el.get(PropertyIdentifier.totalRecordCount));
+        assertEquals(new Unsigned32(4), el.get(PropertyIdentifier.recordCount));
+        assertEquals(new Unsigned32(4), el.get(PropertyIdentifier.totalRecordCount));
         assertTrue(el.isLogDisabled());
 
         // Set StopWhenFull to false and write a couple records.
@@ -404,8 +405,8 @@ public class EventLogObjectTest extends AbstractTest {
         assertEquals(new LogStatus(true, false, false), el.getBuffer().get(1).getLogStatus());
         assertEquals(n1, el.getBuffer().get(2).getNotification());
         assertEquals(n1, el.getBuffer().get(3).getNotification());
-        assertEquals(new UnsignedInteger(4), el.get(PropertyIdentifier.recordCount));
-        assertEquals(new UnsignedInteger(6), el.get(PropertyIdentifier.totalRecordCount));
+        assertEquals(new Unsigned32(4), el.get(PropertyIdentifier.recordCount));
+        assertEquals(new Unsigned32(6), el.get(PropertyIdentifier.totalRecordCount));
         assertFalse(el.isLogDisabled());
 
         // Set StopWhenFull back to true.
@@ -415,15 +416,15 @@ public class EventLogObjectTest extends AbstractTest {
         assertEquals(n1, el.getBuffer().get(1).getNotification());
         assertEquals(n1, el.getBuffer().get(2).getNotification());
         assertEquals(new LogStatus(true, false, false), el.getBuffer().get(3).getLogStatus());
-        assertEquals(new UnsignedInteger(4), el.get(PropertyIdentifier.recordCount));
-        assertEquals(new UnsignedInteger(7), el.get(PropertyIdentifier.totalRecordCount));
+        assertEquals(new Unsigned32(4), el.get(PropertyIdentifier.recordCount));
+        assertEquals(new Unsigned32(7), el.get(PropertyIdentifier.totalRecordCount));
         assertTrue(el.isLogDisabled());
     }
 
     @Test
     public void enableDisable() throws Exception {
         // Create a disabled triggered trend log
-        final EventLogObject el = d1.addObject(new EventLogObject(
+        EventLogObject el = d1.addObject(new EventLogObject(
                 d1, 0, "el", new LinkedListLogBuffer<>(), false, DateTime.UNSPECIFIED,
                 DateTime.UNSPECIFIED, true, 4));
         assertEquals(0, el.getBuffer().size());
@@ -443,7 +444,7 @@ public class EventLogObjectTest extends AbstractTest {
 
     @Test
     public void startStopTimes() throws Exception {
-        final DateTime now = new DateTime(clock.millis());
+        DateTime now = new DateTime(clock.millis());
         GregorianCalendar nowgg = now.getGC();
 
         // Set the start time to 5 minutes from now.
@@ -455,7 +456,7 @@ public class EventLogObjectTest extends AbstractTest {
         DateTime stopTime = new DateTime(nowgg);
 
         // Create a triggered trend log
-        final EventLogObject el = d1.addObject(new EventLogObject(
+        EventLogObject el = d1.addObject(new EventLogObject(
                 d1, 0, "el", new LinkedListLogBuffer<>(), true, startTime, stopTime, true, 7));
         assertTrue(el.isLogDisabled());
         assertEquals(0, el.getBuffer().size());
@@ -481,7 +482,7 @@ public class EventLogObjectTest extends AbstractTest {
 
         // Advance the time past the stop time and do some triggers.
         advanceClock(clock, 5, TimeUnit.MINUTES, 1, TimeUnit.MINUTES, null, TestUtils::quiesce);
-        final DateTime now3 = new DateTime(clock.millis());
+        DateTime now3 = new DateTime(clock.millis());
         assertTrue(el.isLogDisabled());
         assertEquals(3, el.getBuffer().size());
         d2.send(rd1, n2).get();
@@ -523,7 +524,7 @@ public class EventLogObjectTest extends AbstractTest {
     @Test
     public void readLogBuffer() throws Exception {
         // Create a triggered trend log
-        final EventLogObject el = d1.addObject(new EventLogObject(
+        EventLogObject el = d1.addObject(new EventLogObject(
                 d1, 0, "el", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
                 DateTime.UNSPECIFIED, true, 7));
 
@@ -535,7 +536,7 @@ public class EventLogObjectTest extends AbstractTest {
     @Test
     public void purge() throws Exception {
         // Create a triggered trend log
-        final EventLogObject el = d1.addObject(new EventLogObject(
+        EventLogObject el = d1.addObject(new EventLogObject(
                 d1, 0, "el", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
                 DateTime.UNSPECIFIED, true, 7));
 
@@ -546,11 +547,11 @@ public class EventLogObjectTest extends AbstractTest {
 
         // Set the record count to non-zero.
         assertBACnetServiceException(
-                () -> el.writeProperty(null, new PropertyValue(PropertyIdentifier.recordCount, new UnsignedInteger(1))),
+                () -> el.writeProperty(null, new PropertyValue(PropertyIdentifier.recordCount, new Unsigned32(1))),
                 ErrorClass.property, ErrorCode.writeAccessDenied);
 
         // Set the record count to zero. There should be one log status record.
-        el.writeProperty(null, new PropertyValue(PropertyIdentifier.recordCount, UnsignedInteger.ZERO));
+        el.writeProperty(null, new PropertyValue(PropertyIdentifier.recordCount, Unsigned32.ZERO));
         assertEquals(1, el.getBuffer().size());
         assertEquals(new LogStatus(false, true, false), el.getBuffer().get(0).getLogStatus());
     }

--- a/src/test/java/com/serotonin/bacnet4j/obj/TrendLogMultipleObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/TrendLogMultipleObjectTest.java
@@ -80,6 +80,7 @@ import com.serotonin.bacnet4j.type.notificationParameters.NotificationParameters
 import com.serotonin.bacnet4j.type.primitive.Boolean;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
 import com.serotonin.bacnet4j.type.primitive.Real;
+import com.serotonin.bacnet4j.type.primitive.Unsigned32;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
 public class TrendLogMultipleObjectTest extends AbstractTest {
@@ -123,7 +124,7 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
     @Test
     public void pollingAlignedWithOffset() throws Exception {
         // Construct the log to poll each minute, aligned, and with a 2s offset.
-        final TrendLogMultipleObject tl = d1.addObject(new TrendLogMultipleObject(
+        TrendLogMultipleObject tl = d1.addObject(new TrendLogMultipleObject(
                 d1, 0, "tlm", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
                 DateTime.UNSPECIFIED, props, 0, false, 20)
                 .withPolled(1, MINUTES, true, 2, SECONDS));
@@ -133,12 +134,12 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
         //
         // Advance the clock to the polling time.
         LOG.debug("start: {}", clock.instant());
-        final int seconds = (62 - clock.get(ChronoField.SECOND_OF_MINUTE) - 1) % 60 + 1;
+        int seconds = (62 - clock.get(ChronoField.SECOND_OF_MINUTE) - 1) % 60 + 1;
         clock.plusSeconds(seconds);
         LOG.debug("poll: {}", clock.instant());
 
         awaitEquals(1, tl::getRecordCount);
-        final LogMultipleRecord record0 = tl.getRecord(0);
+        LogMultipleRecord record0 = tl.getRecord(0);
         // We asked for alignment and an offset of 2 seconds.
         assertEquals(2.0, record0.getTimestamp().getTime().getSecond(), 1.0);
         assertEquals(1, record0.getSequenceNumber());
@@ -158,7 +159,7 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
         LOG.debug("poll: {}", clock.instant());
 
         awaitEquals(2, tl::getRecordCount);
-        final LogMultipleRecord record1 = tl.getRecord(1);
+        LogMultipleRecord record1 = tl.getRecord(1);
         assertEquals(2, record1.getTimestamp().getTime().getSecond());
         assertEquals((record0.getTimestamp().getTime().getMinute() + 1) % 60,
                 record1.getTimestamp().getTime().getMinute());
@@ -176,13 +177,13 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
         ai.writePropertyInternal(PropertyIdentifier.presentValue, new Real(3));
 
         // Advance the clock to the new polling time.
-        final int minutes = (60 - clock.get(ChronoField.MINUTE_OF_HOUR)) % 60;
+        int minutes = (60 - clock.get(ChronoField.MINUTE_OF_HOUR)) % 60;
         clock.plusMinutes(minutes);
         LOG.debug("poll: {}", clock.instant());
 
         awaitEquals(3, tl::getRecordCount);
         assertEquals(3, tl.getRecordCount());
-        final LogMultipleRecord record2 = tl.getRecord(2);
+        LogMultipleRecord record2 = tl.getRecord(2);
         assertEquals(0, record2.getTimestamp().getTime().getMinute());
         assertEquals(3, record2.getSequenceNumber());
         assertEquals(5, record2.getLogData().getData().size());
@@ -199,7 +200,7 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
 
         // Wait for the polling to finish.
         awaitEquals(4, tl::getRecordCount);
-        final LogMultipleRecord record3 = tl.getRecord(3);
+        LogMultipleRecord record3 = tl.getRecord(3);
         assertEquals(4, record3.getSequenceNumber());
         assertEquals(5, record3.getLogData().getData().size());
         assertEquals(new Real(4), record3.getLogData().getData().get(0).getDatum());
@@ -211,11 +212,11 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
 
     @Test
     public void trigger() throws Exception {
-        final TrendLogMultipleObject tl = d1.addObject(new TrendLogMultipleObject(
+        TrendLogMultipleObject tl = d1.addObject(new TrendLogMultipleObject(
                 d1, 0, "tlm", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
                 DateTime.UNSPECIFIED, props, 0, false, 20));
 
-        final DateTime now = new DateTime(clock.millis());
+        DateTime now = new DateTime(clock.millis());
 
         // The buffer should still be empty
         assertEquals(0, tl.getRecordCount());
@@ -237,10 +238,10 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
         awaitEquals(1, tl::getRecordCount);
 
         // The log record should be there.
-        final LogMultipleRecord record0 = tl.getRecord(0);
+        LogMultipleRecord record0 = tl.getRecord(0);
         assertEquals(now, record0.getTimestamp());
         assertEquals(1, record0.getSequenceNumber());
-        final LogData data0 = record0.getLogData();
+        LogData data0 = record0.getLogData();
         assertEquals(new SequenceOf<>( //
                         new LogDataElement(new Real(3)), //
                         new LogDataElement(new Real(0)), //
@@ -254,20 +255,20 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
     @Test
     public void intrinsicReporting() throws Exception {
         // Create a triggered trend log with intrinsic reporting enabled.
-        final TrendLogMultipleObject tl = d1.addObject(new TrendLogMultipleObject(
+        TrendLogMultipleObject tl = d1.addObject(new TrendLogMultipleObject(
                 d1, 0, "tlm", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
                 DateTime.UNSPECIFIED, props, 0, false, 20) //
                 .supportIntrinsicReporting(5, 23, new EventTransitionBits(true, true, true), NotifyType.event));
 
-        final RemoteDevice rd2 = d1.getRemoteDeviceBlocking(2);
+        RemoteDevice rd2 = d1.getRemoteDeviceBlocking(2);
 
         // Add d2 as an event recipient.
-        final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
+        SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
         recipients.add(new Destination(new Recipient(rd2.getAddress()), new UnsignedInteger(27), Boolean.TRUE,
                 new EventTransitionBits(true, true, true)));
 
         // Create an event listener on d2 to catch the event notifications.
-        final EventNotifListener listener = new EventNotifListener();
+        EventNotifListener listener = new EventNotifListener();
         d2.getEventHandler().addListener(listener);
 
         //
@@ -275,10 +276,10 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
         doTriggers(tl, 4);
         assertEquals(4, tl.getRecordCount());
         assertEquals(0, listener.getNotifCount());
-        assertEquals(new UnsignedInteger(4), tl.get(PropertyIdentifier.recordCount));
-        assertEquals(new UnsignedInteger(4), tl.get(PropertyIdentifier.totalRecordCount));
-        assertEquals(new UnsignedInteger(4), tl.get(PropertyIdentifier.recordsSinceNotification));
-        assertEquals(UnsignedInteger.ZERO, tl.get(PropertyIdentifier.lastNotifyRecord));
+        assertEquals(new Unsigned32(4), tl.get(PropertyIdentifier.recordCount));
+        assertEquals(new Unsigned32(4), tl.get(PropertyIdentifier.totalRecordCount));
+        assertEquals(new Unsigned32(4), tl.get(PropertyIdentifier.recordsSinceNotification));
+        assertEquals(Unsigned32.ZERO, tl.get(PropertyIdentifier.lastNotifyRecord));
 
         //
         // Write one more and make sure a notification was received.
@@ -304,10 +305,10 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
                         UnsignedInteger.ZERO, new UnsignedInteger(5))), notif.eventValues());
 
         // Validate the internally maintained values.
-        assertEquals(new UnsignedInteger(5), tl.get(PropertyIdentifier.recordCount));
-        assertEquals(new UnsignedInteger(5), tl.get(PropertyIdentifier.totalRecordCount));
-        assertEquals(UnsignedInteger.ZERO, tl.get(PropertyIdentifier.recordsSinceNotification));
-        assertEquals(new UnsignedInteger(5), tl.get(PropertyIdentifier.lastNotifyRecord));
+        assertEquals(new Unsigned32(5), tl.get(PropertyIdentifier.recordCount));
+        assertEquals(new Unsigned32(5), tl.get(PropertyIdentifier.totalRecordCount));
+        assertEquals(Unsigned32.ZERO, tl.get(PropertyIdentifier.recordsSinceNotification));
+        assertEquals(new Unsigned32(5), tl.get(PropertyIdentifier.lastNotifyRecord));
 
         //
         // Write another 5 triggers and ensure that the notification looks ok.
@@ -333,15 +334,15 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
                         new UnsignedInteger(5), new UnsignedInteger(10))), notif.eventValues());
 
         // Validate the internally maintained values.
-        assertEquals(new UnsignedInteger(10), tl.get(PropertyIdentifier.recordCount));
-        assertEquals(new UnsignedInteger(10), tl.get(PropertyIdentifier.totalRecordCount));
-        assertEquals(UnsignedInteger.ZERO, tl.get(PropertyIdentifier.recordsSinceNotification));
-        assertEquals(new UnsignedInteger(10), tl.get(PropertyIdentifier.lastNotifyRecord));
+        assertEquals(new Unsigned32(10), tl.get(PropertyIdentifier.recordCount));
+        assertEquals(new Unsigned32(10), tl.get(PropertyIdentifier.totalRecordCount));
+        assertEquals(Unsigned32.ZERO, tl.get(PropertyIdentifier.recordsSinceNotification));
+        assertEquals(new Unsigned32(10), tl.get(PropertyIdentifier.lastNotifyRecord));
 
         //
         // Update the values of the trend log such that we can trigger condition 2 in the buffer ready algo.
-        tl.set(PropertyIdentifier.lastNotifyRecord, new UnsignedInteger(0xFFFFFFFDL));
-        tl.set(PropertyIdentifier.totalRecordCount, new UnsignedInteger(0xFFFFFFFDL));
+        tl.set(PropertyIdentifier.lastNotifyRecord, new Unsigned32(0xFFFFFFFDL));
+        tl.set(PropertyIdentifier.totalRecordCount, new Unsigned32(0xFFFFFFFDL));
         doTriggers(tl, 5);
         awaitEquals(15, tl::getRecordCount);
         awaitEquals(1, listener::getNotifCount);
@@ -364,13 +365,13 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
                         new UnsignedInteger(0xFFFFFFFDL), new UnsignedInteger(3))), notif.eventValues());
 
         // Validate the internally maintained values.
-        assertEquals(new UnsignedInteger(15), tl.get(PropertyIdentifier.recordCount));
-        assertEquals(new UnsignedInteger(3), tl.get(PropertyIdentifier.totalRecordCount));
-        assertEquals(UnsignedInteger.ZERO, tl.get(PropertyIdentifier.recordsSinceNotification));
-        assertEquals(new UnsignedInteger(3), tl.get(PropertyIdentifier.lastNotifyRecord));
+        assertEquals(new Unsigned32(15), tl.get(PropertyIdentifier.recordCount));
+        assertEquals(new Unsigned32(3), tl.get(PropertyIdentifier.totalRecordCount));
+        assertEquals(Unsigned32.ZERO, tl.get(PropertyIdentifier.recordsSinceNotification));
+        assertEquals(new Unsigned32(3), tl.get(PropertyIdentifier.lastNotifyRecord));
     }
 
-    private static void doTriggers(final TrendLogMultipleObject tl, final int count) throws Exception {
+    private static void doTriggers(TrendLogMultipleObject tl, int count) throws Exception {
         int remaining = count;
         while (remaining > 0) {
             await(tl::trigger);
@@ -383,25 +384,25 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
     @Test
     public void eventReporting() throws Exception {
         // Create a triggered trend log
-        final TrendLogMultipleObject tl = d1.addObject(new TrendLogMultipleObject(
+        TrendLogMultipleObject tl = d1.addObject(new TrendLogMultipleObject(
                 d1, 0, "tlm", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
                 DateTime.UNSPECIFIED, props, 0, false, 20));
 
         // Create the event enrollment.
-        final DeviceObjectPropertyReference ref =
+        DeviceObjectPropertyReference ref =
                 new DeviceObjectPropertyReference(tl.getId(), PropertyIdentifier.totalRecordCount, null, d1.getId());
-        final EventEnrollmentObject ee = d1.addObject(new EventEnrollmentObject(
+        EventEnrollmentObject ee = d1.addObject(new EventEnrollmentObject(
                 d1, 0, "ee", ref, NotifyType.event,
                 new EventParameter(new BufferReady(new UnsignedInteger(3), UnsignedInteger.ZERO)),
                 new EventTransitionBits(true, true, true), 23, 1000, null, null));
 
         // Set d2 as an event recipient.
-        final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
+        SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
         recipients.add(new Destination(new Recipient(d2.getId()), new UnsignedInteger(28), Boolean.TRUE,
                 new EventTransitionBits(true, true, true)));
 
         // Create an event listener on d2 to catch the event notifications.
-        final EventNotifListener listener = new EventNotifListener();
+        EventNotifListener listener = new EventNotifListener();
         d2.getEventHandler().addListener(listener);
 
         // Trigger updates, but not enough to cause a notification.
@@ -434,7 +435,7 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
         assertEquals(EventState.normal, notif.toState());
         assertEquals(new NotificationParameters(
                 new BufferReadyNotif(new DeviceObjectPropertyReference(1, tl.getId(), PropertyIdentifier.logBuffer),
-                        UnsignedInteger.ZERO, new UnsignedInteger(3))), notif.eventValues());
+                        new UnsignedInteger(0), new UnsignedInteger(3))), notif.eventValues());
 
         // Trigger another batch of updates. One notification should be sent.
         doTriggers(tl, 7);
@@ -462,11 +463,11 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
     @Test
     public void stopWhenFull() throws Exception {
         // Create a triggered trend log
-        final TrendLogMultipleObject tl = d1.addObject(new TrendLogMultipleObject(
+        TrendLogMultipleObject tl = d1.addObject(new TrendLogMultipleObject(
                 d1, 0, "tlm", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
                 DateTime.UNSPECIFIED, props, 0, true, 4));
 
-        final SequenceOf<LogDataElement> logData = new SequenceOf<>( //
+        SequenceOf<LogDataElement> logData = new SequenceOf<>( //
                 new LogDataElement(new Real(0)), //
                 new LogDataElement(new Real(0)), //
                 new LogDataElement(unknownObject), //
@@ -478,8 +479,8 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
         assertEquals(2, tl.getRecordCount());
         assertEquals(logData, tl.getRecord(0).getLogData().getData());
         assertEquals(logData, tl.getRecord(1).getLogData().getData());
-        assertEquals(new UnsignedInteger(2), tl.get(PropertyIdentifier.recordCount));
-        assertEquals(new UnsignedInteger(2), tl.get(PropertyIdentifier.totalRecordCount));
+        assertEquals(new Unsigned32(2), tl.get(PropertyIdentifier.recordCount));
+        assertEquals(new Unsigned32(2), tl.get(PropertyIdentifier.totalRecordCount));
 
         // Add another record. This will cause the buffer to be full after the buffer full notification is written.
         doTriggers(tl, 1);
@@ -488,8 +489,8 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
         assertEquals(logData, tl.getRecord(1).getLogData().getData());
         assertEquals(logData, tl.getRecord(2).getLogData().getData());
         assertEquals(new LogStatus(true, false, false), tl.getRecord(3).getLogData().getLogStatus());
-        assertEquals(new UnsignedInteger(4), tl.get(PropertyIdentifier.recordCount));
-        assertEquals(new UnsignedInteger(4), tl.get(PropertyIdentifier.totalRecordCount));
+        assertEquals(new Unsigned32(4), tl.get(PropertyIdentifier.recordCount));
+        assertEquals(new Unsigned32(4), tl.get(PropertyIdentifier.totalRecordCount));
         assertTrue(tl.isLogDisabled());
 
         // Add more records. The log should not change. Advance the time just to be sure.
@@ -500,8 +501,8 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
         assertEquals(logData, tl.getRecord(1).getLogData().getData());
         assertEquals(logData, tl.getRecord(2).getLogData().getData());
         assertEquals(new LogStatus(true, false, false), tl.getRecord(3).getLogData().getLogStatus());
-        assertEquals(new UnsignedInteger(4), tl.get(PropertyIdentifier.recordCount));
-        assertEquals(new UnsignedInteger(4), tl.get(PropertyIdentifier.totalRecordCount));
+        assertEquals(new Unsigned32(4), tl.get(PropertyIdentifier.recordCount));
+        assertEquals(new Unsigned32(4), tl.get(PropertyIdentifier.totalRecordCount));
         assertTrue(tl.isLogDisabled());
 
         // Set StopWhenFull to false and write a couple records.
@@ -513,8 +514,8 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
         assertEquals(new LogStatus(true, false, false), tl.getRecord(1).getLogData().getLogStatus());
         assertEquals(logData, tl.getRecord(2).getLogData().getData());
         assertEquals(logData, tl.getRecord(3).getLogData().getData());
-        assertEquals(new UnsignedInteger(4), tl.get(PropertyIdentifier.recordCount));
-        assertEquals(new UnsignedInteger(6), tl.get(PropertyIdentifier.totalRecordCount));
+        assertEquals(new Unsigned32(4), tl.get(PropertyIdentifier.recordCount));
+        assertEquals(new Unsigned32(6), tl.get(PropertyIdentifier.totalRecordCount));
         assertFalse(tl.isLogDisabled());
 
         // Set StopWhenFull back to true.
@@ -524,15 +525,15 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
         assertEquals(logData, tl.getRecord(1).getLogData().getData());
         assertEquals(logData, tl.getRecord(2).getLogData().getData());
         assertEquals(new LogStatus(true, false, false), tl.getRecord(3).getLogData().getLogStatus());
-        assertEquals(new UnsignedInteger(4), tl.get(PropertyIdentifier.recordCount));
-        assertEquals(new UnsignedInteger(7), tl.get(PropertyIdentifier.totalRecordCount));
+        assertEquals(new Unsigned32(4), tl.get(PropertyIdentifier.recordCount));
+        assertEquals(new Unsigned32(7), tl.get(PropertyIdentifier.totalRecordCount));
         assertTrue(tl.isLogDisabled());
     }
 
     @Test
     public void enableDisable() throws Exception {
         // Create a disabled triggered trend log
-        final TrendLogMultipleObject tl = d1.addObject(new TrendLogMultipleObject(
+        TrendLogMultipleObject tl = d1.addObject(new TrendLogMultipleObject(
                 d1, 0, "tlm", new LinkedListLogBuffer<>(), false, DateTime.UNSPECIFIED,
                 DateTime.UNSPECIFIED, props, 0, true, 4));
 
@@ -551,7 +552,7 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
 
     @Test
     public void startStopTimes() throws Exception {
-        final DateTime now = new DateTime(clock.millis());
+        DateTime now = new DateTime(clock.millis());
         GregorianCalendar nowgg = now.getGC();
 
         // Set the start time to 5 minutes from now.
@@ -562,7 +563,7 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
         nowgg.add(Calendar.MINUTE, 5);
         DateTime stopTime = new DateTime(nowgg);
 
-        final SequenceOf<LogDataElement> logData = new SequenceOf<>( //
+        SequenceOf<LogDataElement> logData = new SequenceOf<>( //
                 new LogDataElement(new Real(0)), //
                 new LogDataElement(new Real(0)), //
                 new LogDataElement(unknownObject), //
@@ -570,7 +571,7 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
                 new LogDataElement(noPropSpecified));
 
         // Create a triggered trend log
-        final TrendLogMultipleObject tl = d1.addObject(new TrendLogMultipleObject(
+        TrendLogMultipleObject tl = d1.addObject(new TrendLogMultipleObject(
                 d1, 0, "tlm", new LinkedListLogBuffer<>(), true, startTime, stopTime, props,
                 0, true, 7));
 
@@ -598,7 +599,7 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
         clock.plusMinutes(5);
         awaitTrue(tl::isLogDisabled);
         awaitEquals(3, tl::getRecordCount);
-        final DateTime now3 = new DateTime(clock.millis());
+        DateTime now3 = new DateTime(clock.millis());
         doTriggers(tl, 2);
         assertEquals(3, tl.getRecordCount());
         assertEquals(logData, tl.getRecord(0).getLogData().getData());
@@ -634,7 +635,7 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
     @Test
     public void readLogBuffer() throws Exception {
         // Create a triggered trend log
-        final TrendLogMultipleObject tl = d1.addObject(new TrendLogMultipleObject(
+        TrendLogMultipleObject tl = d1.addObject(new TrendLogMultipleObject(
                 d1, 0, "tlm", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
                 DateTime.UNSPECIFIED, props, 0, true, 7));
 
@@ -646,7 +647,7 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
     @Test
     public void purge() throws Exception {
         // Create a triggered trend log
-        final TrendLogMultipleObject tl = d1.addObject(new TrendLogMultipleObject(
+        TrendLogMultipleObject tl = d1.addObject(new TrendLogMultipleObject(
                 d1, 0, "tlm", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
                 DateTime.UNSPECIFIED, props, 0, true, 7));
 
@@ -656,11 +657,11 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
 
         // Set the record count to non-zero.
         assertBACnetServiceException(
-                () -> tl.writeProperty(null, new PropertyValue(PropertyIdentifier.recordCount, new UnsignedInteger(1))),
+                () -> tl.writeProperty(null, new PropertyValue(PropertyIdentifier.recordCount, new Unsigned32(1))),
                 ErrorClass.property, ErrorCode.writeAccessDenied);
 
         // Set the record count to zero. There should be one log status record.
-        tl.writeProperty(null, new PropertyValue(PropertyIdentifier.recordCount, UnsignedInteger.ZERO));
+        tl.writeProperty(null, new PropertyValue(PropertyIdentifier.recordCount, Unsigned32.ZERO));
         assertEquals(1, tl.getRecordCount());
         assertEquals(new LogStatus(false, true, false), tl.getRecord(0).getLogData().getLogStatus());
     }
@@ -670,7 +671,7 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
         ao.writePropertyInternal(PropertyIdentifier.presentValue, new Real(13));
         ai.writePropertyInternal(PropertyIdentifier.presentValue, new Real(14));
 
-        final SequenceOf<LogDataElement> logData1 = new SequenceOf<>( //
+        SequenceOf<LogDataElement> logData1 = new SequenceOf<>( //
                 new LogDataElement(new Real(14)), //
                 new LogDataElement(new Real(13)), //
                 new LogDataElement(unknownObject), //
@@ -678,7 +679,7 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
                 new LogDataElement(noPropSpecified));
 
         // Create a triggered trend log
-        final TrendLogMultipleObject tl = d1.addObject(new TrendLogMultipleObject(
+        TrendLogMultipleObject tl = d1.addObject(new TrendLogMultipleObject(
                 d1, 0, "tlm", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
                 DateTime.UNSPECIFIED, props, 0, true, 100));
 
@@ -687,7 +688,7 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
         assertEquals(logData1, tl.getRecord(0).getLogData().getData());
         assertEquals(logData1, tl.getRecord(1).getLogData().getData());
 
-        final BACnetArray<DeviceObjectPropertyReference> newProps = new BACnetArray<>( //
+        BACnetArray<DeviceObjectPropertyReference> newProps = new BACnetArray<>( //
                 // Remote
                 new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue),
                 // Local
@@ -701,7 +702,7 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
                         PropertyIdentifier.presentValue, null,
                         new ObjectIdentifier(ObjectType.device, ObjectIdentifier.UNINITIALIZED)));
 
-        final SequenceOf<LogDataElement> logData2 = new SequenceOf<>( //
+        SequenceOf<LogDataElement> logData2 = new SequenceOf<>( //
                 new LogDataElement(new Real(14)), //
                 new LogDataElement(new Real(13)), //
                 new LogDataElement(noPropSpecified), //

--- a/src/test/java/com/serotonin/bacnet4j/obj/TrendLogObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/TrendLogObjectTest.java
@@ -81,6 +81,7 @@ import com.serotonin.bacnet4j.type.notificationParameters.NotificationParameters
 import com.serotonin.bacnet4j.type.primitive.Boolean;
 import com.serotonin.bacnet4j.type.primitive.Null;
 import com.serotonin.bacnet4j.type.primitive.Real;
+import com.serotonin.bacnet4j.type.primitive.Unsigned32;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
 public class TrendLogObjectTest extends AbstractTest {
@@ -102,7 +103,7 @@ public class TrendLogObjectTest extends AbstractTest {
 
     @Test
     public void remotePollingAlignedWithOffset() throws Exception {
-        final TrendLogObject tl = d1.addObject(new TrendLogObject(
+        TrendLogObject tl = d1.addObject(new TrendLogObject(
                 d1, 0, "tl0", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
                 DateTime.UNSPECIFIED,
                 new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, false,
@@ -112,7 +113,7 @@ public class TrendLogObjectTest extends AbstractTest {
 
     @Test
     public void localPolling() throws Exception {
-        final TrendLogObject tl = d1.addObject(new TrendLogObject(
+        TrendLogObject tl = d1.addObject(new TrendLogObject(
                 d1, 0, "tl0", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
                 DateTime.UNSPECIFIED,
                 new DeviceObjectPropertyReference(1, ao.getId(), PropertyIdentifier.presentValue), 0, false,
@@ -120,19 +121,19 @@ public class TrendLogObjectTest extends AbstractTest {
         polling(tl, ao);
     }
 
-    private void polling(final TrendLogObject tl, final BACnetObject bo) throws Exception {
+    private void polling(TrendLogObject tl, BACnetObject bo) throws Exception {
         assertEquals(0, tl.getRecordCount());
 
         //
         // Advance the clock to the polling time.
         LOG.info("Starting time: {}", clock.instant());
-        final int seconds = (62 - clock.get(ChronoField.SECOND_OF_MINUTE) - 1) % 60 + 1;
+        int seconds = (62 - clock.get(ChronoField.SECOND_OF_MINUTE) - 1) % 60 + 1;
         clock.plusSeconds(seconds);
         quiesce();
         LOG.info("First poll time: {}", clock.instant());
 
         assertEquals(1, tl.getRecordCount());
-        final LogRecord record1 = tl.getRecord(0);
+        LogRecord record1 = tl.getRecord(0);
         // We asked for alignment and an offset of 2 seconds.
         assertEquals(2.0, record1.getTimestamp().getTime().getSecond(), 1.0);
         assertEquals(new Real(0), record1.getChoice());
@@ -146,7 +147,7 @@ public class TrendLogObjectTest extends AbstractTest {
         clock.plusMinutes(1);
 
         awaitEquals(2, tl::getRecordCount);
-        final LogRecord record2 = tl.getRecord(1);
+        LogRecord record2 = tl.getRecord(1);
         assertEquals(2, record2.getTimestamp().getTime().getSecond());
         assertEquals((record1.getTimestamp().getTime().getMinute() + 1) % 60,
                 record2.getTimestamp().getTime().getMinute());
@@ -161,7 +162,7 @@ public class TrendLogObjectTest extends AbstractTest {
         clock.plusMinutes(1);
         awaitEquals(3, tl::getRecordCount);
 
-        final LogRecord record3 = tl.getRecord(2);
+        LogRecord record3 = tl.getRecord(2);
         assertEquals(2, record3.getTimestamp().getTime().getSecond());
         assertEquals((record1.getTimestamp().getTime().getMinute() + 2) % 60,
                 record3.getTimestamp().getTime().getMinute());
@@ -174,11 +175,11 @@ public class TrendLogObjectTest extends AbstractTest {
         bo.writePropertyInternal(PropertyIdentifier.presentValue, new Real(3));
 
         // Advance the clock to the new polling time.
-        final int minutes = (62 - clock.get(ChronoField.MINUTE_OF_HOUR)) % 60;
+        int minutes = (62 - clock.get(ChronoField.MINUTE_OF_HOUR)) % 60;
         clock.plusMinutes(minutes);
 
         awaitEquals(4, tl::getRecordCount);
-        final LogRecord record4 = tl.getRecord(3);
+        LogRecord record4 = tl.getRecord(3);
         assertEquals(2, record4.getTimestamp().getTime().getMinute());
         assertEquals(new Real(3), record4.getChoice());
         assertEquals(new StatusFlags(false, false, true, false), record4.getStatusFlags());
@@ -191,14 +192,14 @@ public class TrendLogObjectTest extends AbstractTest {
 
         // Wait for the polling to finish.
         awaitEquals(5, tl::getRecordCount);
-        final LogRecord record5 = tl.getRecord(4);
+        LogRecord record5 = tl.getRecord(4);
         assertEquals(new Real(4), record5.getChoice());
         assertEquals(new StatusFlags(false, false, false, false), record5.getStatusFlags());
     }
 
     @Test
     public void remoteCov() throws Exception {
-        final TrendLogObject tl = d1.addObject(new TrendLogObject(
+        TrendLogObject tl = d1.addObject(new TrendLogObject(
                 d1, 0, "tl0", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
                 DateTime.UNSPECIFIED,
                 new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, false,
@@ -208,7 +209,7 @@ public class TrendLogObjectTest extends AbstractTest {
 
     @Test
     public void localCov() throws Exception {
-        final TrendLogObject tl = d1.addObject(new TrendLogObject(
+        TrendLogObject tl = d1.addObject(new TrendLogObject(
                 d1, 0, "tl0", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
                 DateTime.UNSPECIFIED,
                 new DeviceObjectPropertyReference(1, ao.getId(), PropertyIdentifier.presentValue), 0, false,
@@ -216,7 +217,7 @@ public class TrendLogObjectTest extends AbstractTest {
         cov(tl, d1, ao);
     }
 
-    private void cov(final TrendLogObject tl, final LocalDevice d, final BACnetObject bo) throws Exception {
+    private void cov(TrendLogObject tl, LocalDevice d, BACnetObject bo) throws Exception {
         DateTime now = new DateTime(clock.millis());
 
         // Wait for the COV to set up, and for the initial notification to be sent.
@@ -230,11 +231,11 @@ public class TrendLogObjectTest extends AbstractTest {
         // Remember the process id.
         SequenceOf<CovSubscription> subscriptions =
                 d.getObject(d.getId()).readProperty(PropertyIdentifier.activeCovSubscriptions);
-        final int processId = subscriptions.getBase1(1).getRecipient().getProcessIdentifier().intValue();
+        int processId = subscriptions.getBase1(1).getRecipient().getProcessIdentifier().intValue();
 
         // The initial notification should be there.
         awaitEquals(1, tl::getRecordCount);
-        final LogRecord record1 = tl.getRecord(0);
+        LogRecord record1 = tl.getRecord(0);
         assertEquals(now, record1.getTimestamp());
         assertEquals(new Real(0), record1.getChoice());
         assertEquals(new StatusFlags(false, false, false, false), record1.getStatusFlags());
@@ -244,7 +245,7 @@ public class TrendLogObjectTest extends AbstractTest {
         bo.writePropertyInternal(PropertyIdentifier.presentValue, new Real(1));
         LOG.info("Update");
         awaitEquals(2, tl::getRecordCount);
-        final LogRecord record2 = tl.getRecord(1);
+        LogRecord record2 = tl.getRecord(1);
         assertEquals(now, record2.getTimestamp());
         assertEquals(new Real(1), record2.getChoice());
         assertEquals(new StatusFlags(false, false, false, false), record2.getStatusFlags());
@@ -264,7 +265,7 @@ public class TrendLogObjectTest extends AbstractTest {
         now = new DateTime(clock.millis());
         bo.writePropertyInternal(PropertyIdentifier.presentValue, new Real(1.6F));
         awaitEquals(3, tl::getRecordCount);
-        final LogRecord record3 = tl.getRecord(2);
+        LogRecord record3 = tl.getRecord(2);
         assertEquals(now, record3.getTimestamp());
         assertEquals(new Real(1.6F), record3.getChoice());
         assertEquals(new StatusFlags(false, false, false, false), record3.getStatusFlags());
@@ -275,7 +276,7 @@ public class TrendLogObjectTest extends AbstractTest {
         now = new DateTime(clock.millis());
         bo.setOverridden(true);
         awaitEquals(4, tl::getRecordCount);
-        final LogRecord record4 = tl.getRecord(3);
+        LogRecord record4 = tl.getRecord(3);
         assertEquals(now, record4.getTimestamp());
         assertEquals(new Real(1.6F), record4.getChoice());
         assertEquals(new StatusFlags(false, false, true, false), record4.getStatusFlags());
@@ -285,7 +286,7 @@ public class TrendLogObjectTest extends AbstractTest {
         clock.plusSeconds(20);
         now = new DateTime(clock.millis());
         awaitEquals(5, tl::getRecordCount);
-        final LogRecord record5 = tl.getRecord(4);
+        LogRecord record5 = tl.getRecord(4);
         assertEquals(now, record5.getTimestamp());
         assertEquals(new Real(1.6F), record5.getChoice());
         assertEquals(new StatusFlags(false, false, true, false), record5.getStatusFlags());
@@ -299,7 +300,7 @@ public class TrendLogObjectTest extends AbstractTest {
         // Check that there is still only one subscription, and that it has a different process id.
         subscriptions = d.getObject(d.getId()).readProperty(PropertyIdentifier.activeCovSubscriptions);
         assertEquals(1, subscriptions.getValues().size());
-        final int processId2 = subscriptions.getBase1(1).getRecipient().getProcessIdentifier().intValue();
+        int processId2 = subscriptions.getBase1(1).getRecipient().getProcessIdentifier().intValue();
         assertEquals(processId + 1, processId2);
 
         // Check that an update was sent due to the resubscription.
@@ -320,13 +321,13 @@ public class TrendLogObjectTest extends AbstractTest {
 
     @Test
     public void trigger() throws Exception {
-        final TrendLogObject tl = d1.addObject(new TrendLogObject(
+        TrendLogObject tl = d1.addObject(new TrendLogObject(
                 d1, 0, "tl0", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
                 DateTime.UNSPECIFIED,
                 new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, false,
                 20));
 
-        final DateTime now = new DateTime(clock.millis());
+        DateTime now = new DateTime(clock.millis());
 
         // The buffer should still be empty
         assertEquals(0, tl.getRecordCount());
@@ -350,7 +351,7 @@ public class TrendLogObjectTest extends AbstractTest {
 
         // The log record should be there.
         assertEquals(1, tl.getRecordCount());
-        final LogRecord record1 = tl.getRecord(0);
+        LogRecord record1 = tl.getRecord(0);
         assertEquals(now, record1.getTimestamp());
         assertEquals(new Real(3), record1.getChoice());
         assertEquals(new StatusFlags(false, false, false, false), record1.getStatusFlags());
@@ -360,22 +361,22 @@ public class TrendLogObjectTest extends AbstractTest {
     @Test
     public void intrinsicReporting() throws Exception {
         // Create a triggered trend log with intrinsic reporting enabled.
-        final TrendLogObject tl = d1.addObject(new TrendLogObject(
+        TrendLogObject tl = d1.addObject(new TrendLogObject(
                 d1, 0, "tl0", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
                 DateTime.UNSPECIFIED,
                 new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, false,
                 20)
                 .supportIntrinsicReporting(5, 23, new EventTransitionBits(true, true, true), NotifyType.event));
 
-        final RemoteDevice rd2 = d1.getRemoteDeviceBlocking(2);
+        RemoteDevice rd2 = d1.getRemoteDeviceBlocking(2);
 
         // Add d2 as an event recipient.
-        final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
+        SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
         recipients.add(new Destination(new Recipient(rd2.getAddress()), new UnsignedInteger(27), Boolean.TRUE,
                 new EventTransitionBits(true, true, true)));
 
         // Create an event listener on d2 to catch the event notifications.
-        final EventNotifListener listener = new EventNotifListener();
+        EventNotifListener listener = new EventNotifListener();
         d2.getEventHandler().addListener(listener);
 
         //
@@ -383,10 +384,10 @@ public class TrendLogObjectTest extends AbstractTest {
         doTriggers(tl, 4);
         assertEquals(4, tl.getRecordCount());
         assertEquals(0, listener.getNotifCount());
-        assertEquals(new UnsignedInteger(4), tl.get(PropertyIdentifier.recordCount));
-        assertEquals(new UnsignedInteger(4), tl.get(PropertyIdentifier.totalRecordCount));
-        assertEquals(new UnsignedInteger(4), tl.get(PropertyIdentifier.recordsSinceNotification));
-        assertEquals(UnsignedInteger.ZERO, tl.get(PropertyIdentifier.lastNotifyRecord));
+        assertEquals(new Unsigned32(4), tl.get(PropertyIdentifier.recordCount));
+        assertEquals(new Unsigned32(4), tl.get(PropertyIdentifier.totalRecordCount));
+        assertEquals(new Unsigned32(4), tl.get(PropertyIdentifier.recordsSinceNotification));
+        assertEquals(Unsigned32.ZERO, tl.get(PropertyIdentifier.lastNotifyRecord));
 
         //
         // Write one more and make sure a notification was received.
@@ -412,10 +413,10 @@ public class TrendLogObjectTest extends AbstractTest {
                         UnsignedInteger.ZERO, new UnsignedInteger(5))), notif.eventValues());
 
         // Validate the internally maintained values.
-        assertEquals(new UnsignedInteger(5), tl.get(PropertyIdentifier.recordCount));
-        assertEquals(new UnsignedInteger(5), tl.get(PropertyIdentifier.totalRecordCount));
-        assertEquals(UnsignedInteger.ZERO, tl.get(PropertyIdentifier.recordsSinceNotification));
-        assertEquals(new UnsignedInteger(5), tl.get(PropertyIdentifier.lastNotifyRecord));
+        assertEquals(new Unsigned32(5), tl.get(PropertyIdentifier.recordCount));
+        assertEquals(new Unsigned32(5), tl.get(PropertyIdentifier.totalRecordCount));
+        assertEquals(Unsigned32.ZERO, tl.get(PropertyIdentifier.recordsSinceNotification));
+        assertEquals(new Unsigned32(5), tl.get(PropertyIdentifier.lastNotifyRecord));
 
         //
         // Write another 5 triggers and ensure that the notification looks ok.
@@ -441,15 +442,15 @@ public class TrendLogObjectTest extends AbstractTest {
                         new UnsignedInteger(5), new UnsignedInteger(10))), notif.eventValues());
 
         // Validate the internally maintained values.
-        assertEquals(new UnsignedInteger(10), tl.get(PropertyIdentifier.recordCount));
-        assertEquals(new UnsignedInteger(10), tl.get(PropertyIdentifier.totalRecordCount));
-        assertEquals(UnsignedInteger.ZERO, tl.get(PropertyIdentifier.recordsSinceNotification));
-        assertEquals(new UnsignedInteger(10), tl.get(PropertyIdentifier.lastNotifyRecord));
+        assertEquals(new Unsigned32(10), tl.get(PropertyIdentifier.recordCount));
+        assertEquals(new Unsigned32(10), tl.get(PropertyIdentifier.totalRecordCount));
+        assertEquals(Unsigned32.ZERO, tl.get(PropertyIdentifier.recordsSinceNotification));
+        assertEquals(new Unsigned32(10), tl.get(PropertyIdentifier.lastNotifyRecord));
 
         //
         // Update the values of the trend log such that we can trigger condition 2 in the buffer ready algo.
-        tl.set(PropertyIdentifier.lastNotifyRecord, new UnsignedInteger(0xFFFFFFFDL));
-        tl.set(PropertyIdentifier.totalRecordCount, new UnsignedInteger(0xFFFFFFFDL));
+        tl.set(PropertyIdentifier.lastNotifyRecord, new Unsigned32(0xFFFFFFFDL));
+        tl.set(PropertyIdentifier.totalRecordCount, new Unsigned32(0xFFFFFFFDL));
         doTriggers(tl, 5);
         awaitEquals(15, tl::getRecordCount);
         awaitEquals(1, listener::getNotifCount);
@@ -473,13 +474,13 @@ public class TrendLogObjectTest extends AbstractTest {
                         new UnsignedInteger(0xFFFFFFFDL), new UnsignedInteger(3))), notif.eventValues());
 
         // Validate the internally maintained values.
-        assertEquals(new UnsignedInteger(15), tl.get(PropertyIdentifier.recordCount));
-        assertEquals(new UnsignedInteger(3), tl.get(PropertyIdentifier.totalRecordCount));
-        assertEquals(UnsignedInteger.ZERO, tl.get(PropertyIdentifier.recordsSinceNotification));
-        assertEquals(new UnsignedInteger(3), tl.get(PropertyIdentifier.lastNotifyRecord));
+        assertEquals(new Unsigned32(15), tl.get(PropertyIdentifier.recordCount));
+        assertEquals(new Unsigned32(3), tl.get(PropertyIdentifier.totalRecordCount));
+        assertEquals(Unsigned32.ZERO, tl.get(PropertyIdentifier.recordsSinceNotification));
+        assertEquals(new Unsigned32(3), tl.get(PropertyIdentifier.lastNotifyRecord));
     }
 
-    private static void doTriggers(final TrendLogObject tl, final int count) throws Exception {
+    private static void doTriggers(TrendLogObject tl, int count) throws Exception {
         int remaining = count;
         while (remaining > 0) {
             await(tl::trigger);
@@ -492,27 +493,27 @@ public class TrendLogObjectTest extends AbstractTest {
     @Test
     public void eventReporting() throws Exception {
         // Create a triggered trend log
-        final TrendLogObject tl = d1.addObject(new TrendLogObject(
+        TrendLogObject tl = d1.addObject(new TrendLogObject(
                 d1, 0, "tl", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
                 DateTime.UNSPECIFIED,
                 new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, false,
                 20));
 
         // Create the event enrollment.
-        final DeviceObjectPropertyReference ref =
+        DeviceObjectPropertyReference ref =
                 new DeviceObjectPropertyReference(tl.getId(), PropertyIdentifier.totalRecordCount, null, d1.getId());
-        final EventEnrollmentObject ee = d1.addObject(new EventEnrollmentObject(
+        EventEnrollmentObject ee = d1.addObject(new EventEnrollmentObject(
                 d1, 0, "ee", ref, NotifyType.event,
                 new EventParameter(new BufferReady(new UnsignedInteger(3), UnsignedInteger.ZERO)),
                 new EventTransitionBits(true, true, true), 23, 1000, null, null));
 
         // Set d2 as an event recipient.
-        final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
+        SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
         recipients.add(new Destination(new Recipient(d2.getId()), new UnsignedInteger(28), Boolean.TRUE,
                 new EventTransitionBits(true, true, true)));
 
         // Create an event listener on d2 to catch the event notifications.
-        final EventNotifListener listener = new EventNotifListener();
+        EventNotifListener listener = new EventNotifListener();
         d2.getEventHandler().addListener(listener);
 
         // Trigger updates, but not enough to cause a notification.
@@ -574,22 +575,22 @@ public class TrendLogObjectTest extends AbstractTest {
     @Test
     public void stopWhenFull() throws Exception {
         // Create a triggered trend log
-        final TrendLogObject tl = d1.addObject(new TrendLogObject(
+        TrendLogObject tl = d1.addObject(new TrendLogObject(
                 d1, 0, "tl", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
                 DateTime.UNSPECIFIED,
                 new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, true,
                 4));
 
-        final DateTime now = new DateTime(clock.millis());
-        final StatusFlags sf = new StatusFlags(false, false, false, false);
+        DateTime now = new DateTime(clock.millis());
+        StatusFlags sf = new StatusFlags(false, false, false, false);
 
         // Add a couple records and validate the buffer content
         doTriggers(tl, 2);
         assertEquals(2, tl.getRecordCount());
         assertEquals(LogRecord.createFromMonitoredValue(now, new Real(0), sf), tl.getRecord(0));
         assertEquals(LogRecord.createFromMonitoredValue(now, new Real(0), sf), tl.getRecord(1));
-        assertEquals(new UnsignedInteger(2), tl.get(PropertyIdentifier.recordCount));
-        assertEquals(new UnsignedInteger(2), tl.get(PropertyIdentifier.totalRecordCount));
+        assertEquals(new Unsigned32(2), tl.get(PropertyIdentifier.recordCount));
+        assertEquals(new Unsigned32(2), tl.get(PropertyIdentifier.totalRecordCount));
 
         // Add another record. This will cause the buffer to be full after the buffer full notification is written.
         doTriggers(tl, 1);
@@ -598,8 +599,8 @@ public class TrendLogObjectTest extends AbstractTest {
         assertEquals(LogRecord.createFromMonitoredValue(now, new Real(0), sf), tl.getRecord(1));
         assertEquals(LogRecord.createFromMonitoredValue(now, new Real(0), sf), tl.getRecord(2));
         assertEquals(new LogRecord(now, new LogStatus(true, false, false), null), tl.getRecord(3));
-        assertEquals(new UnsignedInteger(4), tl.get(PropertyIdentifier.recordCount));
-        assertEquals(new UnsignedInteger(4), tl.get(PropertyIdentifier.totalRecordCount));
+        assertEquals(new Unsigned32(4), tl.get(PropertyIdentifier.recordCount));
+        assertEquals(new Unsigned32(4), tl.get(PropertyIdentifier.totalRecordCount));
         assertTrue(tl.isLogDisabled());
 
         // Add more records. The log should not change. Advance the time just to be sure.
@@ -610,11 +611,11 @@ public class TrendLogObjectTest extends AbstractTest {
         assertEquals(LogRecord.createFromMonitoredValue(now, new Real(0), sf), tl.getRecord(1));
         assertEquals(LogRecord.createFromMonitoredValue(now, new Real(0), sf), tl.getRecord(2));
         assertEquals(new LogRecord(now, new LogStatus(true, false, false), null), tl.getRecord(3));
-        assertEquals(new UnsignedInteger(4), tl.get(PropertyIdentifier.recordCount));
-        assertEquals(new UnsignedInteger(4), tl.get(PropertyIdentifier.totalRecordCount));
+        assertEquals(new Unsigned32(4), tl.get(PropertyIdentifier.recordCount));
+        assertEquals(new Unsigned32(4), tl.get(PropertyIdentifier.totalRecordCount));
         assertTrue(tl.isLogDisabled());
 
-        final DateTime now2 = new DateTime(clock.millis());
+        DateTime now2 = new DateTime(clock.millis());
 
         // Set StopWhenFull to false and write a couple records.
         tl.writeProperty(null, new PropertyValue(PropertyIdentifier.stopWhenFull, Boolean.FALSE));
@@ -625,8 +626,8 @@ public class TrendLogObjectTest extends AbstractTest {
         assertEquals(new LogRecord(now, new LogStatus(true, false, false), null), tl.getRecord(1));
         assertEquals(LogRecord.createFromMonitoredValue(now2, new Real(0), sf), tl.getRecord(2));
         assertEquals(LogRecord.createFromMonitoredValue(now2, new Real(0), sf), tl.getRecord(3));
-        assertEquals(new UnsignedInteger(4), tl.get(PropertyIdentifier.recordCount));
-        assertEquals(new UnsignedInteger(6), tl.get(PropertyIdentifier.totalRecordCount));
+        assertEquals(new Unsigned32(4), tl.get(PropertyIdentifier.recordCount));
+        assertEquals(new Unsigned32(6), tl.get(PropertyIdentifier.totalRecordCount));
         assertFalse(tl.isLogDisabled());
 
         // Set StopWhenFull back to true.
@@ -636,15 +637,15 @@ public class TrendLogObjectTest extends AbstractTest {
         assertEquals(LogRecord.createFromMonitoredValue(now2, new Real(0), sf), tl.getRecord(1));
         assertEquals(LogRecord.createFromMonitoredValue(now2, new Real(0), sf), tl.getRecord(2));
         assertEquals(new LogRecord(now2, new LogStatus(true, false, false), null), tl.getRecord(3));
-        assertEquals(new UnsignedInteger(4), tl.get(PropertyIdentifier.recordCount));
-        assertEquals(new UnsignedInteger(7), tl.get(PropertyIdentifier.totalRecordCount));
+        assertEquals(new Unsigned32(4), tl.get(PropertyIdentifier.recordCount));
+        assertEquals(new Unsigned32(7), tl.get(PropertyIdentifier.totalRecordCount));
         assertTrue(tl.isLogDisabled());
     }
 
     @Test
     public void enableDisable() throws Exception {
         // Create a disabled triggered trend log
-        final TrendLogObject tl = d1.addObject(new TrendLogObject(
+        TrendLogObject tl = d1.addObject(new TrendLogObject(
                 d1, 0, "tl", new LinkedListLogBuffer<>(), false, DateTime.UNSPECIFIED,
                 DateTime.UNSPECIFIED,
                 new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, true, 4));
@@ -663,7 +664,7 @@ public class TrendLogObjectTest extends AbstractTest {
 
     @Test
     public void startStopTimes() throws Exception {
-        final DateTime now = new DateTime(clock.millis());
+        DateTime now = new DateTime(clock.millis());
         GregorianCalendar nowgg = now.getGC();
 
         // Set the start time to 5 minutes from now.
@@ -675,13 +676,13 @@ public class TrendLogObjectTest extends AbstractTest {
         DateTime stopTime = new DateTime(nowgg);
 
         // Create a triggered trend log
-        final TrendLogObject tl = d1.addObject(new TrendLogObject(
+        TrendLogObject tl = d1.addObject(new TrendLogObject(
                 d1, 0, "tl", new LinkedListLogBuffer<>(), true, startTime, stopTime,
                 new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, true, 7));
         assertTrue(tl.isLogDisabled());
         assertEquals(0, tl.getRecordCount());
 
-        final StatusFlags sf = new StatusFlags(false, false, false, false);
+        StatusFlags sf = new StatusFlags(false, false, false, false);
 
         // Do some triggers.
         doTriggers(tl, 2);
@@ -697,14 +698,14 @@ public class TrendLogObjectTest extends AbstractTest {
         // Advance the time past the start time and do some triggers.
         clock.plusMinutes(3);
         quiesce();
-        final DateTime now2 = new DateTime(clock.millis());
+        DateTime now2 = new DateTime(clock.millis());
         assertFalse(tl.isLogDisabled());
         doTriggers(tl, 2);
         assertEquals(2, tl.getRecordCount());
 
         // Advance the time past the stop time and do some triggers.
         clock.plusMinutes(5);
-        final DateTime now3 = new DateTime(clock.millis());
+        DateTime now3 = new DateTime(clock.millis());
         awaitEquals(3, tl::getRecordCount);
         assertTrue(tl.isLogDisabled());
         doTriggers(tl, 2);
@@ -742,7 +743,7 @@ public class TrendLogObjectTest extends AbstractTest {
     @Test
     public void readLogBuffer() throws Exception {
         // Create a triggered trend log
-        final TrendLogObject tl = d1.addObject(new TrendLogObject(
+        TrendLogObject tl = d1.addObject(new TrendLogObject(
                 d1, 0, "tl", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
                 DateTime.UNSPECIFIED,
                 new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, true, 7));
@@ -754,10 +755,10 @@ public class TrendLogObjectTest extends AbstractTest {
 
     @Test
     public void purge() throws Exception {
-        final DateTime now = new DateTime(clock.millis());
+        DateTime now = new DateTime(clock.millis());
 
         // Create a triggered trend log
-        final TrendLogObject tl = d1.addObject(new TrendLogObject(
+        TrendLogObject tl = d1.addObject(new TrendLogObject(
                 d1, 0, "tl", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
                 DateTime.UNSPECIFIED,
                 new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, true, 7));
@@ -768,22 +769,22 @@ public class TrendLogObjectTest extends AbstractTest {
 
         // Set the record count to non-zero.
         assertBACnetServiceException(
-                () -> tl.writeProperty(null, new PropertyValue(PropertyIdentifier.recordCount, new UnsignedInteger(1))),
+                () -> tl.writeProperty(null, new PropertyValue(PropertyIdentifier.recordCount, new Unsigned32(1))),
                 ErrorClass.property, ErrorCode.writeAccessDenied);
 
         // Set the record count to zero. There should be one log status record.
-        tl.writeProperty(null, new PropertyValue(PropertyIdentifier.recordCount, UnsignedInteger.ZERO));
+        tl.writeProperty(null, new PropertyValue(PropertyIdentifier.recordCount, Unsigned32.ZERO));
         assertEquals(1, tl.getRecordCount());
         assertEquals(new LogRecord(now, new LogStatus(false, true, false), null), tl.getRecord(0));
     }
 
     @Test
     public void writePropertyReference() throws Exception {
-        final DateTime now = new DateTime(clock.millis());
-        final StatusFlags sf = new StatusFlags(false, false, false, false);
+        DateTime now = new DateTime(clock.millis());
+        StatusFlags sf = new StatusFlags(false, false, false, false);
 
         // Create a triggered trend log
-        final TrendLogObject tl = d1.addObject(new TrendLogObject(
+        TrendLogObject tl = d1.addObject(new TrendLogObject(
                 d1, 0, "tl", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
                 DateTime.UNSPECIFIED,
                 new DeviceObjectPropertyReference(2, ai.getId(), PropertyIdentifier.presentValue), 0, true,
@@ -811,20 +812,20 @@ public class TrendLogObjectTest extends AbstractTest {
     @SuppressWarnings("unchecked")
     @Test
     public void fault() throws Exception {
-        final RemoteDevice rd2 = d1.getRemoteDeviceBlocking(2);
+        RemoteDevice rd2 = d1.getRemoteDeviceBlocking(2);
 
         // Add d2 as an event recipient.
-        final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
+        SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
         recipients.add(new Destination(new Recipient(rd2.getAddress()), new UnsignedInteger(27), Boolean.TRUE,
                 new EventTransitionBits(true, true, true)));
 
         // Create an event listener on d2 to catch the event notifications.
-        final EventNotifListener listener = new EventNotifListener();
+        EventNotifListener listener = new EventNotifListener();
         d2.getEventHandler().addListener(listener);
 
         LOG.debug("start");
         // Create a COV trend log that references a device that doesn't exist.
-        final TrendLogObject tl = d1.addObject(new TrendLogObject(
+        TrendLogObject tl = d1.addObject(new TrendLogObject(
                 d1, 0, "tl", new LinkedListLogBuffer<>(), true, DateTime.UNSPECIFIED,
                 DateTime.UNSPECIFIED,
                 new DeviceObjectPropertyReference(3, ai.getId(), PropertyIdentifier.presentValue), 0, false,
@@ -836,7 +837,7 @@ public class TrendLogObjectTest extends AbstractTest {
         awaitEquals(1, listener::getNotifCount);
 
         // Validate notification
-        final EventNotifListener.Notif notif = listener.removeNotif();
+        EventNotifListener.Notif notif = listener.removeNotif();
         assertEquals(new UnsignedInteger(27), notif.processIdentifier());
         assertEquals(d1.getId(), notif.initiatingDevice());
         assertEquals(tl.getId(), notif.eventObjectIdentifier());

--- a/src/test/java/com/serotonin/bacnet4j/type/constructed/AuthorizationPolicyTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/type/constructed/AuthorizationPolicyTest.java
@@ -1,0 +1,85 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2026 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
+package com.serotonin.bacnet4j.type.constructed;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.serotonin.bacnet4j.enums.DayOfWeek;
+import com.serotonin.bacnet4j.enums.Month;
+import com.serotonin.bacnet4j.exception.BACnetException;
+import com.serotonin.bacnet4j.type.constructed.AuthorizationConstraint.Authentication;
+import com.serotonin.bacnet4j.type.constructed.AuthorizationConstraint.Origin;
+import com.serotonin.bacnet4j.type.constructed.AuthorizationScope.Standard;
+import com.serotonin.bacnet4j.type.primitive.CharacterString;
+import com.serotonin.bacnet4j.type.primitive.Date;
+import com.serotonin.bacnet4j.type.primitive.Time;
+import com.serotonin.bacnet4j.type.primitive.Unsigned32;
+import com.serotonin.bacnet4j.util.sero.ByteQueue;
+
+public class AuthorizationPolicyTest {
+    private static DateTime ts(int hour) {
+        return new DateTime(new Date(2026, Month.JUNE, 12, DayOfWeek.FRIDAY), new Time(hour, 0, 0, 0));
+    }
+
+    @Test
+    public void allFields() throws BACnetException {
+        AuthorizationPolicy p = new AuthorizationPolicy(
+                ts(8),
+                ts(17),
+                new SequenceOf<>(new Unsigned32(1001), new Unsigned32(1002)),
+                new AuthorizationConstraint(Origin.sameNetwork, Authentication.certified),
+                new AuthorizationScope(
+                        new Standard(
+                                true, false, true, false, true, false, false, false, false,
+                                false, false, false, false, false, false, false,
+                                false, false, false, false, false, false, false, false),
+                        new SequenceOf<>(new CharacterString("vendor:42-customScope"))));
+
+        ByteQueue queue = new ByteQueue();
+        p.write(queue);
+
+        assertEquals(p, new AuthorizationPolicy(queue));
+    }
+
+    @Test
+    public void optionalDatesAbsent() throws BACnetException {
+        AuthorizationPolicy p = new AuthorizationPolicy(
+                null,
+                null,
+                new SequenceOf<>(new Unsigned32(1)),
+                new AuthorizationConstraint(Origin.anyNetwork, Authentication.anyMethod),
+                new AuthorizationScope(new Standard(), null));
+
+        ByteQueue queue = new ByteQueue();
+        p.write(queue);
+
+        assertEquals(p, new AuthorizationPolicy(queue));
+    }
+}

--- a/src/test/java/com/serotonin/bacnet4j/type/constructed/AuthorizationScopeDescriptionTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/type/constructed/AuthorizationScopeDescriptionTest.java
@@ -1,0 +1,50 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2026 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
+package com.serotonin.bacnet4j.type.constructed;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.serotonin.bacnet4j.exception.BACnetException;
+import com.serotonin.bacnet4j.type.primitive.CharacterString;
+import com.serotonin.bacnet4j.util.sero.ByteQueue;
+
+public class AuthorizationScopeDescriptionTest {
+    @Test
+    public void roundTrip() throws BACnetException {
+        AuthorizationScopeDescription d = new AuthorizationScopeDescription(
+                new CharacterString("vendor:42-customScope"),
+                new CharacterString("Custom scope for vendor 42 devices"));
+
+        ByteQueue queue = new ByteQueue();
+        d.write(queue);
+
+        assertEquals(d, new AuthorizationScopeDescription(queue));
+    }
+}


### PR DESCRIPTION
https://radixiot.atlassian.net/browse/MANGO-2995

This commit implements the fixes identified in the ObjectProperties spec-compliance audit. Three thematic groups:

  1. Datatype/conformance fixes to ObjectProperties
  2. New spec types — AuthorizationPolicy, AuthorizationScopeDescription, SuccessFilter.
  3. Style cleanup — mass removal of final from method parameters and local variables across the touched files to reduce visual pollution.

