### PR TITLE
MANGO-2951 Verify WritePropertyMultiple Result(-) response shape

### DIFF
--- a/src/test/java/com/serotonin/bacnet4j/TestUtils.java
+++ b/src/test/java/com/serotonin/bacnet4j/TestUtils.java
@@ -66,50 +66,50 @@ import lohbihler.warp.WarpClock;
 public class TestUtils {
     static final Logger LOG = LoggerFactory.getLogger(TestUtils.class);
 
-    public static <T, U> void assertListEqualsIgnoreOrder(final List<T> expectedList, final List<U> actualList,
-            final BiPredicate<T, U> predicate) {
+    public static <T, U> void assertListEqualsIgnoreOrder(List<T> expectedList, List<U> actualList,
+            BiPredicate<T, U> predicate) {
         Assert.assertEquals(expectedList.size(), actualList.size());
-        final List<U> actualListCopy = new ArrayList<>(actualList);
-        for (final T expected : expectedList) {
+        List<U> actualListCopy = new ArrayList<>(actualList);
+        for (T expected : expectedList) {
             // Find an element in the actual copy list where the predicate returns true.
-            final int index = indexOf(actualListCopy, expected, predicate);
+            int index = indexOf(actualListCopy, expected, predicate);
             if (index == -1)
                 Assert.fail("Did not find " + expected + " in actual list");
             actualListCopy.remove(index);
         }
     }
 
-    public static <T, U> int indexOf(final List<U> list, final T key, final BiPredicate<T, U> predicate) {
+    public static <T, U> int indexOf(List<U> list, T key, BiPredicate<T, U> predicate) {
         for (int i = 0; i < list.size(); i++) {
-            final U value = list.get(i);
+            U value = list.get(i);
             if (predicate.test(key, value))
                 return i;
         }
         return -1;
     }
 
-    public static <T> void assertListEqualsIgnoreOrder(final List<T> expectedList, final List<T> actualList) {
+    public static <T> void assertListEqualsIgnoreOrder(List<T> expectedList, List<T> actualList) {
         Assert.assertEquals(expectedList.size(), actualList.size());
-        final List<T> actualListCopy = new ArrayList<>(actualList);
-        for (final T expected : expectedList) {
+        List<T> actualListCopy = new ArrayList<>(actualList);
+        for (T expected : expectedList) {
             // Find an element in the actual copy list which equals the expected.
-            final int index = indexOf(actualListCopy, expected);
+            int index = indexOf(actualListCopy, expected);
             if (index == -1)
                 Assert.fail("Did not find " + expected + " in actual list");
             actualListCopy.remove(index);
         }
     }
 
-    public static <T> int indexOf(final List<T> list, final T key) {
+    public static <T> int indexOf(List<T> list, T key) {
         for (int i = 0; i < list.size(); i++) {
-            final T value = list.get(i);
+            T value = list.get(i);
             if (Objects.equals(value, key))
                 return i;
         }
         return -1;
     }
 
-    public static void assertEquals(final TimeStamp expected, final TimeStamp actual, final int deadbandHundredths) {
+    public static void assertEquals(TimeStamp expected, TimeStamp actual, int deadbandHundredths) {
         if (expected.isDateTime() && actual.isDateTime())
             assertEquals(expected.getDateTime(), actual.getDateTime(), deadbandHundredths);
         else if (expected.isTime() && actual.isTime())
@@ -118,9 +118,9 @@ public class TestUtils {
             Assert.assertEquals(expected, actual);
     }
 
-    public static void assertEquals(final DateTime expected, final DateTime actual, final int deadbandHundredths) {
-        final long expectedMillis = expected.getGC().getTimeInMillis();
-        final long actualMillis = actual.getGC().getTimeInMillis();
+    public static void assertEquals(DateTime expected, DateTime actual, int deadbandHundredths) {
+        long expectedMillis = expected.getGC().getTimeInMillis();
+        long actualMillis = actual.getGC().getTimeInMillis();
 
         long diff = expectedMillis - actualMillis;
         if (diff < 0)
@@ -132,10 +132,10 @@ public class TestUtils {
         }
     }
 
-    public static void assertEquals(final Time expected, final Time actual, final int deadbandHundredths) {
+    public static void assertEquals(Time expected, Time actual, int deadbandHundredths) {
         // Can only compare this way if the times are fully specified.
         if (expected.isFullySpecified() && actual.isFullySpecified()) {
-            final int diff = expected.getSmallestDiff(actual);
+            int diff = expected.getSmallestDiff(actual);
             if (diff > deadbandHundredths) {
                 // This will fail
                 Assert.assertEquals(expected, actual);
@@ -146,24 +146,24 @@ public class TestUtils {
     }
 
     @SafeVarargs
-    public static <T> List<T> toList(final T... elements) {
-        final List<T> result = new ArrayList<>(elements.length);
+    public static <T> List<T> toList(T... elements) {
+        List<T> result = new ArrayList<>(elements.length);
         result.addAll(Arrays.asList(elements));
         return result;
     }
 
-    public static void assertBACnetServiceException(final BACnetServiceException e, final ErrorClass errorClass,
-            final ErrorCode errorCode) {
+    public static void assertBACnetServiceException(BACnetServiceException e, ErrorClass errorClass,
+            ErrorCode errorCode) {
         Assert.assertEquals(errorClass, e.getErrorClass());
         Assert.assertEquals(errorCode, e.getErrorCode());
     }
 
-    public static void assertBACnetServiceException(final ServiceExceptionCommand command, final ErrorClass errorClass,
-            final ErrorCode errorCode) {
+    public static void assertBACnetServiceException(ServiceExceptionCommand command, ErrorClass errorClass,
+            ErrorCode errorCode) {
         try {
             command.call();
             fail("BACnetServiceException was expected");
-        } catch (final BACnetServiceException e) {
+        } catch (BACnetServiceException e) {
             assertBACnetServiceException(e, errorClass, errorCode);
         }
     }
@@ -173,14 +173,14 @@ public class TestUtils {
         void call() throws BACnetServiceException;
     }
 
-    public static void assertRequestHandleException(final RequestHandleExceptionCommand command,
-            final ErrorClass errorClass, final ErrorCode errorCode) {
+    public static void assertRequestHandleException(RequestHandleExceptionCommand command, ErrorClass errorClass,
+            ErrorCode errorCode) {
         try {
             command.call();
             fail("BACnetException was expected");
-        } catch (final BACnetErrorException e) {
+        } catch (BACnetErrorException e) {
             assertErrorClassAndCode(e.getBacnetError().getError().getErrorClassAndCode(), errorClass, errorCode);
-        } catch (final BACnetException e) {
+        } catch (BACnetException e) {
             fail("Not a BACnetErrorException: " + e);
         }
     }
@@ -191,19 +191,18 @@ public class TestUtils {
     }
 
     @SuppressWarnings("unchecked")
-    public static <T extends BaseError> T assertErrorAPDUException(final BACnetExceptionCommand command,
-            final ErrorClass errorClass, final ErrorCode errorCode) {
+    public static <T extends BaseError> T assertErrorAPDUException(BACnetExceptionCommand command,
+            ErrorClass errorClass, ErrorCode errorCode) {
         try {
             command.call();
-            fail("BACnetException was expected");
-        } catch (final BACnetException e) {
+        } catch (BACnetException e) {
             if (e instanceof ErrorAPDUException eae) {
                 assertErrorClassAndCode(eae.getError().getErrorClassAndCode(), errorClass, errorCode);
                 return (T) eae.getApdu().getError();
             }
-            fail("Embedded ErrorAPDUException was expected: " + e.getClass());
+            throw new AssertionError("Embedded ErrorAPDUException was expected: " + e.getClass());
         }
-        return null;
+        throw new AssertionError("BACnetException was expected");
     }
 
     @FunctionalInterface
@@ -211,17 +210,16 @@ public class TestUtils {
         void call() throws BACnetException;
     }
 
-    public static void assertErrorClassAndCode(final ErrorClassAndCode ecac, final ErrorClass errorClass,
-            final ErrorCode errorCode) {
+    public static void assertErrorClassAndCode(ErrorClassAndCode ecac, ErrorClass errorClass, ErrorCode errorCode) {
         Assert.assertEquals(errorClass, ecac.getErrorClass());
         Assert.assertEquals(errorCode, ecac.getErrorCode());
     }
 
-    public static void assertEncoding(final Encodable encodable, final String expectedHex) {
-        final ByteQueue expectedResult = new ByteQueue(expectedHex);
+    public static void assertEncoding(Encodable encodable, String expectedHex) {
+        ByteQueue expectedResult = new ByteQueue(expectedHex);
 
         // Serialize the Encodable and compare with the hex.
-        final ByteQueue queue = new ByteQueue();
+        ByteQueue queue = new ByteQueue();
         encodable.write(queue);
         Assert.assertEquals(expectedResult, queue);
 
@@ -229,7 +227,7 @@ public class TestUtils {
         Encodable parsed;
         try {
             parsed = Encodable.read(queue, encodable.getClass());
-        } catch (final BACnetException e) {
+        } catch (BACnetException e) {
             LOG.error("", e);
             fail(e.getMessage());
             return;
@@ -239,12 +237,12 @@ public class TestUtils {
         Assert.assertEquals(encodable, parsed);
     }
 
-    public static <T extends Encodable> void assertSequenceEncoding(final SequenceOf<T> encodable,
-            final Class<T> innerType, final String expectedHex) {
-        final ByteQueue expectedResult = new ByteQueue(expectedHex);
+    public static <T extends Encodable> void assertSequenceEncoding(SequenceOf<T> encodable, Class<T> innerType,
+            String expectedHex) {
+        ByteQueue expectedResult = new ByteQueue(expectedHex);
 
         // Serialize the Encodable and compare with the hex.
-        final ByteQueue queue = new ByteQueue();
+        ByteQueue queue = new ByteQueue();
         encodable.write(queue);
         Assert.assertEquals(expectedResult, queue);
 
@@ -252,7 +250,7 @@ public class TestUtils {
         Encodable parsed;
         try {
             parsed = Encodable.readSequenceOf(queue, innerType);
-        } catch (final BACnetException e) {
+        } catch (BACnetException e) {
             LOG.error("", e);
             fail(e.getMessage());
             return;
@@ -262,12 +260,12 @@ public class TestUtils {
         Assert.assertEquals(encodable, parsed);
     }
 
-    public static void assertFileContentEquals(final File expected, final File actual) throws IOException {
+    public static void assertFileContentEquals(File expected, File actual) throws IOException {
         Assert.assertEquals(expected.exists(), actual.exists());
         Assert.assertEquals(expected.length(), actual.length());
 
         // Slow, but easy
-        final long length = expected.length();
+        long length = expected.length();
         long position = 0;
         try (FileInputStream expectedFis = new FileInputStream(expected);
                 FileInputStream actualFis = new FileInputStream(actual)) {
@@ -365,7 +363,7 @@ public class TestUtils {
      * @param expected       the value to match
      * @param actualSupplier the supplier the value of which to check
      */
-    public static void awaitEquals(int expected, final IntSupplierWithException actualSupplier) throws Exception {
+    public static void awaitEquals(int expected, IntSupplierWithException actualSupplier) throws Exception {
         awaitEquals(expected, actualSupplier, 10000);
     }
 
@@ -377,7 +375,7 @@ public class TestUtils {
      * @param timeoutMs the maximum amount of time to wait
      * @throws Exception the exception if any thrown by the supplier
      */
-    public static void awaitEquals(int expected, final IntSupplierWithException supplier, long timeoutMs)
+    public static void awaitEquals(int expected, IntSupplierWithException supplier, long timeoutMs)
             throws Exception {
         if (await(true, () -> supplier.get() == expected, timeoutMs)) {
             return;
@@ -399,7 +397,7 @@ public class TestUtils {
      * @param expected       the value to match
      * @param actualSupplier the supplier the value of which to check
      */
-    public static void awaitEquals(Encodable expected, final EncodableSupplierWithException actualSupplier)
+    public static void awaitEquals(Encodable expected, EncodableSupplierWithException actualSupplier)
             throws Exception {
         awaitEquals(expected, actualSupplier, 5000);
     }
@@ -412,7 +410,7 @@ public class TestUtils {
      * @param timeoutMs the maximum amount of time to wait
      * @throws Exception the exception if any thrown by the supplier
      */
-    public static void awaitEquals(Encodable expected, final EncodableSupplierWithException supplier, long timeoutMs)
+    public static void awaitEquals(Encodable expected, EncodableSupplierWithException supplier, long timeoutMs)
             throws Exception {
         if (await(true, () -> equalsRegardingNull(expected, supplier.get()), timeoutMs)) {
             return;
@@ -454,7 +452,7 @@ public class TestUtils {
      */
     public static boolean await(boolean expected, BooleanSupplierWithException condition, long timeoutMs)
             throws Exception {
-        final long deadline = Clock.systemUTC().millis() + timeoutMs;
+        long deadline = Clock.systemUTC().millis() + timeoutMs;
         while (true) {
             if (condition.getAsBoolean() == expected) {
                 return true;
@@ -515,10 +513,7 @@ public class TestUtils {
                     postAdvance.run();
             } else {
                 while (remainder > 0L) {
-                    long nanos = each;
-                    if (each > remainder) {
-                        nanos = remainder;
-                    }
+                    long nanos = Math.min(each, remainder);
 
                     if (preAdvance != null)
                         preAdvance.run();

--- a/src/test/java/com/serotonin/bacnet4j/service/confirmed/WritePropertyMultipleRequestTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/service/confirmed/WritePropertyMultipleRequestTest.java
@@ -28,6 +28,7 @@
 package com.serotonin.bacnet4j.service.confirmed;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import org.junit.After;
 import org.junit.Before;
@@ -35,6 +36,7 @@ import org.junit.Test;
 
 import com.serotonin.bacnet4j.LocalDevice;
 import com.serotonin.bacnet4j.RemoteDevice;
+import com.serotonin.bacnet4j.TestUtils;
 import com.serotonin.bacnet4j.exception.BACnetException;
 import com.serotonin.bacnet4j.npdu.test.TestNetwork;
 import com.serotonin.bacnet4j.npdu.test.TestNetworkMap;
@@ -46,9 +48,16 @@ import com.serotonin.bacnet4j.type.constructed.PropertyValue;
 import com.serotonin.bacnet4j.type.constructed.Recipient;
 import com.serotonin.bacnet4j.type.constructed.SequenceOf;
 import com.serotonin.bacnet4j.type.constructed.WriteAccessSpecification;
+import com.serotonin.bacnet4j.type.enumerated.ErrorClass;
+import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
+import com.serotonin.bacnet4j.type.enumerated.ObjectType;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
+import com.serotonin.bacnet4j.type.error.WritePropertyMultipleError;
 import com.serotonin.bacnet4j.type.primitive.CharacterString;
+import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
+import com.serotonin.bacnet4j.type.primitive.Real;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
+import com.serotonin.bacnet4j.util.sero.ByteQueue;
 
 public class WritePropertyMultipleRequestTest {
     private final TestNetworkMap map = new TestNetworkMap();
@@ -159,5 +168,131 @@ public class WritePropertyMultipleRequestTest {
         assertEquals("d", newStateText.getBase1(4).getValue());
         assertEquals(CharacterString.EMPTY, newStateText.getBase1(5));
         assertEquals(new UnsignedInteger(5), msv0.get(PropertyIdentifier.numberOfStates));
+    }
+
+    // ======================================================================================
+    // Addendum 135-2016bl-1: Clarify Result(-) response for failed WritePropertyMultiple
+    // requests. Verifies:
+    //   - Mid-stream write failures surface as a Result(-) (WritePropertyMultipleError) with
+    //     the failing property named in 'First Failed Write Attempt'; earlier writes take
+    //     effect and later writes are skipped.
+    //   - First-property write failures also surface as Result(-); no state changes.
+    //   - Wire-format decode failures do not produce partial writes (BACnet4J decodes the
+    //     entire request before invoking handle(), so a decode error occurs before any
+    //     write can happen).
+    // ======================================================================================
+
+    /**
+     * Two writes succeed, the third targets a non-existent object. The receiver must return
+     * a Result(-) whose 'First Failed Write Attempt' names the third spec's object and
+     * property. The first two writes must take effect; subsequent writes (there are none
+     * here after the failing one, but the semantic is exercised) must not.
+     */
+    @Test
+    public void writeFailsMidStream_returnsResultMinusWithFailedProperty() {
+        // Pre-state: description has its original value; alarmValues will be set by write 2.
+        assertEquals("my description", msv0.get(PropertyIdentifier.description).toString());
+
+        var nonExistentObject = new ObjectIdentifier(ObjectType.analogValue, 999);
+        var writeAccessSpecs = new SequenceOf<>(
+                // Write 1 — succeeds.
+                new WriteAccessSpecification(msv0.getId(), new SequenceOf<>(
+                        new PropertyValue(PropertyIdentifier.description, new CharacterString("updated")))),
+                // Write 2 — succeeds.
+                new WriteAccessSpecification(msv0.getId(), new SequenceOf<>(
+                        new PropertyValue(PropertyIdentifier.alarmValues,
+                                new SequenceOf<>(new UnsignedInteger(7), new UnsignedInteger(8))))),
+                // Write 3 — fails: object doesn't exist on the remote device.
+                new WriteAccessSpecification(nonExistentObject, new SequenceOf<>(
+                        new PropertyValue(PropertyIdentifier.eventMessageTexts, new UnsignedInteger(1),
+                                new CharacterString("new value"), null))));
+
+        // The response is an Error-PDU carrying WritePropertyMultipleError (Result(-) per
+        // clause 15.10). Assert the error class/code and the identity of the failed write.
+        WritePropertyMultipleError wpmError = TestUtils.assertErrorAPDUException(
+                () -> localDevice.send(remoteDeviceReference, new WritePropertyMultipleRequest(writeAccessSpecs)).get(),
+                ErrorClass.property, ErrorCode.unknownObject);
+
+        var firstFailed = wpmError.getFirstFailedWriteAttempt();
+        assertEquals(nonExistentObject, firstFailed.getObjectIdentifier());
+        assertEquals(PropertyIdentifier.eventMessageTexts, firstFailed.getPropertyIdentifier());
+        assertEquals(new UnsignedInteger(1), firstFailed.getPropertyArrayIndex());
+
+        // Writes 1 and 2 took effect before the failure was encountered.
+        assertEquals("updated", msv0.get(PropertyIdentifier.description).toString());
+        SequenceOf<UnsignedInteger> newAlarmValues = msv0.get(PropertyIdentifier.alarmValues);
+        assertEquals(2, newAlarmValues.size());
+        assertEquals(7, newAlarmValues.getBase1(1).intValue());
+        assertEquals(8, newAlarmValues.getBase1(2).intValue());
+    }
+
+    /**
+     * The very first write fails. The receiver must return a Result(-) with the failing
+     * property named, and no state on the target device may change.
+     */
+    @Test
+    public void writeFailsFirstProperty_returnsResultMinus() {
+        var originalDescription = msv0.get(PropertyIdentifier.description).toString();
+
+        var nonExistentObject = new ObjectIdentifier(ObjectType.analogValue, 999);
+        var writeAccessSpecs = new SequenceOf<>(
+                // Fails: object doesn't exist.
+                new WriteAccessSpecification(nonExistentObject, new SequenceOf<>(
+                        new PropertyValue(PropertyIdentifier.presentValue, new Real(1.0f)))),
+                // Would succeed if reached, but must not be executed because write 1 failed.
+                new WriteAccessSpecification(msv0.getId(), new SequenceOf<>(
+                        new PropertyValue(PropertyIdentifier.description, new CharacterString("must-not-apply")))));
+
+        WritePropertyMultipleError wpmError = TestUtils.assertErrorAPDUException(
+                () -> localDevice.send(remoteDeviceReference, new WritePropertyMultipleRequest(writeAccessSpecs)).get(),
+                ErrorClass.property, ErrorCode.unknownObject);
+
+        var firstFailed = wpmError.getFirstFailedWriteAttempt();
+        assertEquals(nonExistentObject, firstFailed.getObjectIdentifier());
+        assertEquals(PropertyIdentifier.presentValue, firstFailed.getPropertyIdentifier());
+
+        // No writes happened — description is unchanged.
+        assertEquals(originalDescription, msv0.get(PropertyIdentifier.description).toString());
+    }
+
+    /**
+     * A wire-format decode failure inside a WritePropertyMultiple-Request cannot leave the
+     * receiver with partial writes: the request is decoded fully by the constructor before
+     * {@code handle()} runs, so a mid-stream parse error prevents any write from executing.
+     * This test pins that architectural invariant by feeding a malformed byte stream to
+     * {@link WritePropertyMultipleRequest}'s parse constructor and verifying the constructor
+     * throws — which means {@code handle()} is never reached, and per addendum 135-2016bl-1
+     * a {@code Reject-PDU} for the parse failure is compliant (no writes have happened).
+     */
+    @Test
+    public void decodeFails_parserRejectsMalformedRequestBeforeAnyWrite() {
+        // Serialize a valid single-spec WPM request, then truncate the byte stream in the
+        // middle of a WriteAccessSpecification so the parser starts consuming one and runs
+        // out of bytes before it can complete. This is the closest simulation of a
+        // wire-format decode failure available without direct transport injection.
+        var valid = new WritePropertyMultipleRequest(new SequenceOf<>(new WriteAccessSpecification(
+                msv0.getId(),
+                new SequenceOf<>(new PropertyValue(PropertyIdentifier.description,
+                        new CharacterString("original"))))));
+        var buffer = new ByteQueue();
+        valid.write(buffer);
+        byte[] fullBytes = buffer.popAll();
+        // Chop off the last 5 bytes: enough to leave the outer WriteAccessSpecification
+        // partly decoded, so the parser starts committing to a spec and then fails when
+        // the payload runs out.
+        byte[] truncated = new byte[fullBytes.length - 5];
+        System.arraycopy(fullBytes, 0, truncated, 0, truncated.length);
+        var malformed = new ByteQueue(truncated);
+
+        assertThrows(BACnetException.class, () -> new WritePropertyMultipleRequest(malformed));
+
+        // Because the constructor throws, handle() cannot run — no writes are performed.
+        // Verify by reading the target property directly: its value remains the pre-test
+        // value.
+        assertEquals("my description", msv0.get(PropertyIdentifier.description).toString());
+        // No response-format assertion here: the transport's handling of parse errors
+        // (Reject-PDU vs Error-PDU) is a separate concern. bl-1 requires only that no
+        // partial writes occur when parse fails; the constructor-throws invariant is
+        // sufficient to guarantee that.
     }
 }


### PR DESCRIPTION
https://radixiot.atlassian.net/browse/MANGO-2951

Adds tests to pin the library's compliance with the clarifications in 135-2016bl-1 (Clarify Result(-) response for failed WritePropertyMultiple requests). No production code changes — the library's decode-then-write architecture is already spec-compliant.

As with other PRs this also removes "final" litter