### PR TITLE
MANGO-2950 Device communication control must reject deprecated disable value for rev 20 compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ UnsignedInteger ui = trendLog.get(PropertyIdentifier.recordCount); // Immediate 
 trendLogMult.writeProperty(PropertyIdentifier.recordCount, new UnsignedInteger(100)); // Possibly delayed ClassCastException
 ```
 
+- the device communicate control option DISABLE has been deprecated as per 135-2016bi-2
+
 *Version 6.2.0*
 
 - Methods `LocalDevice.addRemoteDevice(RemoteDevice)` and `LocalDevice.removeRemoteDevice(int)` have been added to allow

--- a/src/main/java/com/serotonin/bacnet4j/LocalDevice.java
+++ b/src/main/java/com/serotonin/bacnet4j/LocalDevice.java
@@ -1131,10 +1131,17 @@ public class LocalDevice implements AutoCloseable {
     private ScheduledFuture<?> communicationControlFuture;
 
     public void setCommunicationControl(EnableDisable enableDisable, int minutes) {
+        // Per addendum 135-2016bi-2: 'disable' was deprecated in Protocol Revision 20. Callers
+        // must migrate to 'disableInitiation'. Requests carrying 'disable' are rejected at the
+        // service handler; this guard protects the state field from any other caller.
+        if (EnableDisable.disable.equals(enableDisable)) {
+            throw new IllegalArgumentException(
+                    "EnableDisable.disable is deprecated (bi-2); use EnableDisable.disableInitiation");
+        }
         synchronized (communicationControlMonitor) {
             communicationControlState = enableDisable;
             cancelCommunicationControlFuture();
-            if (enableDisable.isOneOf(EnableDisable.disableInitiation, EnableDisable.disable)) {
+            if (EnableDisable.disableInitiation.equals(enableDisable)) {
                 if (minutes > 0) {
                     communicationControlFuture = schedule(() -> {
                         synchronized (communicationControlMonitor) {

--- a/src/main/java/com/serotonin/bacnet4j/service/confirmed/DeviceCommunicationControlRequest.java
+++ b/src/main/java/com/serotonin/bacnet4j/service/confirmed/DeviceCommunicationControlRequest.java
@@ -109,7 +109,7 @@ public class DeviceCommunicationControlRequest extends ConfirmedRequestService {
 
     public static class EnableDisable extends Enumerated {
         public static final EnableDisable enable = new EnableDisable(0);
-        public static final EnableDisable disable = new EnableDisable(1);
+        public static final EnableDisable disable = new EnableDisable(1); // Deprecated
         public static final EnableDisable disableInitiation = new EnableDisable(2);
 
         private static final Map<Integer, Enumerated> idMap = new HashMap<>();
@@ -154,39 +154,16 @@ public class DeviceCommunicationControlRequest extends ConfirmedRequestService {
     }
 
     @Override
-    public int hashCode() {
-        int prime = 31;
-        int result = 1;
-        result = prime * result + (enableDisable == null ? 0 : enableDisable.hashCode());
-        result = prime * result + (password == null ? 0 : password.hashCode());
-        result = prime * result + (timeDuration == null ? 0 : timeDuration.hashCode());
-        return result;
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass())
+            return false;
+        DeviceCommunicationControlRequest that = (DeviceCommunicationControlRequest) o;
+        return Objects.equals(timeDuration, that.timeDuration) && Objects.equals(enableDisable,
+                that.enableDisable) && Objects.equals(password, that.password);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        DeviceCommunicationControlRequest other = (DeviceCommunicationControlRequest) obj;
-        if (enableDisable == null) {
-            if (other.enableDisable != null)
-                return false;
-        } else if (!enableDisable.equals(other.enableDisable))
-            return false;
-        if (password == null) {
-            if (other.password != null)
-                return false;
-        } else if (!password.equals(other.password))
-            return false;
-        if (timeDuration == null) {
-            if (other.timeDuration != null)
-                return false;
-        } else if (!timeDuration.equals(other.timeDuration))
-            return false;
-        return true;
+    public int hashCode() {
+        return Objects.hash(timeDuration, enableDisable, password);
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/service/confirmed/DeviceCommunicationControlRequest.java
+++ b/src/main/java/com/serotonin/bacnet4j/service/confirmed/DeviceCommunicationControlRequest.java
@@ -51,8 +51,8 @@ public class DeviceCommunicationControlRequest extends ConfirmedRequestService {
     private final EnableDisable enableDisable;
     private final CharacterString password;
 
-    public DeviceCommunicationControlRequest(final UnsignedInteger timeDuration, final EnableDisable enableDisable,
-            final CharacterString password) {
+    public DeviceCommunicationControlRequest(UnsignedInteger timeDuration, EnableDisable enableDisable,
+            CharacterString password) {
         super();
         this.timeDuration = timeDuration;
         this.enableDisable = enableDisable;
@@ -65,13 +65,20 @@ public class DeviceCommunicationControlRequest extends ConfirmedRequestService {
     }
 
     @Override
-    public AcknowledgementService handle(final LocalDevice localDevice, final Address from) throws BACnetException {
+    public AcknowledgementService handle(LocalDevice localDevice, Address from) throws BACnetException {
         String givenPassword = null;
         if (password != null)
             givenPassword = password.getValue();
 
         if (!Objects.equals(givenPassword, localDevice.getPassword())) {
             throw new BACnetErrorException(getChoiceId(), ErrorClass.security, ErrorCode.passwordFailure);
+        }
+
+        // Per addendum 135-2016bi-2: 'disable' was deprecated in Protocol Revision 20. A valid
+        // request carrying the deprecated value shall be ignored and an Error-PDU with
+        // ErrorClass=SERVICES / ErrorCode=SERVICE_REQUEST_DENIED shall be returned.
+        if (EnableDisable.disable.equals(enableDisable)) {
+            throw new BACnetErrorException(getChoiceId(), ErrorClass.services, ErrorCode.serviceRequestDenied);
         }
 
         int minutes = 0;
@@ -83,13 +90,13 @@ public class DeviceCommunicationControlRequest extends ConfirmedRequestService {
     }
 
     @Override
-    public void write(final ByteQueue queue) {
+    public void write(ByteQueue queue) {
         writeOptional(queue, timeDuration, 0);
         write(queue, enableDisable, 1);
         writeOptional(queue, password, 2);
     }
 
-    DeviceCommunicationControlRequest(final ByteQueue queue) throws BACnetException {
+    DeviceCommunicationControlRequest(ByteQueue queue) throws BACnetException {
         timeDuration = readOptional(queue, UnsignedInteger.class, 0);
         enableDisable = read(queue, EnableDisable.class, 1);
         password = readOptional(queue, CharacterString.class, 2);
@@ -113,18 +120,18 @@ public class DeviceCommunicationControlRequest extends ConfirmedRequestService {
             Enumerated.init(MethodHandles.lookup().lookupClass(), idMap, nameMap, prettyMap);
         }
 
-        public static EnableDisable forId(final int id) {
+        public static EnableDisable forId(int id) {
             EnableDisable e = (EnableDisable) idMap.get(id);
             if (e == null)
                 e = new EnableDisable(id);
             return e;
         }
 
-        public static String nameForId(final int id) {
+        public static String nameForId(int id) {
             return prettyMap.get(id);
         }
 
-        public static EnableDisable forName(final String name) {
+        public static EnableDisable forName(String name) {
             return (EnableDisable) Enumerated.forName(nameMap, name);
         }
 
@@ -132,11 +139,11 @@ public class DeviceCommunicationControlRequest extends ConfirmedRequestService {
             return idMap.size();
         }
 
-        private EnableDisable(final int value) {
+        private EnableDisable(int value) {
             super(value);
         }
 
-        public EnableDisable(final ByteQueue queue) throws BACnetErrorException {
+        public EnableDisable(ByteQueue queue) throws BACnetErrorException {
             super(queue);
         }
 
@@ -148,7 +155,7 @@ public class DeviceCommunicationControlRequest extends ConfirmedRequestService {
 
     @Override
     public int hashCode() {
-        final int PRIME = 31;
+        int PRIME = 31;
         int result = 1;
         result = PRIME * result + (enableDisable == null ? 0 : enableDisable.hashCode());
         result = PRIME * result + (password == null ? 0 : password.hashCode());
@@ -157,14 +164,14 @@ public class DeviceCommunicationControlRequest extends ConfirmedRequestService {
     }
 
     @Override
-    public boolean equals(final Object obj) {
+    public boolean equals(Object obj) {
         if (this == obj)
             return true;
         if (obj == null)
             return false;
         if (getClass() != obj.getClass())
             return false;
-        final DeviceCommunicationControlRequest other = (DeviceCommunicationControlRequest) obj;
+        DeviceCommunicationControlRequest other = (DeviceCommunicationControlRequest) obj;
         if (enableDisable == null) {
             if (other.enableDisable != null)
                 return false;

--- a/src/main/java/com/serotonin/bacnet4j/service/confirmed/DeviceCommunicationControlRequest.java
+++ b/src/main/java/com/serotonin/bacnet4j/service/confirmed/DeviceCommunicationControlRequest.java
@@ -155,11 +155,11 @@ public class DeviceCommunicationControlRequest extends ConfirmedRequestService {
 
     @Override
     public int hashCode() {
-        int PRIME = 31;
+        int prime = 31;
         int result = 1;
-        result = PRIME * result + (enableDisable == null ? 0 : enableDisable.hashCode());
-        result = PRIME * result + (password == null ? 0 : password.hashCode());
-        result = PRIME * result + (timeDuration == null ? 0 : timeDuration.hashCode());
+        result = prime * result + (enableDisable == null ? 0 : enableDisable.hashCode());
+        result = prime * result + (password == null ? 0 : password.hashCode());
+        result = prime * result + (timeDuration == null ? 0 : timeDuration.hashCode());
         return result;
     }
 

--- a/src/main/java/com/serotonin/bacnet4j/service/confirmed/DeviceCommunicationControlRequest.java
+++ b/src/main/java/com/serotonin/bacnet4j/service/confirmed/DeviceCommunicationControlRequest.java
@@ -41,17 +41,17 @@ import com.serotonin.bacnet4j.type.enumerated.ErrorClass;
 import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
 import com.serotonin.bacnet4j.type.primitive.CharacterString;
 import com.serotonin.bacnet4j.type.primitive.Enumerated;
-import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
+import com.serotonin.bacnet4j.type.primitive.Unsigned16;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
 
 public class DeviceCommunicationControlRequest extends ConfirmedRequestService {
     public static final byte TYPE_ID = 17;
 
-    private final UnsignedInteger timeDuration;
+    private final Unsigned16 timeDuration;
     private final EnableDisable enableDisable;
     private final CharacterString password;
 
-    public DeviceCommunicationControlRequest(UnsignedInteger timeDuration, EnableDisable enableDisable,
+    public DeviceCommunicationControlRequest(Unsigned16 timeDuration, EnableDisable enableDisable,
             CharacterString password) {
         super();
         this.timeDuration = timeDuration;
@@ -97,7 +97,7 @@ public class DeviceCommunicationControlRequest extends ConfirmedRequestService {
     }
 
     DeviceCommunicationControlRequest(ByteQueue queue) throws BACnetException {
-        timeDuration = readOptional(queue, UnsignedInteger.class, 0);
+        timeDuration = readOptional(queue, Unsigned16.class, 0);
         enableDisable = read(queue, EnableDisable.class, 1);
         password = readOptional(queue, CharacterString.class, 2);
     }

--- a/src/main/java/com/serotonin/bacnet4j/service/confirmed/ReinitializeDeviceRequest.java
+++ b/src/main/java/com/serotonin/bacnet4j/service/confirmed/ReinitializeDeviceRequest.java
@@ -156,10 +156,10 @@ public class ReinitializeDeviceRequest extends ConfirmedRequestService {
 
     @Override
     public int hashCode() {
-        int PRIME = 31;
+        int prime = 31;
         int result = 1;
-        result = PRIME * result + (password == null ? 0 : password.hashCode());
-        result = PRIME * result + (reinitializedStateOfDevice == null ? 0 : reinitializedStateOfDevice.hashCode());
+        result = prime * result + (password == null ? 0 : password.hashCode());
+        result = prime * result + (reinitializedStateOfDevice == null ? 0 : reinitializedStateOfDevice.hashCode());
         return result;
     }
 

--- a/src/main/java/com/serotonin/bacnet4j/service/confirmed/ReinitializeDeviceRequest.java
+++ b/src/main/java/com/serotonin/bacnet4j/service/confirmed/ReinitializeDeviceRequest.java
@@ -155,33 +155,16 @@ public class ReinitializeDeviceRequest extends ConfirmedRequestService {
     }
 
     @Override
-    public int hashCode() {
-        int prime = 31;
-        int result = 1;
-        result = prime * result + (password == null ? 0 : password.hashCode());
-        result = prime * result + (reinitializedStateOfDevice == null ? 0 : reinitializedStateOfDevice.hashCode());
-        return result;
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass())
+            return false;
+        ReinitializeDeviceRequest that = (ReinitializeDeviceRequest) o;
+        return Objects.equals(reinitializedStateOfDevice,
+                that.reinitializedStateOfDevice) && Objects.equals(password, that.password);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        ReinitializeDeviceRequest other = (ReinitializeDeviceRequest) obj;
-        if (password == null) {
-            if (other.password != null)
-                return false;
-        } else if (!password.equals(other.password))
-            return false;
-        if (reinitializedStateOfDevice == null) {
-            if (other.reinitializedStateOfDevice != null)
-                return false;
-        } else if (!reinitializedStateOfDevice.equals(other.reinitializedStateOfDevice))
-            return false;
-        return true;
+    public int hashCode() {
+        return Objects.hash(reinitializedStateOfDevice, password);
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/service/confirmed/ReinitializeDeviceRequest.java
+++ b/src/main/java/com/serotonin/bacnet4j/service/confirmed/ReinitializeDeviceRequest.java
@@ -37,7 +37,6 @@ import com.serotonin.bacnet4j.event.ReinitializeDeviceHandler;
 import com.serotonin.bacnet4j.exception.BACnetErrorException;
 import com.serotonin.bacnet4j.exception.BACnetException;
 import com.serotonin.bacnet4j.service.acknowledgement.AcknowledgementService;
-import com.serotonin.bacnet4j.service.confirmed.DeviceCommunicationControlRequest.EnableDisable;
 import com.serotonin.bacnet4j.type.constructed.Address;
 import com.serotonin.bacnet4j.type.enumerated.ErrorClass;
 import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
@@ -51,13 +50,13 @@ public class ReinitializeDeviceRequest extends ConfirmedRequestService {
     private final ReinitializedStateOfDevice reinitializedStateOfDevice;
     private final CharacterString password;
 
-    public ReinitializeDeviceRequest(final ReinitializedStateOfDevice reinitializedStateOfDevice,
-            final CharacterString password) {
+    public ReinitializeDeviceRequest(ReinitializedStateOfDevice reinitializedStateOfDevice,
+            CharacterString password) {
         this.reinitializedStateOfDevice = reinitializedStateOfDevice;
         this.password = password;
     }
 
-    public ReinitializeDeviceRequest(final ReinitializedStateOfDevice reinitializedStateOfDevice) {
+    public ReinitializeDeviceRequest(ReinitializedStateOfDevice reinitializedStateOfDevice) {
         this(reinitializedStateOfDevice, null);
     }
 
@@ -67,32 +66,21 @@ public class ReinitializeDeviceRequest extends ConfirmedRequestService {
     }
 
     @Override
-    public void write(final ByteQueue queue) {
+    public void write(ByteQueue queue) {
         write(queue, reinitializedStateOfDevice, 0);
         writeOptional(queue, password, 1);
     }
 
-    ReinitializeDeviceRequest(final ByteQueue queue) throws BACnetException {
+    ReinitializeDeviceRequest(ByteQueue queue) throws BACnetException {
         reinitializedStateOfDevice = read(queue, ReinitializedStateOfDevice.class, 0);
         password = readOptional(queue, CharacterString.class, 1);
     }
 
     @Override
-    public AcknowledgementService handle(final LocalDevice localDevice, final Address from) throws BACnetException {
-        final ReinitializeDeviceHandler handler = localDevice.getReinitializeDeviceHandler();
+    public AcknowledgementService handle(LocalDevice localDevice, Address from) throws BACnetException {
+        ReinitializeDeviceHandler handler = localDevice.getReinitializeDeviceHandler();
         if (handler == null) {
             throw new BACnetErrorException(ErrorClass.device, ErrorCode.notConfigured);
-        }
-
-        if (reinitializedStateOfDevice.isOneOf( //
-                ReinitializedStateOfDevice.startBackup, //
-                ReinitializedStateOfDevice.endBackup, //
-                ReinitializedStateOfDevice.startRestore, //
-                ReinitializedStateOfDevice.endRestore, //
-                ReinitializedStateOfDevice.abortRestore)) {
-            if (EnableDisable.disable.equals(localDevice.getCommunicationControlState())) {
-                throw new BACnetErrorException(ErrorClass.services, ErrorCode.communicationDisabled);
-            }
         }
 
         // Performance of warmstart and coldstart are listed before the password check in 16.4.2, but we'll check
@@ -133,18 +121,18 @@ public class ReinitializeDeviceRequest extends ConfirmedRequestService {
             Enumerated.init(MethodHandles.lookup().lookupClass(), idMap, nameMap, prettyMap);
         }
 
-        public static ReinitializedStateOfDevice forId(final int id) {
+        public static ReinitializedStateOfDevice forId(int id) {
             ReinitializedStateOfDevice e = (ReinitializedStateOfDevice) idMap.get(id);
             if (e == null)
                 e = new ReinitializedStateOfDevice(id);
             return e;
         }
 
-        public static String nameForId(final int id) {
+        public static String nameForId(int id) {
             return prettyMap.get(id);
         }
 
-        public static ReinitializedStateOfDevice forName(final String name) {
+        public static ReinitializedStateOfDevice forName(String name) {
             return (ReinitializedStateOfDevice) Enumerated.forName(nameMap, name);
         }
 
@@ -152,11 +140,11 @@ public class ReinitializeDeviceRequest extends ConfirmedRequestService {
             return idMap.size();
         }
 
-        private ReinitializedStateOfDevice(final int value) {
+        private ReinitializedStateOfDevice(int value) {
             super(value);
         }
 
-        public ReinitializedStateOfDevice(final ByteQueue queue) throws BACnetErrorException {
+        public ReinitializedStateOfDevice(ByteQueue queue) throws BACnetErrorException {
             super(queue);
         }
 
@@ -168,7 +156,7 @@ public class ReinitializeDeviceRequest extends ConfirmedRequestService {
 
     @Override
     public int hashCode() {
-        final int PRIME = 31;
+        int PRIME = 31;
         int result = 1;
         result = PRIME * result + (password == null ? 0 : password.hashCode());
         result = PRIME * result + (reinitializedStateOfDevice == null ? 0 : reinitializedStateOfDevice.hashCode());
@@ -176,14 +164,14 @@ public class ReinitializeDeviceRequest extends ConfirmedRequestService {
     }
 
     @Override
-    public boolean equals(final Object obj) {
+    public boolean equals(Object obj) {
         if (this == obj)
             return true;
         if (obj == null)
             return false;
         if (getClass() != obj.getClass())
             return false;
-        final ReinitializeDeviceRequest other = (ReinitializeDeviceRequest) obj;
+        ReinitializeDeviceRequest other = (ReinitializeDeviceRequest) obj;
         if (password == null) {
             if (other.password != null)
                 return false;

--- a/src/main/java/com/serotonin/bacnet4j/transport/DefaultTransport.java
+++ b/src/main/java/com/serotonin/bacnet4j/transport/DefaultTransport.java
@@ -888,46 +888,36 @@ public class DefaultTransport implements Transport, Runnable {
         unackedMessages.add(key, ctx);
     }
 
-    private void incomingConfirmedRequest(final ConfirmedRequest confAPDU, final Address address,
-            final OctetString linkService, final byte invokeId) {
+    private void incomingConfirmedRequest(ConfirmedRequest confAPDU, Address address,
+            OctetString linkService, byte invokeId) {
         try {
             try {
                 confAPDU.parseServiceData();
-                final AcknowledgementService ackService = handleConfirmedRequest(address, invokeId,
+                AcknowledgementService ackService = handleConfirmedRequest(address, invokeId,
                         confAPDU.getServiceRequest());
 
-                // 16.1.2: Check if communication is currently disabled. If so, only certain requests are responded.
-                boolean allowResponse = true;
-                if (EnableDisable.disable.equals(localDevice.getCommunicationControlState())) {
-                    // Communication is disabled. Check if the response should be allowed anyway. This includes at
-                    // least communication control and reinitialize device.
-                    if (!confAPDU.getServiceRequest().isCommunicationControlOverride()) {
-                        allowResponse = false;
-                    }
-                }
-
-                if (allowResponse) {
-                    // Send the response.
-                    sendConfirmedResponse(address, linkService, confAPDU, ackService);
-                } else {
-                    LOG.info("Response suppressed because communication has been disabled.");
-                }
-            } catch (final BACnetErrorException e) {
+                // Per addendum 135-2016bi-2 (Protocol Revision 20): DISABLE_INITIATION means the
+                // device stops initiating BACnet messages but continues responding to incoming
+                // requests normally. The old DISABLE option (which suppressed responses) is
+                // deprecated and rejected at the service handler, so no response suppression is
+                // required here.
+                sendConfirmedResponse(address, linkService, confAPDU, ackService);
+            } catch (BACnetErrorException e) {
                 network.sendAPDU(address, linkService,
                         new com.serotonin.bacnet4j.apdu.Error(invokeId, e.getBacnetError()), false);
-            } catch (final BACnetRejectException e) {
+            } catch (BACnetRejectException e) {
                 network.sendAPDU(address, linkService, new Reject(invokeId, e.getRejectReason()), false);
-            } catch (final BACnetAbortException e) {
+            } catch (BACnetAbortException e) {
                 network.sendAPDU(address, linkService, new Abort(true, invokeId, e.getAbortReason()), false);
-            } catch (final BACnetException e) {
+            } catch (BACnetException e) {
                 LOG.warn("Error handling incoming request", e);
-                final com.serotonin.bacnet4j.apdu.Error error = new com.serotonin.bacnet4j.apdu.Error(
+                com.serotonin.bacnet4j.apdu.Error error = new com.serotonin.bacnet4j.apdu.Error(
                         confAPDU.getInvokeId(), 127,
                         new ErrorClassAndCode(ErrorClass.services, ErrorCode.operationalProblem));
                 network.sendAPDU(address, linkService, error, false);
                 localDevice.getExceptionDispatcher().fireReceivedException(e);
             }
-        } catch (final BACnetException e) {
+        } catch (BACnetException e) {
             localDevice.getExceptionDispatcher().fireReceivedException(e);
         }
     }

--- a/src/test/java/com/serotonin/bacnet4j/AnnexFEncodingTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/AnnexFEncodingTest.java
@@ -177,14 +177,14 @@ public class AnnexFEncodingTest {
 
     @Test
     public void e1_1aTest() {
-        final AcknowledgeAlarmRequest acknowledgeAlarmRequest = new AcknowledgeAlarmRequest(new UnsignedInteger(1),
+        AcknowledgeAlarmRequest acknowledgeAlarmRequest = new AcknowledgeAlarmRequest(new UnsignedInteger(1),
                 new ObjectIdentifier(ObjectType.analogInput, 2), EventState.highLimit,
                 new TimeStamp(new UnsignedInteger(16)),
                 new CharacterString(new CharacterEncoding(StandardCharacterEncodings.ANSI_X3_4), "MDL"),
                 new TimeStamp(
                         new DateTime(new Date(1992, Month.JUNE, 21, DayOfWeek.UNSPECIFIED), new Time(13, 3, 41, 9))));
 
-        final ConfirmedRequest pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED,
+        ConfirmedRequest pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED,
                 MaxApduLength.UP_TO_206, (byte) 7, (byte) 0, 0, acknowledgeAlarmRequest);
 
         compare(pdu, "0002070009011c0000000229033e19103f4c004d444c5e2ea45c0615ffb40d0329092f5f");
@@ -192,24 +192,24 @@ public class AnnexFEncodingTest {
 
     @Test
     public void e1_1bTest() {
-        final SimpleACK simpleACK = new SimpleACK((byte) 7, 0);
+        SimpleACK simpleACK = new SimpleACK((byte) 7, 0);
         compare(simpleACK, "200700");
     }
 
     @Test
     public void e1_2aTest() {
-        final List<PropertyValue> list = new ArrayList<>();
+        List<PropertyValue> list = new ArrayList<>();
         list.add(new PropertyValue(PropertyIdentifier.presentValue, null, new Real(65), null));
         list.add(new PropertyValue(PropertyIdentifier.statusFlags, null, new StatusFlags(false, false, false, false),
                 null));
 
-        final SequenceOf<PropertyValue> listOfValues = new SequenceOf<>(list);
+        SequenceOf<PropertyValue> listOfValues = new SequenceOf<>(list);
 
-        final ConfirmedCovNotificationRequest confirmedCovNotification = new ConfirmedCovNotificationRequest(
+        ConfirmedCovNotificationRequest confirmedCovNotification = new ConfirmedCovNotificationRequest(
                 new UnsignedInteger(18), new ObjectIdentifier(ObjectType.device, 4),
                 new ObjectIdentifier(ObjectType.analogInput, 10), UnsignedInteger.ZERO, listOfValues);
 
-        final ConfirmedRequest pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED,
+        ConfirmedRequest pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED,
                 MaxApduLength.UP_TO_206, (byte) 15, (byte) 0, 0, confirmedCovNotification);
 
         compare(pdu, "00020f0109121c020000042c0000000a39004e09552e44428200002f096f2e8204002f4f");
@@ -217,32 +217,32 @@ public class AnnexFEncodingTest {
 
     @Test
     public void e1_2bTest() {
-        final SimpleACK pdu = new SimpleACK((byte) 15, 1);
+        SimpleACK pdu = new SimpleACK((byte) 15, 1);
         compare(pdu, "200f01");
     }
 
     @Test
     public void e1_3Test() {
-        final List<PropertyValue> list = new ArrayList<>();
+        List<PropertyValue> list = new ArrayList<>();
         list.add(new PropertyValue(PropertyIdentifier.presentValue, null, new Real(65), null));
         list.add(new PropertyValue(PropertyIdentifier.statusFlags, null, new StatusFlags(false, false, false, false),
                 null));
 
-        final SequenceOf<PropertyValue> listOfValues = new SequenceOf<>(list);
+        SequenceOf<PropertyValue> listOfValues = new SequenceOf<>(list);
 
-        final UnconfirmedCovNotificationRequest unconfirmedCovNotificationRequest =
+        UnconfirmedCovNotificationRequest unconfirmedCovNotificationRequest =
                 new UnconfirmedCovNotificationRequest(
                         new UnsignedInteger(18), new ObjectIdentifier(ObjectType.device, 4),
                         new ObjectIdentifier(ObjectType.analogInput, 10), UnsignedInteger.ZERO, listOfValues);
 
-        final UnconfirmedRequest pdu = new UnconfirmedRequest(unconfirmedCovNotificationRequest);
+        UnconfirmedRequest pdu = new UnconfirmedRequest(unconfirmedCovNotificationRequest);
 
         compare(pdu, "100209121c020000042c0000000a39004e09552e44428200002f096f2e8204002f4f");
     }
 
     @Test
     public void e1_4aTest() {
-        final ConfirmedEventNotificationRequest confirmedEventNotificationRequest =
+        ConfirmedEventNotificationRequest confirmedEventNotificationRequest =
                 new ConfirmedEventNotificationRequest(
                         new UnsignedInteger(1), new ObjectIdentifier(ObjectType.device, 4),
                         new ObjectIdentifier(ObjectType.analogInput, 2), new TimeStamp(new UnsignedInteger(16)),
@@ -251,7 +251,7 @@ public class AnnexFEncodingTest {
                         new NotificationParameters(new OutOfRangeNotif(new Real(80.1f),
                                 new StatusFlags(true, false, false, false), new Real(1), new Real(80))));
 
-        final ConfirmedRequest pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED,
+        ConfirmedRequest pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED,
                 MaxApduLength.UP_TO_206, (byte) 16, (byte) 0, 0, confirmedEventNotificationRequest);
 
         compare(pdu, "0002100209011c020000042c000000023e19103f49045964690589009901a900b903ce5e0c42a033331a0"
@@ -260,18 +260,18 @@ public class AnnexFEncodingTest {
 
     @Test
     public void e1_4bTest() {
-        final SimpleACK pdu = new SimpleACK((byte) 16, 2);
+        SimpleACK pdu = new SimpleACK((byte) 16, 2);
         compare(pdu, "201002");
     }
 
     @Test
     public void e1_4cTest() {
-        final AcknowledgeAlarmRequest req = new AcknowledgeAlarmRequest(new UnsignedInteger(1),
+        AcknowledgeAlarmRequest req = new AcknowledgeAlarmRequest(new UnsignedInteger(1),
                 new ObjectIdentifier(ObjectType.analogInput, 2), EventState.highLimit,
                 new TimeStamp(new UnsignedInteger(16)), new CharacterString("MDL"),
                 new TimeStamp(new DateTime(new Date(1992, Month.JUNE, 21, null), new Time(13, 3, 41, 9))));
 
-        final ConfirmedRequest pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED,
+        ConfirmedRequest pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED,
                 MaxApduLength.UP_TO_206, (byte) 7, (byte) 0, 0, req);
 
         compare(pdu, "0002070009011c0000000229033e19103f4c004d444c5e2ea45c0615ffb40d0329092f5f");
@@ -279,13 +279,13 @@ public class AnnexFEncodingTest {
 
     @Test
     public void e1_4dTest() {
-        final SimpleACK pdu = new SimpleACK((byte) 7, 0);
+        SimpleACK pdu = new SimpleACK((byte) 7, 0);
         compare(pdu, "200700");
     }
 
     @Test
     public void e1_5Test() {
-        final UnconfirmedEventNotificationRequest unconfirmedEventNotificationRequest =
+        UnconfirmedEventNotificationRequest unconfirmedEventNotificationRequest =
                 new UnconfirmedEventNotificationRequest(
                         new UnsignedInteger(1), new ObjectIdentifier(ObjectType.device, 9),
                         new ObjectIdentifier(ObjectType.analogInput, 2), new TimeStamp(new UnsignedInteger(16)),
@@ -294,7 +294,7 @@ public class AnnexFEncodingTest {
                         new NotificationParameters(new OutOfRangeNotif(new Real(80.1f),
                                 new StatusFlags(true, false, false, false), new Real(1), new Real(80))));
 
-        final UnconfirmedRequest pdu = new UnconfirmedRequest(unconfirmedEventNotificationRequest);
+        UnconfirmedRequest pdu = new UnconfirmedRequest(unconfirmedEventNotificationRequest);
 
         compare(pdu, "100309011c020000092c000000023e19103f49045964690589009901a900b903ce5e0c42a033331a048"
                 + "02c3f8000003c42a000005fcf");
@@ -302,9 +302,9 @@ public class AnnexFEncodingTest {
 
     @Test
     public void e1_6aTest() {
-        final GetAlarmSummaryRequest getAlarmSummaryRequest = new GetAlarmSummaryRequest();
+        GetAlarmSummaryRequest getAlarmSummaryRequest = new GetAlarmSummaryRequest();
 
-        final ConfirmedRequest pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED,
+        ConfirmedRequest pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED,
                 MaxApduLength.UP_TO_206, (byte) 1, (byte) 0, 0, getAlarmSummaryRequest);
 
         compare(pdu, "00020103");
@@ -312,25 +312,25 @@ public class AnnexFEncodingTest {
 
     @Test
     public void e1_6bTest() {
-        final List<GetAlarmSummaryAck.AlarmSummary> alarmSummaries = new ArrayList<>();
+        List<GetAlarmSummaryAck.AlarmSummary> alarmSummaries = new ArrayList<>();
         alarmSummaries.add(new GetAlarmSummaryAck.AlarmSummary(new ObjectIdentifier(ObjectType.analogInput, 2),
                 EventState.highLimit, new EventTransitionBits(false, true, true)));
         alarmSummaries.add(new GetAlarmSummaryAck.AlarmSummary(new ObjectIdentifier(ObjectType.analogInput, 3),
                 EventState.lowLimit, new EventTransitionBits(true, true, true)));
 
-        final GetAlarmSummaryAck getAlarmSummaryAck = new GetAlarmSummaryAck(new SequenceOf<>(alarmSummaries));
+        GetAlarmSummaryAck getAlarmSummaryAck = new GetAlarmSummaryAck(new SequenceOf<>(alarmSummaries));
 
-        final ComplexACK pdu = new ComplexACK(false, false, (byte) 1, 0, 0, getAlarmSummaryAck);
+        ComplexACK pdu = new ComplexACK(false, false, (byte) 1, 0, 0, getAlarmSummaryAck);
 
         compare(pdu, "300103c4000000029103820560c40000000391048205e0");
     }
 
     @Test
     public void e1_7aTest() {
-        final GetEnrollmentSummaryRequest getEnrollmentSummaryRequest = new GetEnrollmentSummaryRequest(
+        GetEnrollmentSummaryRequest getEnrollmentSummaryRequest = new GetEnrollmentSummaryRequest(
                 GetEnrollmentSummaryRequest.AcknowledgmentFilter.notAcked, null, null, null, null, null);
 
-        final ConfirmedRequest pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED,
+        ConfirmedRequest pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED,
                 MaxApduLength.UP_TO_206, (byte) 1, (byte) 0, 0, getEnrollmentSummaryRequest);
 
         compare(pdu, "000201040902");
@@ -338,7 +338,7 @@ public class AnnexFEncodingTest {
 
     @Test
     public void e1_7bTest() {
-        final List<GetEnrollmentSummaryAck.EnrollmentSummary> enrollmentSummaries = new ArrayList<>();
+        List<GetEnrollmentSummaryAck.EnrollmentSummary> enrollmentSummaries = new ArrayList<>();
         enrollmentSummaries
                 .add(new GetEnrollmentSummaryAck.EnrollmentSummary(new ObjectIdentifier(ObjectType.analogInput, 2),
                         EventType.outOfRange, EventState.highLimit, new UnsignedInteger(100), new UnsignedInteger(4)));
@@ -346,23 +346,23 @@ public class AnnexFEncodingTest {
                 .add(new GetEnrollmentSummaryAck.EnrollmentSummary(new ObjectIdentifier(ObjectType.eventEnrollment, 6),
                         EventType.changeOfState, EventState.normal, new UnsignedInteger(50), new UnsignedInteger(2)));
 
-        final GetEnrollmentSummaryAck getEnrollmentSummaryAck = new GetEnrollmentSummaryAck(
+        GetEnrollmentSummaryAck getEnrollmentSummaryAck = new GetEnrollmentSummaryAck(
                 new SequenceOf<>(enrollmentSummaries));
 
-        final ComplexACK pdu = new ComplexACK(false, false, (byte) 1, 0, 0, getEnrollmentSummaryAck);
+        ComplexACK pdu = new ComplexACK(false, false, (byte) 1, 0, 0, getEnrollmentSummaryAck);
 
         compare(pdu, "300104c4000000029105910321642104c4024000069101910021322102");
     }
 
     @Test
     public void e1_7cTest() {
-        final GetEnrollmentSummaryRequest getEnrollmentSummaryRequest = new GetEnrollmentSummaryRequest(
+        GetEnrollmentSummaryRequest getEnrollmentSummaryRequest = new GetEnrollmentSummaryRequest(
                 GetEnrollmentSummaryRequest.AcknowledgmentFilter.all,
                 new RecipientProcess(new Recipient(new ObjectIdentifier(ObjectType.device, 17)),
                         new UnsignedInteger(9)),
                 null, null, new PriorityFilter(new UnsignedInteger(6), new UnsignedInteger(10)), null);
 
-        final ConfirmedRequest pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED,
+        ConfirmedRequest pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED,
                 MaxApduLength.UP_TO_206, (byte) 2, (byte) 0, 0, getEnrollmentSummaryRequest);
 
         compare(pdu, "0002020409001e0e0c020000110f19091f4e0906190a4f");
@@ -370,7 +370,7 @@ public class AnnexFEncodingTest {
 
     @Test
     public void e1_7dTest() {
-        final List<GetEnrollmentSummaryAck.EnrollmentSummary> enrollmentSummaries = new ArrayList<>();
+        List<GetEnrollmentSummaryAck.EnrollmentSummary> enrollmentSummaries = new ArrayList<>();
         enrollmentSummaries
                 .add(new GetEnrollmentSummaryAck.EnrollmentSummary(new ObjectIdentifier(ObjectType.analogInput, 2),
                         EventType.outOfRange, EventState.normal, new UnsignedInteger(8), new UnsignedInteger(4)));
@@ -384,10 +384,10 @@ public class AnnexFEncodingTest {
                 .add(new GetEnrollmentSummaryAck.EnrollmentSummary(new ObjectIdentifier(ObjectType.eventEnrollment, 7),
                         EventType.floatingLimit, EventState.normal, new UnsignedInteger(3), new UnsignedInteger(8)));
 
-        final GetEnrollmentSummaryAck getEnrollmentSummaryAck = new GetEnrollmentSummaryAck(
+        GetEnrollmentSummaryAck getEnrollmentSummaryAck = new GetEnrollmentSummaryAck(
                 new SequenceOf<>(enrollmentSummaries));
 
-        final ComplexACK pdu = new ComplexACK(false, false, (byte) 2, 0, 0, getEnrollmentSummaryAck);
+        ComplexACK pdu = new ComplexACK(false, false, (byte) 2, 0, 0, getEnrollmentSummaryAck);
 
         compare(pdu,
                 "300204c4000000029105910021082104c4000000039105910021082104c4000000049105910021082104c4024000079104910021032108");
@@ -395,9 +395,9 @@ public class AnnexFEncodingTest {
 
     @Test
     public void e1_8aTest() {
-        final GetEventInformationRequest getEventInformation = new GetEventInformationRequest(null);
+        GetEventInformationRequest getEventInformation = new GetEventInformationRequest(null);
 
-        final ConfirmedRequest pdu = new ConfirmedRequest(false, false, true, MaxSegments.UNSPECIFIED,
+        ConfirmedRequest pdu = new ConfirmedRequest(false, false, true, MaxSegments.UNSPECIFIED,
                 MaxApduLength.UP_TO_206, (byte) 1, (byte) 0, 0, getEventInformation);
 
         compare(pdu, "0202011d");
@@ -405,7 +405,7 @@ public class AnnexFEncodingTest {
 
     @Test
     public void e1_8bTest() {
-        final List<GetEventInformationAck.EventSummary> eventSummaries = new ArrayList<>();
+        List<GetEventInformationAck.EventSummary> eventSummaries = new ArrayList<>();
         eventSummaries.add(new GetEventInformationAck.EventSummary( //
                 new ObjectIdentifier(ObjectType.analogInput, 2), //
                 EventState.highLimit, //
@@ -425,10 +425,10 @@ public class AnnexFEncodingTest {
                 new EventTransitionBits(true, true, true),
                 new BACnetArray<>(new UnsignedInteger(15), new UnsignedInteger(15), new UnsignedInteger(20))));
 
-        final GetEventInformationAck getEventInformationAck = new GetEventInformationAck(
+        GetEventInformationAck getEventInformationAck = new GetEventInformationAck(
                 new SequenceOf<>(eventSummaries), Boolean.FALSE);
 
-        final ComplexACK pdu = new ComplexACK(false, false, (byte) 1, 0, 0, getEventInformationAck);
+        ComplexACK pdu = new ComplexACK(false, false, (byte) 1, 0, 0, getEventInformationAck);
 
         compare(pdu, "30011d0e0c0000000219032a05603e0c0f2300140cffffffff0cffffffff3f49005a05e06e210f210f21146f0"
                 + "c0000000319002a05c03e0c0f2800000cffffffff0c0f2d1e1e3f49005a05e06e210f210f21146f0f1900");
@@ -436,12 +436,12 @@ public class AnnexFEncodingTest {
 
     @Test
     public void e1_9aTest() {
-        final LifeSafetyOperationRequest lifeSafetyOperationRequest = new LifeSafetyOperationRequest(
+        LifeSafetyOperationRequest lifeSafetyOperationRequest = new LifeSafetyOperationRequest(
                 new UnsignedInteger(18),
                 new CharacterString(new CharacterEncoding(StandardCharacterEncodings.ANSI_X3_4), "MDL"),
                 LifeSafetyOperation.reset, new ObjectIdentifier(ObjectType.lifeSafetyPoint, 1));
 
-        final ConfirmedRequest pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED,
+        ConfirmedRequest pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED,
                 MaxApduLength.UP_TO_206, (byte) 15, (byte) 0, 0, lifeSafetyOperationRequest);
 
         compare(pdu, "00020f1b09121c004d444c29043c05400001");
@@ -449,16 +449,16 @@ public class AnnexFEncodingTest {
 
     @Test
     public void e1_9bTest() {
-        final SimpleACK pdu = new SimpleACK((byte) 15, 27);
+        SimpleACK pdu = new SimpleACK((byte) 15, 27);
         compare(pdu, "200f1b");
     }
 
     @Test
     public void e1_10aTest() {
-        final SubscribeCOVRequest subscribeCOVRequest = new SubscribeCOVRequest(new UnsignedInteger(18),
+        SubscribeCOVRequest subscribeCOVRequest = new SubscribeCOVRequest(new UnsignedInteger(18),
                 new ObjectIdentifier(ObjectType.analogInput, 10), Boolean.TRUE, UnsignedInteger.ZERO);
 
-        final ConfirmedRequest pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED,
+        ConfirmedRequest pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED,
                 MaxApduLength.UP_TO_206, (byte) 15, (byte) 0, 0, subscribeCOVRequest);
 
         compare(pdu, "00020f0509121c0000000a29013900");
@@ -466,17 +466,17 @@ public class AnnexFEncodingTest {
 
     @Test
     public void e1_10bTest() {
-        final SimpleACK pdu = new SimpleACK((byte) 15, 5);
+        SimpleACK pdu = new SimpleACK((byte) 15, 5);
         compare(pdu, "200f05");
     }
 
     @Test
     public void e1_11aTest() {
-        final SubscribeCOVPropertyRequest subscribeCOVPropertyRequest = new SubscribeCOVPropertyRequest(
+        SubscribeCOVPropertyRequest subscribeCOVPropertyRequest = new SubscribeCOVPropertyRequest(
                 new UnsignedInteger(18), new ObjectIdentifier(ObjectType.analogInput, 10), Boolean.TRUE,
                 new UnsignedInteger(60), new PropertyReference(PropertyIdentifier.presentValue, null), new Real(1));
 
-        final ConfirmedRequest pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED,
+        ConfirmedRequest pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED,
                 MaxApduLength.UP_TO_206, (byte) 15, (byte) 0, 0, subscribeCOVPropertyRequest);
 
         compare(pdu, "00020f1c09121c0000000a2901393c4e09554f5c3f800000");
@@ -484,13 +484,13 @@ public class AnnexFEncodingTest {
 
     @Test
     public void e1_11bTest() {
-        final SimpleACK pdu = new SimpleACK((byte) 15, 28);
+        SimpleACK pdu = new SimpleACK((byte) 15, 28);
         compare(pdu, "200f1c");
     }
 
     @Test
     public void e1_12aTest() {
-        final SubscribeCOVPropertyMultipleRequest req = new SubscribeCOVPropertyMultipleRequest(new Unsigned32(18),
+        SubscribeCOVPropertyMultipleRequest req = new SubscribeCOVPropertyMultipleRequest(new Unsigned32(18),
                 Boolean.TRUE,
                 new UnsignedInteger(
                         60),
@@ -507,7 +507,7 @@ public class AnnexFEncodingTest {
                                         new CovReference(new PropertyReference(PropertyIdentifier.presentValue),
                                                 new Real(1), Boolean.TRUE)))));
 
-        final ConfirmedRequest pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED,
+        ConfirmedRequest pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED,
                 MaxApduLength.UP_TO_206, (byte) 15, (byte) 0, 0, req);
 
         compare(pdu, "00020f1e09121901293c39054e0c0000000a1e0e09550f1c3f80000029010e09670f29001f0c004000081e0e" + ""
@@ -516,13 +516,13 @@ public class AnnexFEncodingTest {
 
     @Test
     public void e1_12bTest() {
-        final SimpleACK pdu = new SimpleACK((byte) 15, 30);
+        SimpleACK pdu = new SimpleACK((byte) 15, 30);
         compare(pdu, "200f1e");
     }
 
     @Test
     public void e1_13aTest() {
-        final ConfirmedCovNotificationMultipleRequest req = new ConfirmedCovNotificationMultipleRequest(
+        ConfirmedCovNotificationMultipleRequest req = new ConfirmedCovNotificationMultipleRequest(
                 new Unsigned32(18), new ObjectIdentifier(ObjectType.device, 4), new UnsignedInteger(35),
                 new DateTime(new Date(2013, Month.JUNE, 3, DayOfWeek.MONDAY), new Time(3, 23, 53, 47)),
                 new SequenceOf<>(
@@ -533,7 +533,7 @@ public class AnnexFEncodingTest {
                                 new SequenceOf<>(new CovNotificationValue(PropertyIdentifier.presentValue, null,
                                         new Real(80.1F), null)))));
 
-        final ConfirmedRequest pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED,
+        ConfirmedRequest pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED,
                 MaxApduLength.UP_TO_206, (byte) 15, (byte) 0, 0, req);
 
         // TODO
@@ -548,7 +548,7 @@ public class AnnexFEncodingTest {
 
     @Test
     public void e1_13bTest() {
-        final SimpleACK pdu = new SimpleACK((byte) 15, 31);
+        SimpleACK pdu = new SimpleACK((byte) 15, 31);
         compare(pdu, "200f1f");
     }
 
@@ -556,7 +556,7 @@ public class AnnexFEncodingTest {
     public void e1_14aTest() {
         // TODO the spec appears to be really messed up with this one, putting an unconfirmed service into
         // a confirmed request
-        final UnconfirmedCovNotificationMultipleRequest req = new UnconfirmedCovNotificationMultipleRequest(
+        UnconfirmedCovNotificationMultipleRequest req = new UnconfirmedCovNotificationMultipleRequest(
                 new Unsigned32(18), new ObjectIdentifier(ObjectType.device, 4), new UnsignedInteger(27), null,
                 new SequenceOf<>(
                         new com.serotonin.bacnet4j.service.unconfirmed.UnconfirmedCovNotificationMultipleRequest.CovNotification(
@@ -564,110 +564,110 @@ public class AnnexFEncodingTest {
                                 new com.serotonin.bacnet4j.service.unconfirmed.UnconfirmedCovNotificationMultipleRequest.CovNotification.CovNotificationValue(
                                         PropertyIdentifier.presentValue, null, new Real(65), null)))));
 
-        final UnconfirmedRequest pdu = new UnconfirmedRequest(req);
+        UnconfirmedRequest pdu = new UnconfirmedRequest(req);
 
         compare(pdu, "100b09121c02000004291b4e0c0000000a1e09552e44428200002f1f4f");
     }
 
     @Test
     public void e2_1aTest() {
-        final ConfirmedRequestService service = new AtomicReadFileRequest(new ObjectIdentifier(ObjectType.file, 1),
+        ConfirmedRequestService service = new AtomicReadFileRequest(new ObjectIdentifier(ObjectType.file, 1),
                 new StreamAccess(new SignedInteger(0), new UnsignedInteger(27)));
-        final APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_206,
+        APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_206,
                 (byte) 0, (byte) 0, 0, service);
         compare(pdu, "00020006C4028000010E3100211B0F");
     }
 
     @Test
     public void e2_1bTest() {
-        final AcknowledgementService service = new AtomicReadFileAck(Boolean.FALSE,
+        AcknowledgementService service = new AtomicReadFileAck(Boolean.FALSE,
                 new StreamAccessAck(new SignedInteger(0), new OctetString("Chiller01 On-Time=4.3 Hours".getBytes())));
-        final APDU pdu = new ComplexACK(false, false, (byte) 0, 0, 0, service);
+        APDU pdu = new ComplexACK(false, false, (byte) 0, 0, 0, service);
         compare(pdu, "300006100E3100651B4368696C6C65723031204F6E2D54696D653D342E3320486F7572730F");
     }
 
     @Test
     public void e2_1cTest() {
-        final ConfirmedRequestService service = new AtomicReadFileRequest(new ObjectIdentifier(ObjectType.file, 2),
+        ConfirmedRequestService service = new AtomicReadFileRequest(new ObjectIdentifier(ObjectType.file, 2),
                 new RecordAccess(new SignedInteger(14), new UnsignedInteger(3)));
-        final APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_206,
+        APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_206,
                 (byte) 18, (byte) 0, 0, service);
         compare(pdu, "00021206C4028000021E310E21031F");
     }
 
     @Test
     public void e2_1dTest() {
-        final List<OctetString> strings = new ArrayList<>();
+        List<OctetString> strings = new ArrayList<>();
         strings.add(new OctetString("12:00,45.6".getBytes()));
         strings.add(new OctetString("12:15,44.8".getBytes()));
-        final AcknowledgementService service = new AtomicReadFileAck(Boolean.TRUE,
+        AcknowledgementService service = new AtomicReadFileAck(Boolean.TRUE,
                 new RecordAccessAck(new SignedInteger(14), new UnsignedInteger(2), new SequenceOf<>(strings)));
-        final APDU pdu = new ComplexACK(false, false, (byte) 18, 0, 0, service);
+        APDU pdu = new ComplexACK(false, false, (byte) 18, 0, 0, service);
         compare(pdu, "301206111E310E2102650A31323A30302C34352E36650A31323A31352C34342E381F");
     }
 
     @Test
     public void e2_2aTest() {
-        final ConfirmedRequestService service = new AtomicWriteFileRequest(new ObjectIdentifier(ObjectType.file, 1),
+        ConfirmedRequestService service = new AtomicWriteFileRequest(new ObjectIdentifier(ObjectType.file, 1),
                 new com.serotonin.bacnet4j.service.confirmed.AtomicWriteFileRequest.StreamAccess(new SignedInteger(30),
                         new OctetString("Chiller01 On-Time=4.3 Hours".getBytes())));
-        final APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_206,
+        APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_206,
                 (byte) 85, (byte) 0, 0, service);
         compare(pdu, "00025507C4028000010E311E651B4368696C6C65723031204F6E2D54696D653D342E3320486F7572730F");
     }
 
     @Test
     public void e2_2bTest() {
-        final AcknowledgementService service = new AtomicWriteFileAck(false, new SignedInteger(30));
-        final APDU pdu = new ComplexACK(false, false, (byte) 85, 0, 0, service);
+        AcknowledgementService service = new AtomicWriteFileAck(false, new SignedInteger(30));
+        APDU pdu = new ComplexACK(false, false, (byte) 85, 0, 0, service);
         compare(pdu, "305507091E");
     }
 
     @Test
     public void e2_2cTest() {
-        final List<OctetString> strings = new ArrayList<>();
+        List<OctetString> strings = new ArrayList<>();
         strings.add(new OctetString("12:00,45.6".getBytes()));
         strings.add(new OctetString("12:15,44.8".getBytes()));
-        final ConfirmedRequestService service = new AtomicWriteFileRequest(new ObjectIdentifier(ObjectType.file, 2),
+        ConfirmedRequestService service = new AtomicWriteFileRequest(new ObjectIdentifier(ObjectType.file, 2),
                 new com.serotonin.bacnet4j.service.confirmed.AtomicWriteFileRequest.RecordAccess(new SignedInteger(-1),
                         new UnsignedInteger(2), new SequenceOf<>(strings)));
-        final APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_206,
+        APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_206,
                 (byte) 85, (byte) 0, 0, service);
         compare(pdu, "00025507C4028000021E31FF2102650A31323A30302C34352E36650A31323A31352C34342E381F");
     }
 
     @Test
     public void e2_2dTest() {
-        final AcknowledgementService service = new AtomicWriteFileAck(true, new SignedInteger(14));
-        final APDU pdu = new ComplexACK(false, false, (byte) 85, 0, 0, service);
+        AcknowledgementService service = new AtomicWriteFileAck(true, new SignedInteger(14));
+        APDU pdu = new ComplexACK(false, false, (byte) 85, 0, 0, service);
         compare(pdu, "305507190E");
     }
 
     @Test
     public void e3_1aTest() {
-        final List<PropertyReference> propertyReferences = new ArrayList<>();
+        List<PropertyReference> propertyReferences = new ArrayList<>();
         propertyReferences.add(new PropertyReference(PropertyIdentifier.presentValue, null));
         propertyReferences.add(new PropertyReference(PropertyIdentifier.reliability, null));
 
-        final List<ReadAccessSpecification> elements = new ArrayList<>();
+        List<ReadAccessSpecification> elements = new ArrayList<>();
         elements.add(new ReadAccessSpecification(new ObjectIdentifier(ObjectType.analogInput, 15),
                 new SequenceOf<>(propertyReferences)));
-        final ConfirmedRequestService service = new AddListElementRequest(new ObjectIdentifier(ObjectType.group, 3),
+        ConfirmedRequestService service = new AddListElementRequest(new ObjectIdentifier(ObjectType.group, 3),
                 PropertyIdentifier.listOfGroupMembers, null, new SequenceOf<>(elements));
-        final APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_206,
+        APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_206,
                 (byte) 1, (byte) 0, 0, service);
         compare(pdu, "000201080C02C0000319353E0C0000000F1E095509671F3F");
     }
 
     @Test
     public void e3_1bTest() {
-        final APDU pdu = new SimpleACK((byte) 1, 8);
+        APDU pdu = new SimpleACK((byte) 1, 8);
         compare(pdu, "200108");
     }
 
     @Test
     public void e3_2aTest() {
-        final List<ReadAccessSpecification> readAccessSpecs = new ArrayList<>();
+        List<ReadAccessSpecification> readAccessSpecs = new ArrayList<>();
 
         List<PropertyReference> propertyReferences = new ArrayList<>();
         propertyReferences.add(new PropertyReference(PropertyIdentifier.presentValue, null));
@@ -683,22 +683,22 @@ public class AnnexFEncodingTest {
         readAccessSpecs.add(new ReadAccessSpecification(new ObjectIdentifier(ObjectType.analogInput, 13),
                 new SequenceOf<>(propertyReferences)));
 
-        final ConfirmedRequestService service = new RemoveListElementRequest(new ObjectIdentifier(ObjectType.group, 3),
+        ConfirmedRequestService service = new RemoveListElementRequest(new ObjectIdentifier(ObjectType.group, 3),
                 PropertyIdentifier.listOfGroupMembers, null, new SequenceOf<>(readAccessSpecs));
-        final APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_206,
+        APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_206,
                 (byte) 52, (byte) 0, 0, service);
         compare(pdu, "000234090C02C0000319353E0C0000000C1E09550967091C1F0C0000000D1E09550967091C1F3F");
     }
 
     @Test
     public void e3_2bTest() {
-        final APDU pdu = new SimpleACK((byte) 52, 9);
+        APDU pdu = new SimpleACK((byte) 52, 9);
         compare(pdu, "203409");
     }
 
     @Test
     public void e3_2cTest() {
-        final List<ReadAccessSpecification> readAccessSpecs = new ArrayList<>();
+        List<ReadAccessSpecification> readAccessSpecs = new ArrayList<>();
 
         List<PropertyReference> propertyReferences = new ArrayList<>();
         propertyReferences.add(new PropertyReference(PropertyIdentifier.presentValue, null));
@@ -712,116 +712,116 @@ public class AnnexFEncodingTest {
         readAccessSpecs.add(new ReadAccessSpecification(new ObjectIdentifier(ObjectType.analogInput, 13),
                 new SequenceOf<>(propertyReferences)));
 
-        final ConfirmedRequestService service = new AddListElementRequest(new ObjectIdentifier(ObjectType.group, 3),
+        ConfirmedRequestService service = new AddListElementRequest(new ObjectIdentifier(ObjectType.group, 3),
                 PropertyIdentifier.listOfGroupMembers, null, new SequenceOf<>(readAccessSpecs));
-        final APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_206,
+        APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_206,
                 (byte) 53, (byte) 0, 0, service);
         compare(pdu, "000235080C02C0000319353E0C0000000C1E095509671F0C0000000D1E095509671F3F");
     }
 
     @Test
     public void e3_2dTest() {
-        final APDU pdu = new SimpleACK((byte) 53, 8);
+        APDU pdu = new SimpleACK((byte) 53, 8);
         compare(pdu, "203508");
     }
 
     @Test
     public void e3_3aTest() {
-        final List<PropertyValue> propertyValues = new ArrayList<>();
+        List<PropertyValue> propertyValues = new ArrayList<>();
         propertyValues.add(new PropertyValue(PropertyIdentifier.objectName, null,
                 new CharacterString(new CharacterEncoding(StandardCharacterEncodings.ANSI_X3_4), "Trend 1"), null));
         propertyValues
                 .add(new PropertyValue(PropertyIdentifier.fileAccessMethod, null, FileAccessMethod.recordAccess, null));
-        final ConfirmedRequestService service = new CreateObjectRequest(ObjectType.file,
+        ConfirmedRequestService service = new CreateObjectRequest(ObjectType.file,
                 new SequenceOf<>(propertyValues));
-        final APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_1024,
+        APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_1024,
                 (byte) 86, (byte) 0, 0, service);
         compare(pdu, "0004560A0E090A0F1E094D2E7508005472656E6420312F09292E91002F1F");
     }
 
     @Test
     public void e3_3bTest() {
-        final AcknowledgementService service = new CreateObjectAck(new ObjectIdentifier(ObjectType.file, 13));
-        final APDU pdu = new ComplexACK(false, false, (byte) 86, 0, 0, service);
+        AcknowledgementService service = new CreateObjectAck(new ObjectIdentifier(ObjectType.file, 13));
+        APDU pdu = new ComplexACK(false, false, (byte) 86, 0, 0, service);
         compare(pdu, "30560AC40280000D");
     }
 
     @Test
     public void e3_4aTest() {
-        final ConfirmedRequestService service = new DeleteObjectRequest(new ObjectIdentifier(ObjectType.group, 6));
-        final APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_1024,
+        ConfirmedRequestService service = new DeleteObjectRequest(new ObjectIdentifier(ObjectType.group, 6));
+        APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_1024,
                 (byte) 87, (byte) 0, 0, service);
         compare(pdu, "0004570BC402C00006");
     }
 
     @Test
     public void e3_4bTest() {
-        final APDU pdu = new SimpleACK((byte) 87, 11);
+        APDU pdu = new SimpleACK((byte) 87, 11);
         compare(pdu, "20570B");
     }
 
     @Test
     public void e3_4cTest() {
-        final ConfirmedRequestService service = new DeleteObjectRequest(new ObjectIdentifier(ObjectType.group, 7));
-        final APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_1024,
+        ConfirmedRequestService service = new DeleteObjectRequest(new ObjectIdentifier(ObjectType.group, 7));
+        APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_1024,
                 (byte) 88, (byte) 0, 0, service);
         compare(pdu, "0004580BC402C00007");
     }
 
     @Test
     public void e3_4dTest() {
-        final BaseError baseError = new ErrorClassAndCode(ErrorClass.object, ErrorCode.objectDeletionNotPermitted);
-        final APDU pdu = new com.serotonin.bacnet4j.apdu.Error((byte) 88, 11, baseError);
+        BaseError baseError = new ErrorClassAndCode(ErrorClass.object, ErrorCode.objectDeletionNotPermitted);
+        APDU pdu = new com.serotonin.bacnet4j.apdu.Error((byte) 88, 11, baseError);
         compare(pdu, "50580B91019117");
     }
 
     @Test
     public void e3_5aTest() {
-        final ConfirmedRequestService service = new ReadPropertyRequest(new ObjectIdentifier(ObjectType.analogInput, 5),
+        ConfirmedRequestService service = new ReadPropertyRequest(new ObjectIdentifier(ObjectType.analogInput, 5),
                 PropertyIdentifier.presentValue, null);
-        final APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_50,
+        APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_50,
                 (byte) 1, (byte) 0, 0, service);
         compare(pdu, "0000010C0C000000051955");
     }
 
     @Test
     public void e3_5bTest() {
-        final AcknowledgementService service = new ReadPropertyAck(new ObjectIdentifier(ObjectType.analogInput, 5),
+        AcknowledgementService service = new ReadPropertyAck(new ObjectIdentifier(ObjectType.analogInput, 5),
                 PropertyIdentifier.presentValue, null, new Real(72.3f));
-        final APDU pdu = new ComplexACK(false, false, (byte) 1, 0, 0, service);
+        APDU pdu = new ComplexACK(false, false, (byte) 1, 0, 0, service);
         compare(pdu, "30010C0C0000000519553E444290999A3F");
     }
 
     @Test
     public void e3_7aTest() {
-        final List<ReadAccessSpecification> readAccessSpecs = new ArrayList<>();
-        final List<PropertyReference> propertyReferences = new ArrayList<>();
+        List<ReadAccessSpecification> readAccessSpecs = new ArrayList<>();
+        List<PropertyReference> propertyReferences = new ArrayList<>();
         propertyReferences.add(new PropertyReference(PropertyIdentifier.presentValue, null));
         propertyReferences.add(new PropertyReference(PropertyIdentifier.reliability, null));
         readAccessSpecs.add(new ReadAccessSpecification(new ObjectIdentifier(ObjectType.analogInput, 16),
                 new SequenceOf<>(propertyReferences)));
-        final ConfirmedRequestService service = new ReadPropertyMultipleRequest(new SequenceOf<>(readAccessSpecs));
-        final APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_1024,
+        ConfirmedRequestService service = new ReadPropertyMultipleRequest(new SequenceOf<>(readAccessSpecs));
+        APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_1024,
                 (byte) 241, (byte) 0, 0, service);
         compare(pdu, "0004F10E0C000000101E095509671F");
     }
 
     @Test
     public void e3_7bTest() {
-        final List<ReadAccessResult> readAccessResults = new ArrayList<>();
-        final List<Result> results = new ArrayList<>();
+        List<ReadAccessResult> readAccessResults = new ArrayList<>();
+        List<Result> results = new ArrayList<>();
         results.add(new Result(PropertyIdentifier.presentValue, null, new Real(72.3f)));
         results.add(new Result(PropertyIdentifier.reliability, null, Reliability.noFaultDetected));
         readAccessResults
                 .add(new ReadAccessResult(new ObjectIdentifier(ObjectType.analogInput, 16), new SequenceOf<>(results)));
-        final AcknowledgementService service = new ReadPropertyMultipleAck(new SequenceOf<>(readAccessResults));
-        final APDU pdu = new ComplexACK(false, false, (byte) 241, 0, 0, service);
+        AcknowledgementService service = new ReadPropertyMultipleAck(new SequenceOf<>(readAccessResults));
+        APDU pdu = new ComplexACK(false, false, (byte) 241, 0, 0, service);
         compare(pdu, "30F10E0C000000101E29554E444290999A4F29674E91004F1F");
     }
 
     @Test
     public void e3_7cTest() {
-        final List<ReadAccessSpecification> readAccessSpecs = new ArrayList<>();
+        List<ReadAccessSpecification> readAccessSpecs = new ArrayList<>();
 
         List<PropertyReference> propertyReferences = new ArrayList<>();
         propertyReferences.add(new PropertyReference(PropertyIdentifier.presentValue, null));
@@ -838,15 +838,15 @@ public class AnnexFEncodingTest {
         readAccessSpecs.add(new ReadAccessSpecification(new ObjectIdentifier(ObjectType.analogInput, 35),
                 new SequenceOf<>(propertyReferences)));
 
-        final ConfirmedRequestService service = new ReadPropertyMultipleRequest(new SequenceOf<>(readAccessSpecs));
-        final APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_1024,
+        ConfirmedRequestService service = new ReadPropertyMultipleRequest(new SequenceOf<>(readAccessSpecs));
+        APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_1024,
                 (byte) 2, (byte) 0, 0, service);
         compare(pdu, "0004020E0C000000211E09551F0C000000321E09551F0C000000231E09551F");
     }
 
     @Test
     public void e3_7dTest() {
-        final List<ReadAccessResult> readAccessResults = new ArrayList<>();
+        List<ReadAccessResult> readAccessResults = new ArrayList<>();
 
         List<Result> results = new ArrayList<>();
         results.add(new Result(PropertyIdentifier.presentValue, null, new Real(42.3f)));
@@ -864,26 +864,26 @@ public class AnnexFEncodingTest {
         readAccessResults
                 .add(new ReadAccessResult(new ObjectIdentifier(ObjectType.analogInput, 35), new SequenceOf<>(results)));
 
-        final AcknowledgementService service = new ReadPropertyMultipleAck(new SequenceOf<>(readAccessResults));
-        final APDU pdu = new ComplexACK(false, false, (byte) 2, 0, 0, service);
+        AcknowledgementService service = new ReadPropertyMultipleAck(new SequenceOf<>(readAccessResults));
+        APDU pdu = new ComplexACK(false, false, (byte) 2, 0, 0, service);
         compare(pdu,
                 "30020E0C000000211E29554E44422933334F1F0C000000321E29555E9101911F5F1F0C000000231E29554E4443D9D99A4F1F");
     }
 
     @Test
     public void e3_8aTest() {
-        final ReadRangeRequest req = new ReadRangeRequest(new ObjectIdentifier(ObjectType.trendLog, 1),
+        ReadRangeRequest req = new ReadRangeRequest(new ObjectIdentifier(ObjectType.trendLog, 1),
                 PropertyIdentifier.logBuffer, null,
                 new ByTime(new DateTime(new Date(1998, Month.MARCH, 23, DayOfWeek.MONDAY), new Time(19, 52, 34, 0)),
                         new SignedInteger(4)));
-        final APDU pdu = new ConfirmedRequest(false, false, true, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_206,
+        APDU pdu = new ConfirmedRequest(false, false, true, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_206,
                 (byte) 1, (byte) 0, 0, req);
         compare(pdu, "0202011a0c0500000119837ea462031701b41334220031047f");
     }
 
     @Test
     public void e3_8bTest() {
-        final AcknowledgementService service = new ReadRangeAck(new ObjectIdentifier(ObjectType.trendLog, 1),
+        AcknowledgementService service = new ReadRangeAck(new ObjectIdentifier(ObjectType.trendLog, 1),
                 PropertyIdentifier.logBuffer, null, new ResultFlags(true, true, false), new UnsignedInteger(2),
                 new SequenceOf<>(
                         new LogRecord(
@@ -896,7 +896,7 @@ public class AnnexFEncodingTest {
                                 false, new Real(18.1f), new StatusFlags(false, false, false, false))),
                 new UnsignedInteger(79201));
 
-        final APDU pdu = new ComplexACK(false, false, (byte) 1, 0, 0, service);
+        APDU pdu = new ComplexACK(false, false, (byte) 1, 0, 0, service);
 
         compare(pdu, "30011a0c0500000119833a05c049025e0ea462031701b413361b000f1e2c419000001f2a04000ea462031701" + ""
                 + "b413381b000f1e2c4190cccd1f2a04005f6b013561");
@@ -904,23 +904,23 @@ public class AnnexFEncodingTest {
 
     @Test
     public void e3_9aTest() {
-        final ConfirmedRequestService service = new WritePropertyRequest(
+        ConfirmedRequestService service = new WritePropertyRequest(
                 new ObjectIdentifier(ObjectType.analogValue, 1), PropertyIdentifier.presentValue, null, new Real(180),
                 null);
-        final APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_1024,
+        APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_1024,
                 (byte) 89, (byte) 0, 0, service);
         compare(pdu, "0004590F0C0080000119553E44433400003F");
     }
 
     @Test
     public void e3_9bTest() {
-        final APDU pdu = new SimpleACK((byte) 89, 15);
+        APDU pdu = new SimpleACK((byte) 89, 15);
         compare(pdu, "20590F");
     }
 
     @Test
     public void e3_10aTest() {
-        final List<WriteAccessSpecification> writeAccessSpecs = new ArrayList<>();
+        List<WriteAccessSpecification> writeAccessSpecs = new ArrayList<>();
 
         List<PropertyValue> propertyValues = new ArrayList<>();
         propertyValues.add(new PropertyValue(PropertyIdentifier.presentValue, null, new Real(67), null));
@@ -936,8 +936,8 @@ public class AnnexFEncodingTest {
         propertyValues.add(new PropertyValue(PropertyIdentifier.presentValue, null, new Real(72), null));
         writeAccessSpecs.add(new WriteAccessSpecification(new ObjectIdentifier(ObjectType.analogValue, 7),
                 new SequenceOf<>(propertyValues)));
-        final ConfirmedRequestService service = new WritePropertyMultipleRequest(new SequenceOf<>(writeAccessSpecs));
-        final APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_1024,
+        ConfirmedRequestService service = new WritePropertyMultipleRequest(new SequenceOf<>(writeAccessSpecs));
+        APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_1024,
                 (byte) 1, (byte) 0, 0, service);
         compare(pdu, "000401100C008000051E09552E44428600002F1F0C008000061E09552E44428600002F1F0C008000071E09552E4442"
                 + "9000002F1F");
@@ -945,13 +945,13 @@ public class AnnexFEncodingTest {
 
     @Test
     public void e3_10bTest() {
-        final APDU pdu = new SimpleACK((byte) 1, 16);
+        APDU pdu = new SimpleACK((byte) 1, 16);
         compare(pdu, "200110");
     }
 
     @Test
     public void e3_11Test() {
-        final WriteGroupRequest req = new WriteGroupRequest(new Unsigned32(23), new UnsignedInteger(8),
+        WriteGroupRequest req = new WriteGroupRequest(new Unsigned32(23), new UnsignedInteger(8),
                 new SequenceOf<>(
                         new GroupChannelValue(new Unsigned16(268), null, new ChannelValue(new UnsignedInteger(1111))),
                         new GroupChannelValue(new Unsigned16(269), null, new ChannelValue(new UnsignedInteger(2222)))),
@@ -961,7 +961,7 @@ public class AnnexFEncodingTest {
 
     @Test
     public void e3_12Test() {
-        final WriteGroupRequest req = new WriteGroupRequest(new Unsigned32(23), new UnsignedInteger(8),
+        WriteGroupRequest req = new WriteGroupRequest(new Unsigned32(23), new UnsignedInteger(8),
                 new SequenceOf<>(new GroupChannelValue(new Unsigned16(12), null, new ChannelValue(new Real(67))),
                         new GroupChannelValue(new Unsigned16(13), null, new ChannelValue(new Real(72)))),
                 Boolean.TRUE);
@@ -970,7 +970,7 @@ public class AnnexFEncodingTest {
 
     @Test
     public void e3_13Test() {
-        final WriteGroupRequest req = new WriteGroupRequest(new Unsigned32(23), new UnsignedInteger(8),
+        WriteGroupRequest req = new WriteGroupRequest(new Unsigned32(23), new UnsignedInteger(8),
                 new SequenceOf<>(
                         new GroupChannelValue(new Unsigned16(12), null, new ChannelValue(new UnsignedInteger(1111))),
                         new GroupChannelValue(new Unsigned16(13), new UnsignedInteger(10),
@@ -981,270 +981,273 @@ public class AnnexFEncodingTest {
 
     @Test
     public void e4_1aTest() {
-        final ConfirmedRequestService service = new DeviceCommunicationControlRequest(new UnsignedInteger(5),
-                EnableDisable.disable,
+        // Example E.4.1 per addendum 135-2016bi-2: Enable-Disable = DISABLE_INITIATION (value 2).
+        // Prior to bi-2 the example used DISABLE (value 1); the on-wire enum byte changes from
+        // 0x01 to 0x02.
+        ConfirmedRequestService service = new DeviceCommunicationControlRequest(new Unsigned16(5),
+                EnableDisable.disableInitiation,
                 new CharacterString(new CharacterEncoding(StandardCharacterEncodings.ANSI_X3_4), "#egbdf!"));
-        final APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_1024,
+        APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_1024,
                 (byte) 5, (byte) 0, 0, service);
-        compare(pdu, "00040511090519012D080023656762646621");
+        compare(pdu, "00040511090519022D080023656762646621");
     }
 
     @Test
     public void e4_1bTest() {
-        final APDU pdu = new SimpleACK((byte) 5, 17);
+        APDU pdu = new SimpleACK((byte) 5, 17);
         compare(pdu, "200511");
     }
 
     @Test
     public void e4_2aTest() {
-        final EncodedValue parameters = new EncodedValue(new Real(72.4f), new OctetString(new byte[] {0x16, 0x49}));
-        final ConfirmedRequestService service = new ConfirmedPrivateTransferRequest(new UnsignedInteger(25),
+        EncodedValue parameters = new EncodedValue(new Real(72.4f), new OctetString(new byte[] {0x16, 0x49}));
+        ConfirmedRequestService service = new ConfirmedPrivateTransferRequest(new UnsignedInteger(25),
                 new UnsignedInteger(8), parameters);
-        final APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_1024,
+        APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_1024,
                 (byte) 85, (byte) 0, 0, service);
         compare(pdu, "00045512091919082E444290CCCD6216492F");
     }
 
     @Test
     public void e4_2bTest() {
-        final AcknowledgementService service = new ConfirmedPrivateTransferAck(new UnsignedInteger(25),
+        AcknowledgementService service = new ConfirmedPrivateTransferAck(new UnsignedInteger(25),
                 new UnsignedInteger(8), null);
-        final APDU pdu = new ComplexACK(false, false, (byte) 85, 0, 0, service);
+        APDU pdu = new ComplexACK(false, false, (byte) 85, 0, 0, service);
         compare(pdu, "30551209191908");
     }
 
     @Test
     public void e4_3Test() {
-        final EncodedValue parameters = new EncodedValue(new Real(72.4f), new OctetString(new byte[] {0x16, 0x49}));
-        final UnconfirmedRequestService service = new UnconfirmedPrivateTransferRequest(new UnsignedInteger(25),
+        EncodedValue parameters = new EncodedValue(new Real(72.4f), new OctetString(new byte[] {0x16, 0x49}));
+        UnconfirmedRequestService service = new UnconfirmedPrivateTransferRequest(new UnsignedInteger(25),
                 new UnsignedInteger(8), parameters);
-        final APDU pdu = new UnconfirmedRequest(service);
+        APDU pdu = new UnconfirmedRequest(service);
         compare(pdu, "1004091919082E444290CCCD6216492F");
     }
 
     @Test
     public void e4_4aTest() {
-        final ConfirmedRequestService service = new ReinitializeDeviceRequest(ReinitializedStateOfDevice.warmstart,
+        ConfirmedRequestService service = new ReinitializeDeviceRequest(ReinitializedStateOfDevice.warmstart,
                 new CharacterString(new CharacterEncoding(StandardCharacterEncodings.ANSI_X3_4), "AbCdEfGh"));
-        final APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_128,
+        APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_128,
                 (byte) 2, (byte) 0, 0, service);
         compare(pdu, "0001021409011D09004162436445664768");
     }
 
     @Test
     public void e4_4bTest() {
-        final APDU pdu = new SimpleACK((byte) 2, 20);
+        APDU pdu = new SimpleACK((byte) 2, 20);
         compare(pdu, "200214");
     }
 
     @Test
     public void e4_5aTest() {
-        final ConfirmedRequestService service = new ConfirmedTextMessageRequest(
+        ConfirmedRequestService service = new ConfirmedTextMessageRequest(
                 new ObjectIdentifier(ObjectType.device, 5), MessagePriority.normal,
                 new CharacterString(new CharacterEncoding(StandardCharacterEncodings.ANSI_X3_4),
                         "PM required for PUMP347"));
-        final APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_128,
+        APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_128,
                 (byte) 3, (byte) 0, 0, service);
         compare(pdu, "000103130C0200000529003D1800504D20726571756972656420666F722050554D50333437");
     }
 
     @Test
     public void e4_5bTest() {
-        final APDU pdu = new SimpleACK((byte) 3, 19);
+        APDU pdu = new SimpleACK((byte) 3, 19);
         compare(pdu, "200313");
     }
 
     @Test
     public void e4_6Test() {
-        final UnconfirmedRequestService service = new UnconfirmedTextMessageRequest(
+        UnconfirmedRequestService service = new UnconfirmedTextMessageRequest(
                 new ObjectIdentifier(ObjectType.device, 5), MessagePriority.normal,
                 new CharacterString(new CharacterEncoding(StandardCharacterEncodings.ANSI_X3_4),
                         "PM required for PUMP347"));
-        final APDU pdu = new UnconfirmedRequest(service);
+        APDU pdu = new UnconfirmedRequest(service);
         compare(pdu, "10050C0200000529003D1800504D20726571756972656420666F722050554D50333437");
     }
 
     @Test
     public void e4_7Test() {
-        final UnconfirmedRequestService service = new TimeSynchronizationRequest(
+        UnconfirmedRequestService service = new TimeSynchronizationRequest(
                 new DateTime(new Date(1992, Month.NOVEMBER, 17, DayOfWeek.UNSPECIFIED), new Time(22, 45, 30, 70)));
-        final APDU pdu = new UnconfirmedRequest(service);
+        APDU pdu = new UnconfirmedRequest(service);
         compare(pdu, "1006A45C0B11FFB4162D1E46");
     }
 
     @Test
     public void e4_8aTest() {
-        final UnconfirmedRequestService service = new WhoHasRequest(null,
+        UnconfirmedRequestService service = new WhoHasRequest(null,
                 new CharacterString(new CharacterEncoding(StandardCharacterEncodings.ANSI_X3_4), "OATemp"));
-        final APDU pdu = new UnconfirmedRequest(service);
+        APDU pdu = new UnconfirmedRequest(service);
         compare(pdu, "10073D07004F4154656D70");
     }
 
     @Test
     public void e4_8bTest() {
-        final UnconfirmedRequestService service = new IHaveRequest(new ObjectIdentifier(ObjectType.device, 8),
+        UnconfirmedRequestService service = new IHaveRequest(new ObjectIdentifier(ObjectType.device, 8),
                 new ObjectIdentifier(ObjectType.analogInput, 3),
                 new CharacterString(new CharacterEncoding(StandardCharacterEncodings.ANSI_X3_4), "OATemp"));
-        final APDU pdu = new UnconfirmedRequest(service);
+        APDU pdu = new UnconfirmedRequest(service);
         compare(pdu, "1001C402000008C4000000037507004F4154656D70");
     }
 
     @Test
     public void e4_8cTest() {
-        final UnconfirmedRequestService service = new WhoHasRequest(null,
+        UnconfirmedRequestService service = new WhoHasRequest(null,
                 new ObjectIdentifier(ObjectType.analogInput, 3));
-        final APDU pdu = new UnconfirmedRequest(service);
+        APDU pdu = new UnconfirmedRequest(service);
         compare(pdu, "10072C00000003");
     }
 
     @Test
     public void e4_8dTest() {
-        final UnconfirmedRequestService service = new IHaveRequest(new ObjectIdentifier(ObjectType.device, 8),
+        UnconfirmedRequestService service = new IHaveRequest(new ObjectIdentifier(ObjectType.device, 8),
                 new ObjectIdentifier(ObjectType.analogInput, 3),
                 new CharacterString(new CharacterEncoding(StandardCharacterEncodings.ANSI_X3_4), "OATemp"));
-        final APDU pdu = new UnconfirmedRequest(service);
+        APDU pdu = new UnconfirmedRequest(service);
         compare(pdu, "1001C402000008C4000000037507004F4154656D70");
     }
 
     @Test
     public void e4_9aTest() {
-        final UnconfirmedRequestService service = new WhoIsRequest(new UnsignedInteger(3), new UnsignedInteger(3));
-        final APDU pdu = new UnconfirmedRequest(service);
+        UnconfirmedRequestService service = new WhoIsRequest(new UnsignedInteger(3), new UnsignedInteger(3));
+        APDU pdu = new UnconfirmedRequest(service);
         compare(pdu, "100809031903");
     }
 
     @Test
     public void e4_9bTest() {
-        final UnconfirmedRequestService service = new IAmRequest(new ObjectIdentifier(ObjectType.device, 3),
+        UnconfirmedRequestService service = new IAmRequest(new ObjectIdentifier(ObjectType.device, 3),
                 new UnsignedInteger(1024), Segmentation.noSegmentation, new UnsignedInteger(99));
-        final APDU pdu = new UnconfirmedRequest(service);
+        APDU pdu = new UnconfirmedRequest(service);
         compare(pdu, "1000C40200000322040091032163");
     }
 
     @Test
     public void e4_9cTest() {
-        final UnconfirmedRequestService service = new WhoIsRequest();
-        final APDU pdu = new UnconfirmedRequest(service);
+        UnconfirmedRequestService service = new WhoIsRequest();
+        APDU pdu = new UnconfirmedRequest(service);
         compare(pdu, "1008");
     }
 
     @Test
     public void e4_9dTest() {
-        final UnconfirmedRequestService service = new IAmRequest(new ObjectIdentifier(ObjectType.device, 1),
+        UnconfirmedRequestService service = new IAmRequest(new ObjectIdentifier(ObjectType.device, 1),
                 new UnsignedInteger(480), Segmentation.segmentedTransmit, new UnsignedInteger(99));
-        final APDU pdu = new UnconfirmedRequest(service);
+        APDU pdu = new UnconfirmedRequest(service);
         compare(pdu, "1000C4020000012201E091012163");
     }
 
     @Test
     public void e4_9eTest() {
-        final UnconfirmedRequestService service = new IAmRequest(new ObjectIdentifier(ObjectType.device, 2),
+        UnconfirmedRequestService service = new IAmRequest(new ObjectIdentifier(ObjectType.device, 2),
                 new UnsignedInteger(206), Segmentation.segmentedReceive, new UnsignedInteger(33));
-        final APDU pdu = new UnconfirmedRequest(service);
+        APDU pdu = new UnconfirmedRequest(service);
         compare(pdu, "1000C40200000221CE91022121");
     }
 
     @Test
     public void e4_9fTest() {
-        final UnconfirmedRequestService service = new IAmRequest(new ObjectIdentifier(ObjectType.device, 3),
+        UnconfirmedRequestService service = new IAmRequest(new ObjectIdentifier(ObjectType.device, 3),
                 new UnsignedInteger(1024), Segmentation.noSegmentation, new UnsignedInteger(99));
-        final APDU pdu = new UnconfirmedRequest(service);
+        APDU pdu = new UnconfirmedRequest(service);
         compare(pdu, "1000C40200000322040091032163");
     }
 
     @Test
     public void e4_9gTest() {
-        final UnconfirmedRequestService service = new IAmRequest(new ObjectIdentifier(ObjectType.device, 4),
+        UnconfirmedRequestService service = new IAmRequest(new ObjectIdentifier(ObjectType.device, 4),
                 new UnsignedInteger(128), Segmentation.segmentedBoth, new UnsignedInteger(66));
-        final APDU pdu = new UnconfirmedRequest(service);
+        APDU pdu = new UnconfirmedRequest(service);
         compare(pdu, "1000C402000004218091002142");
     }
 
     @Test
     public void e5_aTest() {
-        final ConfirmedRequestService service = new VtOpenRequest(VtClass.ansi_x3_64, new UnsignedInteger(5));
-        final APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_128,
+        ConfirmedRequestService service = new VtOpenRequest(VtClass.ansi_x3_64, new UnsignedInteger(5));
+        APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_128,
                 (byte) 80, (byte) 0, 0, service);
         compare(pdu, "0001501591012105");
     }
 
     @Test
     public void e5_bTest() {
-        final AcknowledgementService service = new VtOpenAck(new UnsignedInteger(29));
-        final APDU pdu = new ComplexACK(false, false, (byte) 80, 0, 0, service);
+        AcknowledgementService service = new VtOpenAck(new UnsignedInteger(29));
+        APDU pdu = new ComplexACK(false, false, (byte) 80, 0, 0, service);
         compare(pdu, "305015211D");
     }
 
     @Test
     public void e5_cTest() {
-        final byte[] data = "\r\nEnter User Name:".getBytes();
-        final ConfirmedRequestService service = new VtDataRequest(new UnsignedInteger(5), new OctetString(data),
+        byte[] data = "\r\nEnter User Name:".getBytes();
+        ConfirmedRequestService service = new VtDataRequest(new UnsignedInteger(5), new OctetString(data),
                 UnsignedInteger.ZERO);
-        final APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_128,
+        APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_128,
                 (byte) 81, (byte) 0, 0, service);
         compare(pdu, "00015117210565120D0A456E7465722055736572204E616D653A2100");
     }
 
     @Test
     public void e5_dTest() {
-        final AcknowledgementService service = new VtDataAck(Boolean.TRUE, null);
-        final APDU pdu = new ComplexACK(false, false, (byte) 81, 0, 0, service);
+        AcknowledgementService service = new VtDataAck(Boolean.TRUE, null);
+        APDU pdu = new ComplexACK(false, false, (byte) 81, 0, 0, service);
         compare(pdu, "3051170901");
     }
 
     @Test
     public void e5_eTest() {
-        final ConfirmedRequestService service = new VtDataRequest(new UnsignedInteger(29),
+        ConfirmedRequestService service = new VtDataRequest(new UnsignedInteger(29),
                 new OctetString("FRED\r".getBytes()), UnsignedInteger.ZERO);
-        final APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_128,
+        APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_128,
                 (byte) 82, (byte) 0, 0, service);
         compare(pdu, "00015217211D6505465245440D2100");
     }
 
     @Test
     public void e5_fTest() {
-        final AcknowledgementService service = new VtDataAck(Boolean.TRUE, null);
-        final APDU pdu = new ComplexACK(false, false, (byte) 82, 0, 0, service);
+        AcknowledgementService service = new VtDataAck(Boolean.TRUE, null);
+        APDU pdu = new ComplexACK(false, false, (byte) 82, 0, 0, service);
         compare(pdu, "3052170901");
     }
 
     @Test
     public void e5_gTest() {
-        final ConfirmedRequestService service = new VtDataRequest(new UnsignedInteger(5),
+        ConfirmedRequestService service = new VtDataRequest(new UnsignedInteger(5),
                 new OctetString("FRED\r\nEnter Password:".getBytes()), new UnsignedInteger(1));
-        final APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_128,
+        APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_128,
                 (byte) 83, (byte) 0, 0, service);
         compare(pdu, "0001531721056515465245440D0A456E7465722050617373776F72643A2101");
     }
 
     @Test
     public void e5_hTest() {
-        final AcknowledgementService service = new VtDataAck(Boolean.TRUE, null);
-        final APDU pdu = new ComplexACK(false, false, (byte) 83, 0, 0, service);
+        AcknowledgementService service = new VtDataAck(Boolean.TRUE, null);
+        APDU pdu = new ComplexACK(false, false, (byte) 83, 0, 0, service);
         compare(pdu, "3053170901");
     }
 
     @Test
     public void e5_iTest() {
-        final List<UnsignedInteger> ids = new ArrayList<>();
+        List<UnsignedInteger> ids = new ArrayList<>();
         ids.add(new UnsignedInteger(29));
-        final ConfirmedRequestService service = new VtCloseRequest(new SequenceOf<>(ids));
-        final APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_128,
+        ConfirmedRequestService service = new VtCloseRequest(new SequenceOf<>(ids));
+        APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_128,
                 (byte) 84, (byte) 0, 0, service);
         compare(pdu, "00015416211D");
     }
 
     @Test
     public void e5_jTest() {
-        final APDU pdu = new SimpleACK((byte) 84, 22);
+        APDU pdu = new SimpleACK((byte) 84, 22);
         compare(pdu, "205416");
     }
 
-    private void compare(final APDU pdu, final String expectedHex) {
-        final ByteQueue expectedResult = new ByteQueue(expectedHex);
+    private void compare(APDU pdu, String expectedHex) {
+        ByteQueue expectedResult = new ByteQueue(expectedHex);
 
         // Serialize the APDU and compare with the hex.
-        final ByteQueue queue = new ByteQueue();
+        ByteQueue queue = new ByteQueue();
         pdu.write(queue);
         assertEquals(expectedResult, queue);
 
@@ -1256,7 +1259,7 @@ public class AnnexFEncodingTest {
                 ((Segmentable) parsedAPDU).parseServiceData();
             if (parsedAPDU instanceof UnconfirmedRequest)
                 ((UnconfirmedRequest) parsedAPDU).parseServiceData();
-        } catch (final BACnetException e) {
+        } catch (BACnetException e) {
             e.printStackTrace();
             fail(e.getMessage());
             return;

--- a/src/test/java/com/serotonin/bacnet4j/service/confirmed/DeviceCommunicationControlRequestTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/service/confirmed/DeviceCommunicationControlRequestTest.java
@@ -58,7 +58,7 @@ import com.serotonin.bacnet4j.type.enumerated.ObjectType;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
 import com.serotonin.bacnet4j.type.primitive.CharacterString;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
-import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
+import com.serotonin.bacnet4j.type.primitive.Unsigned16;
 
 /**
  * All tests modify the communication control in device d1.
@@ -218,7 +218,7 @@ public class DeviceCommunicationControlRequestTest extends AbstractTest {
     public void timer() throws Exception {
         // Disable-initiation on d1 for 5 minutes.
         d2.send(rd1, new DeviceCommunicationControlRequest(
-                new UnsignedInteger(5), EnableDisable.disableInitiation, null)).get();
+                new Unsigned16(5), EnableDisable.disableInitiation, null)).get();
         awaitEquals(EnableDisable.disableInitiation, d1::getCommunicationControlState);
 
         // d1 cannot initiate a request during the disable window.
@@ -259,7 +259,7 @@ public class DeviceCommunicationControlRequestTest extends AbstractTest {
     public void timerCancel() throws Exception {
         // Disable-initiation on d1 for 5 minutes.
         d2.send(rd1, new DeviceCommunicationControlRequest(
-                new UnsignedInteger(5), EnableDisable.disableInitiation, null)).get();
+                new Unsigned16(5), EnableDisable.disableInitiation, null)).get();
         awaitEquals(EnableDisable.disableInitiation, d1::getCommunicationControlState);
 
         // Confirm d1 cannot initiate during the disable window.
@@ -278,7 +278,7 @@ public class DeviceCommunicationControlRequestTest extends AbstractTest {
         clock.plusMinutes(1);
 
         // Re-enable explicitly. The 5-minute timer should be cancelled so it can't fire later.
-        d2.send(rd1, new DeviceCommunicationControlRequest(new UnsignedInteger(5), EnableDisable.enable, null)).get();
+        d2.send(rd1, new DeviceCommunicationControlRequest(new Unsigned16(5), EnableDisable.enable, null)).get();
         awaitEquals(EnableDisable.enable, d1::getCommunicationControlState);
 
         // d1 can initiate now.

--- a/src/test/java/com/serotonin/bacnet4j/service/confirmed/DeviceCommunicationControlRequestTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/service/confirmed/DeviceCommunicationControlRequestTest.java
@@ -28,12 +28,13 @@
 package com.serotonin.bacnet4j.service.confirmed;
 
 import static com.serotonin.bacnet4j.TestUtils.awaitEquals;
-import static com.serotonin.bacnet4j.TestUtils.awaitTrue;
 import static com.serotonin.bacnet4j.TestUtils.quiesce;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
@@ -41,13 +42,10 @@ import org.junit.Test;
 import com.serotonin.bacnet4j.AbstractTest;
 import com.serotonin.bacnet4j.LocalDevice;
 import com.serotonin.bacnet4j.RemoteDevice;
-import com.serotonin.bacnet4j.ServiceFuture;
 import com.serotonin.bacnet4j.TestUtils;
 import com.serotonin.bacnet4j.event.DefaultReinitializeDeviceHandler;
 import com.serotonin.bacnet4j.event.DeviceEventAdapter;
-import com.serotonin.bacnet4j.exception.BACnetErrorException;
 import com.serotonin.bacnet4j.exception.BACnetException;
-import com.serotonin.bacnet4j.exception.BACnetTimeoutException;
 import com.serotonin.bacnet4j.exception.CommunicationDisabledException;
 import com.serotonin.bacnet4j.exception.ErrorAPDUException;
 import com.serotonin.bacnet4j.service.confirmed.DeviceCommunicationControlRequest.EnableDisable;
@@ -101,7 +99,7 @@ public class DeviceCommunicationControlRequestTest extends AbstractTest {
                     new WritePropertyRequest(new ObjectIdentifier(ObjectType.device, 2), PropertyIdentifier.description,
                             null, new CharacterString("a"), null)).get();
             fail("BACnetException should have been thrown");
-        } catch (final BACnetException e) {
+        } catch (BACnetException e) {
             // Inner exception must be a BACCommunicationDisabledException
             if (!(e.getCause() instanceof CommunicationDisabledException)) {
                 fail("CommunicationDisabledException should have been thrown");
@@ -116,10 +114,10 @@ public class DeviceCommunicationControlRequestTest extends AbstractTest {
         assertEquals(new CharacterString("a"), d1.get(PropertyIdentifier.description));
 
         // Sending of IAms...
-        final AtomicInteger iamCount = new AtomicInteger(0);
+        AtomicInteger iamCount = new AtomicInteger(0);
         d2.getEventHandler().addListener(new DeviceEventAdapter() {
             @Override
-            public void iAmReceived(final RemoteDevice d) {
+            public void iAmReceived(RemoteDevice d) {
                 iamCount.incrementAndGet();
             }
         });
@@ -146,72 +144,27 @@ public class DeviceCommunicationControlRequestTest extends AbstractTest {
     }
 
     /**
-     * Ensure that only DCCR and reinitialize are handled when disabled
+     * Per addendum 135-2016bi-2 (Protocol Revision 20), the DISABLE option is deprecated.
+     * A valid request carrying the deprecated value must be rejected with SERVICES /
+     * SERVICE_REQUEST_DENIED, and the receiver's communication state must not change.
      */
     @Test
-    public void disable() throws Exception {
-        // Disable
-        d2.send(rd1, new DeviceCommunicationControlRequest(null, EnableDisable.disable, null)).get();
+    public void disable_deprecatedValueRejected() throws Exception {
+        assertEquals(EnableDisable.enable, d1.getCommunicationControlState());
 
-        // Fail to send a request.
-        try {
-            d1.send(rd2,
-                    new WritePropertyRequest(new ObjectIdentifier(ObjectType.device, 2), PropertyIdentifier.description,
-                            null, new CharacterString("a"), null)).get();
-            fail("BACnetException should have been thrown");
-        } catch (final BACnetException e) {
-            // Inner exception must be a BACCommunicationDisabledException
-            if (!(e.getCause() instanceof CommunicationDisabledException)) {
-                fail("CommunicationDisabledException should have been thrown");
-            }
-        }
-
-        // Fail to receive a request
-        try {
-            final ServiceFuture future = d2.send(rd1,
-                    new WritePropertyRequest(new ObjectIdentifier(ObjectType.device, 1), PropertyIdentifier.description,
-                            null, new CharacterString("a"), null));
-
-            // We need to advance the clock because otherwise the request will never time out.
-            // First give the transport a chance to send the request.
-            awaitTrue(() -> future.getState() == ServiceFuture.State.SENT);
-            // Then advance past the timeout.
-            clock.plusMillis(TIMEOUT + 1);
-
-            future.get();
-            fail("BACnetTimeoutException should have been thrown");
-        } catch (@SuppressWarnings("unused") final BACnetTimeoutException e) {
-            // Expected
-        }
-
-        // Start backup "works" by returning a communication disabled error.
         TestUtils.assertErrorAPDUException(() -> {
-            d2.send(rd1, new ReinitializeDeviceRequest(ReinitializedStateOfDevice.startBackup, null)).get();
-        }, ErrorClass.services, ErrorCode.communicationDisabled);
+            d2.send(rd1, new DeviceCommunicationControlRequest(null, EnableDisable.disable, null)).get();
+        }, ErrorClass.services, ErrorCode.serviceRequestDenied);
 
-        // Reinitialize "works", or at least doesn't return an error after the proper method is overridden.
-        d1.setReinitializeDeviceHandler(new DefaultReinitializeDeviceHandler() {
-            @Override
-            protected void activateChanges(final LocalDevice localDevice, final Address from)
-                    throws BACnetErrorException {
-                // no op
-            }
-        });
-        d2.send(rd1, new ReinitializeDeviceRequest(ReinitializedStateOfDevice.activateChanges, null)).get();
+        // State must not have changed.
+        assertEquals(EnableDisable.enable, d1.getCommunicationControlState());
 
-        // Re-enable
-        d2.send(rd1, new DeviceCommunicationControlRequest(null, EnableDisable.enable, null)).get();
-
-        // Send a request. This time it succeeds.
-        assertNull(d2.get(PropertyIdentifier.description));
+        // Regular traffic still works — d1 can send, and d1 can receive.
         d1.send(rd2,
                 new WritePropertyRequest(new ObjectIdentifier(ObjectType.device, 2), PropertyIdentifier.description,
                         null, new CharacterString("a"), null)).get();
         assertEquals(new CharacterString("a"), d2.get(PropertyIdentifier.description));
 
-        // Receive a request. This time it too succeeds. Note that the value is already "a", because requests are
-        // still processed, just not responded.
-        assertEquals(new CharacterString("a"), d1.get(PropertyIdentifier.description));
         d2.send(rd1,
                 new WritePropertyRequest(new ObjectIdentifier(ObjectType.device, 1), PropertyIdentifier.description,
                         null, new CharacterString("b"), null)).get();
@@ -219,114 +172,160 @@ public class DeviceCommunicationControlRequestTest extends AbstractTest {
     }
 
     /**
-     * Ensure that the timer works.
+     * Per addendum 135-2016bi-2: LocalDevice.setCommunicationControl(disable, ...) must reject
+     * the deprecated value. This is a defence-in-depth check for callers that bypass the
+     * service handler.
+     */
+    @Test
+    public void disable_setCommunicationControlThrows() {
+        try {
+            d1.setCommunicationControl(EnableDisable.disable, 0);
+            fail("IllegalArgumentException should have been thrown");
+        } catch (@SuppressWarnings("unused") IllegalArgumentException expected) {
+            // Expected.
+        }
+    }
+
+    /**
+     * Under DISABLE_INITIATION, incoming ReinitializeDevice(startBackup) is not treated
+     * specially by the DCC layer — it proceeds through the normal handler path. Prior to
+     * bi-2, the service handler returned COMMUNICATION_DISABLED for backup states when the
+     * device was in DISABLE. That code path is removed because DISABLE is deprecated and
+     * COMMUNICATION_DISABLED is no longer intended as a service-response error code.
+     */
+    @Test
+    public void disableInitiation_reinitializeStartBackupProceedsToHandler() throws Exception {
+        AtomicBoolean called = new AtomicBoolean(false);
+        d1.setReinitializeDeviceHandler(new DefaultReinitializeDeviceHandler() {
+            @Override
+            protected void startBackup(LocalDevice localDevice, Address from) {
+                called.set(true);
+            }
+        });
+
+        d2.send(rd1, new DeviceCommunicationControlRequest(null, EnableDisable.disableInitiation, null)).get();
+        d2.send(rd1, new ReinitializeDeviceRequest(ReinitializedStateOfDevice.startBackup, null)).get();
+
+        assertTrue(called.get());
+    }
+
+    /**
+     * Ensure that the timer works. Under DISABLE_INITIATION, d1 cannot initiate BACnet
+     * services for the duration; incoming requests are still responded to normally. When
+     * the timer expires, d1 returns to ENABLE and can initiate again.
      */
     @Test
     public void timer() throws Exception {
-        // Disable for 5 minutes.
-        d2.send(rd1, new DeviceCommunicationControlRequest(new UnsignedInteger(5), EnableDisable.disable, null)).get();
-        awaitEquals(EnableDisable.disable, d1::getCommunicationControlState);
+        // Disable-initiation on d1 for 5 minutes.
+        d2.send(rd1, new DeviceCommunicationControlRequest(
+                new UnsignedInteger(5), EnableDisable.disableInitiation, null)).get();
+        awaitEquals(EnableDisable.disableInitiation, d1::getCommunicationControlState);
 
-        // Fail to receive a request
+        // d1 cannot initiate a request during the disable window.
         try {
-            final ServiceFuture future = d2.send(rd1,
-                    new WritePropertyRequest(new ObjectIdentifier(ObjectType.device, 1), PropertyIdentifier.description,
-                            null, new CharacterString("a"), null));
-
-            // We need to advance the clock because otherwise the request will never time out.
-            // First give the transport a chance to send the request.
-            awaitTrue(() -> future.getState() == ServiceFuture.State.SENT);
-
-            // Then advance past the timeout.
-            clock.plusMillis(TIMEOUT + 1);
-
-            future.get();
-            fail("BACnetTimeoutException should have been thrown");
-        } catch (@SuppressWarnings("unused") final BACnetTimeoutException e) {
-            // Expected
+            d1.send(rd2, new WritePropertyRequest(
+                    new ObjectIdentifier(ObjectType.device, 2), PropertyIdentifier.description, null,
+                    new CharacterString("a"), null)).get();
+            fail("BACnetException should have been thrown");
+        } catch (BACnetException e) {
+            if (!(e.getCause() instanceof CommunicationDisabledException)) {
+                fail("CommunicationDisabledException should have been thrown");
+            }
         }
+
+        // But d1 still responds to incoming requests.
+        d2.send(rd1, new WritePropertyRequest(
+                new ObjectIdentifier(ObjectType.device, 1), PropertyIdentifier.description, null,
+                new CharacterString("a"), null)).get();
+        assertEquals(new CharacterString("a"), d1.get(PropertyIdentifier.description));
 
         // Let the 5 minutes elapse.
         clock.plusMinutes(6);
         awaitEquals(EnableDisable.enable, d1::getCommunicationControlState);
 
-        // Receive a request. This time it too succeeds. Note that the value is already "a", because requests are
-        // still processed, just not responded.
-        assertEquals(new CharacterString("a"), d1.get(PropertyIdentifier.description));
-        d2.send(rd1,
-                new WritePropertyRequest(new ObjectIdentifier(ObjectType.device, 1), PropertyIdentifier.description,
-                        null, new CharacterString("b"), null)).get();
-        assertEquals(new CharacterString("b"), d1.get(PropertyIdentifier.description));
+        // d1 can initiate again.
+        assertNull(d2.get(PropertyIdentifier.description));
+        d1.send(rd2, new WritePropertyRequest(
+                new ObjectIdentifier(ObjectType.device, 2), PropertyIdentifier.description, null,
+                new CharacterString("b"), null)).get();
+        assertEquals(new CharacterString("b"), d2.get(PropertyIdentifier.description));
     }
 
     /**
-     * Ensure that the timer gets cancelled.
+     * Ensure that an explicit re-enable cancels the pending timer, so no spurious re-enable
+     * fires later when the timer would have expired.
      */
     @Test
     public void timerCancel() throws Exception {
-        // Disable for 5 minutes.
-        d2.send(rd1, new DeviceCommunicationControlRequest(new UnsignedInteger(5), EnableDisable.disable, null)).get();
+        // Disable-initiation on d1 for 5 minutes.
+        d2.send(rd1, new DeviceCommunicationControlRequest(
+                new UnsignedInteger(5), EnableDisable.disableInitiation, null)).get();
+        awaitEquals(EnableDisable.disableInitiation, d1::getCommunicationControlState);
 
-        // Fail to receive a request
+        // Confirm d1 cannot initiate during the disable window.
         try {
-            final ServiceFuture future = d2.send(rd1,
-                    new WritePropertyRequest(new ObjectIdentifier(ObjectType.device, 1), PropertyIdentifier.description,
-                            null, new CharacterString("a"), null));
-
-            // We need to advance the clock because otherwise the request will never time out.
-            // First give the transport a chance to send the request.
-            awaitTrue(() -> future.getState() == ServiceFuture.State.SENT);
-            // Then advance past the timeout.
-            clock.plusMillis(TIMEOUT + 1);
-
-            future.get();
-            fail("BACnetTimeoutException should have been thrown");
-        } catch (@SuppressWarnings("unused") final BACnetTimeoutException e) {
-            // Expected
+            d1.send(rd2, new WritePropertyRequest(
+                    new ObjectIdentifier(ObjectType.device, 2), PropertyIdentifier.description, null,
+                    new CharacterString("a"), null)).get();
+            fail("BACnetException should have been thrown");
+        } catch (BACnetException e) {
+            if (!(e.getCause() instanceof CommunicationDisabledException)) {
+                fail("CommunicationDisabledException should have been thrown");
+            }
         }
 
         // Let 1 minute go by.
         clock.plusMinutes(1);
 
-        // Re-enable. Yes, the timeout is still there, which shouldn't matter.
+        // Re-enable explicitly. The 5-minute timer should be cancelled so it can't fire later.
         d2.send(rd1, new DeviceCommunicationControlRequest(new UnsignedInteger(5), EnableDisable.enable, null)).get();
+        awaitEquals(EnableDisable.enable, d1::getCommunicationControlState);
 
-        // Receive a request. This time it too succeeds. Note that the value is already "a", because requests are
-        // still processed, just not responded.
-        assertEquals(new CharacterString("a"), d1.get(PropertyIdentifier.description));
-        d2.send(rd1,
-                new WritePropertyRequest(new ObjectIdentifier(ObjectType.device, 1), PropertyIdentifier.description,
-                        null, new CharacterString("b"), null)).get();
-        assertEquals(new CharacterString("b"), d1.get(PropertyIdentifier.description));
+        // d1 can initiate now.
+        assertNull(d2.get(PropertyIdentifier.description));
+        d1.send(rd2, new WritePropertyRequest(
+                new ObjectIdentifier(ObjectType.device, 2), PropertyIdentifier.description, null,
+                new CharacterString("b"), null)).get();
+        assertEquals(new CharacterString("b"), d2.get(PropertyIdentifier.description));
     }
 
     /**
-     * Ensure that the password functionality works.
+     * Ensure that the password functionality works. Password validation must precede the
+     * bi-2 deprecated-value check, so a null or wrong password on a request carrying the
+     * deprecated DISABLE value still surfaces PASSWORD_FAILURE — not SERVICE_REQUEST_DENIED.
+     * A request with the correct password and the current DISABLE_INITIATION value succeeds.
      */
     @Test
     public void password() throws BACnetException {
         d1.withPassword("asdf");
 
-        // Try to disable with null
+        // Null password against a request that would otherwise be deprecated-value-rejected:
+        // password failure takes precedence.
         try {
             d2.send(rd1, new DeviceCommunicationControlRequest(null, EnableDisable.disable, null)).get();
             fail("ErrorAPDUException should have been thrown");
-        } catch (final ErrorAPDUException e) {
+        } catch (ErrorAPDUException e) {
             TestUtils.assertErrorClassAndCode(e.getError(), ErrorClass.security, ErrorCode.passwordFailure);
         }
 
-        // Try to disable with incorrect password
+        // Wrong password: also PASSWORD_FAILURE, not SERVICE_REQUEST_DENIED.
         try {
-            d2.send(rd1,
-                            new DeviceCommunicationControlRequest(null, EnableDisable.disable, new CharacterString("qwer")))
-                    .get();
+            d2.send(rd1, new DeviceCommunicationControlRequest(
+                    null, EnableDisable.disable, new CharacterString("qwer"))).get();
             fail("ErrorAPDUException should have been thrown");
-        } catch (final ErrorAPDUException e) {
+        } catch (ErrorAPDUException e) {
             TestUtils.assertErrorClassAndCode(e.getError(), ErrorClass.security, ErrorCode.passwordFailure);
         }
 
-        // Try to disable with correct password
-        d2.send(rd1, new DeviceCommunicationControlRequest(null, EnableDisable.disable, new CharacterString("asdf")))
-                .get();
+        // Correct password + deprecated DISABLE value: the deprecated-value check fires
+        // after the password check, so this now surfaces SERVICE_REQUEST_DENIED.
+        TestUtils.assertErrorAPDUException(() -> {
+            d2.send(rd1, new DeviceCommunicationControlRequest(
+                    null, EnableDisable.disable, new CharacterString("asdf"))).get();
+        }, ErrorClass.services, ErrorCode.serviceRequestDenied);
+
+        // Correct password + valid DISABLE_INITIATION value: request succeeds.
+        d2.send(rd1, new DeviceCommunicationControlRequest(
+                null, EnableDisable.disableInitiation, new CharacterString("asdf"))).get();
     }
 }


### PR DESCRIPTION
https://radixiot.atlassian.net/browse/MANGO-2950

Included cleanup of "final" in method parameters and local variables.

 Implements the changes required by addendum bi-2 (Protocol Revision 20).

#  Behavior changes:
  - DISABLE is now rejected with ErrorClass.services / ErrorCode.serviceRequestDenied. DISABLE_INITIATION is the only supported non-enable state.
  - Under DISABLE_INITIATION, the device stops initiating messages but responds to incoming requests normally.
  - Removed the COMMUNICATION_DISABLED service-response error from ReinitializeDeviceRequest — that code is reserved for internal use per bi-2.
  - timeDuration field tightened from UnsignedInteger to Unsigned16 per the spec's ASN.1 production.

 # Breaking:
  - Callers passing EnableDisable.disable to LocalDevice.setCommunicationControl(...) will now get IllegalArgumentException. Use disableInitiation instead.
  - DeviceCommunicationControlRequest constructor takes Unsigned16 instead of UnsignedInteger. Wire format unchanged.

 Not in scope: audit-notification exemption from the initiation ban — audit services are not implemented in BACnet4J.