### PR TITLE
MANGO-2952 Verify ReadPropertyMultiple handling of OPTIONAL-when-empty

### DIFF
--- a/src/test/java/com/serotonin/bacnet4j/AnnexFEncodingTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/AnnexFEncodingTest.java
@@ -510,7 +510,7 @@ public class AnnexFEncodingTest {
         ConfirmedRequest pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED,
                 MaxApduLength.UP_TO_206, (byte) 15, (byte) 0, 0, req);
 
-        compare(pdu, "00020f1e09121901293c39054e0c0000000a1e0e09550f1c3f80000029010e09670f29001f0c004000081e0e" + ""
+        compare(pdu, "00020f1e09121901293c39054e0c0000000a1e0e09550f1c3f80000029010e09670f29001f0c004000081e0e"
                 + "09550f1c3f80000029011f4f");
     }
 
@@ -536,14 +536,12 @@ public class AnnexFEncodingTest {
         ConfirmedRequest pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED,
                 MaxApduLength.UP_TO_206, (byte) 15, (byte) 0, 0, req);
 
-        // TODO
         // There are multiple differences with the spec here.
         // 1) ---------------------------27
         // 2) -----------------------------------------------------------------------------------2e
-        compare(pdu,
-                "00020f1f09121c0200000429233ea471060301b40317352f3f4e0c0000000a1e09552e44428200002f3c03173400"
-                        // 3) ---------------------------2e
-                        + "1f0c004000051e09552e4442a033332f1f4f");
+        compare(pdu, "00020f1f09121c0200000429233ea471060301b40317352f3f4e0c0000000a1e09552e44428200002f3c03173400"
+                // 3) ---------------------------2e
+                + "1f0c004000051e09552e4442a033332f1f4f");
     }
 
     @Test
@@ -554,7 +552,7 @@ public class AnnexFEncodingTest {
 
     @Test
     public void e1_14aTest() {
-        // TODO the spec appears to be really messed up with this one, putting an unconfirmed service into
+        // The spec appears to be really messed up with this one, putting an unconfirmed service into
         // a confirmed request
         UnconfirmedCovNotificationMultipleRequest req = new UnconfirmedCovNotificationMultipleRequest(
                 new Unsigned32(18), new ObjectIdentifier(ObjectType.device, 4), new UnsignedInteger(27), null,
@@ -870,6 +868,46 @@ public class AnnexFEncodingTest {
                 "30020E0C000000211E29554E44422933334F1F0C000000321E29555E9101911F5F1F0C000000231E29554E4443D9D99A4F1F");
     }
 
+    /**
+     * Per addendum 135-2016bl-2 (Example F.3.X): the ReadPropertyMultiple request for the
+     * OPTIONAL pseudo-property of a single object. Byte-for-byte reproduction of the spec
+     * example. Object under test is (Analog Input, 19).
+     * <p>
+     * Note: the addendum text prints X'55' for the OPTIONAL enum byte, but the correct
+     * encoding is X'50'. OPTIONAL is enum value 80 decimal (per the BACnetPropertyIdentifier
+     * production), which is 0x50 in hex. The addendum's X'55' is an encoding-annotation
+     * typo — the annotation itself reads "80 (OPTIONAL)" which is the correct value.
+     */
+    @Test
+    public void e3_bl2_optionalRequest_matchesSpecExample() {
+        List<PropertyReference> propertyReferences = new ArrayList<>();
+        propertyReferences.add(new PropertyReference(PropertyIdentifier.optional, null));
+        List<ReadAccessSpecification> readAccessSpecs = new ArrayList<>();
+        readAccessSpecs.add(new ReadAccessSpecification(new ObjectIdentifier(ObjectType.analogInput, 19),
+                new SequenceOf<>(propertyReferences)));
+        ConfirmedRequestService service = new ReadPropertyMultipleRequest(new SequenceOf<>(readAccessSpecs));
+        APDU pdu = new ConfirmedRequest(false, false, false, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_1024,
+                (byte) 2, (byte) 0, 0, service);
+        // 00 04 02 0E  0C 00000013  1E  09 50  1F
+        compare(pdu, "0004020E0C000000131E09501F");
+    }
+
+    /**
+     * Per addendum 135-2016bl-2 (Example F.3.X): the ReadPropertyMultiple-ACK response when
+     * the target object has no optional properties. The list of results is empty, encoded as
+     * opening tag 1 immediately followed by closing tag 1 with nothing in between.
+     */
+    @Test
+    public void e3_bl2_optionalResponseWithEmptyResults_matchesSpecExample() {
+        List<ReadAccessResult> readAccessResults = new ArrayList<>();
+        readAccessResults.add(new ReadAccessResult(new ObjectIdentifier(ObjectType.analogInput, 19),
+                new SequenceOf<>()));
+        AcknowledgementService service = new ReadPropertyMultipleAck(new SequenceOf<>(readAccessResults));
+        APDU pdu = new ComplexACK(false, false, (byte) 2, 0, 0, service);
+        // 30 02 0E  0C 00000013  1E 1F
+        compare(pdu, "30020E0C000000131E1F");
+    }
+
     @Test
     public void e3_8aTest() {
         ReadRangeRequest req = new ReadRangeRequest(new ObjectIdentifier(ObjectType.trendLog, 1),
@@ -898,7 +936,7 @@ public class AnnexFEncodingTest {
 
         APDU pdu = new ComplexACK(false, false, (byte) 1, 0, 0, service);
 
-        compare(pdu, "30011a0c0500000119833a05c049025e0ea462031701b413361b000f1e2c419000001f2a04000ea462031701" + ""
+        compare(pdu, "30011a0c0500000119833a05c049025e0ea462031701b413361b000f1e2c419000001f2a04000ea462031701"
                 + "b413381b000f1e2c4190cccd1f2a04005f6b013561");
     }
 
@@ -1084,7 +1122,7 @@ public class AnnexFEncodingTest {
     }
 
     @Test
-    public void e4_8bTest() {
+    public void e4_8b_and_e4_8dTest() {
         UnconfirmedRequestService service = new IHaveRequest(new ObjectIdentifier(ObjectType.device, 8),
                 new ObjectIdentifier(ObjectType.analogInput, 3),
                 new CharacterString(new CharacterEncoding(StandardCharacterEncodings.ANSI_X3_4), "OATemp"));
@@ -1101,15 +1139,6 @@ public class AnnexFEncodingTest {
     }
 
     @Test
-    public void e4_8dTest() {
-        UnconfirmedRequestService service = new IHaveRequest(new ObjectIdentifier(ObjectType.device, 8),
-                new ObjectIdentifier(ObjectType.analogInput, 3),
-                new CharacterString(new CharacterEncoding(StandardCharacterEncodings.ANSI_X3_4), "OATemp"));
-        APDU pdu = new UnconfirmedRequest(service);
-        compare(pdu, "1001C402000008C4000000037507004F4154656D70");
-    }
-
-    @Test
     public void e4_9aTest() {
         UnconfirmedRequestService service = new WhoIsRequest(new UnsignedInteger(3), new UnsignedInteger(3));
         APDU pdu = new UnconfirmedRequest(service);
@@ -1117,7 +1146,7 @@ public class AnnexFEncodingTest {
     }
 
     @Test
-    public void e4_9bTest() {
+    public void e4_9b_and_e4_9fTest() {
         UnconfirmedRequestService service = new IAmRequest(new ObjectIdentifier(ObjectType.device, 3),
                 new UnsignedInteger(1024), Segmentation.noSegmentation, new UnsignedInteger(99));
         APDU pdu = new UnconfirmedRequest(service);
@@ -1145,14 +1174,6 @@ public class AnnexFEncodingTest {
                 new UnsignedInteger(206), Segmentation.segmentedReceive, new UnsignedInteger(33));
         APDU pdu = new UnconfirmedRequest(service);
         compare(pdu, "1000C40200000221CE91022121");
-    }
-
-    @Test
-    public void e4_9fTest() {
-        UnconfirmedRequestService service = new IAmRequest(new ObjectIdentifier(ObjectType.device, 3),
-                new UnsignedInteger(1024), Segmentation.noSegmentation, new UnsignedInteger(99));
-        APDU pdu = new UnconfirmedRequest(service);
-        compare(pdu, "1000C40200000322040091032163");
     }
 
     @Test
@@ -1260,7 +1281,6 @@ public class AnnexFEncodingTest {
             if (parsedAPDU instanceof UnconfirmedRequest)
                 ((UnconfirmedRequest) parsedAPDU).parseServiceData();
         } catch (BACnetException e) {
-            e.printStackTrace();
             fail(e.getMessage());
             return;
         }
@@ -1268,9 +1288,6 @@ public class AnnexFEncodingTest {
         assertEquals(0, queue.size());
 
         if (!parsedAPDU.equals(pdu)) {
-            parsedAPDU.equals(pdu); // For debugging
-            parsedAPDU.equals(pdu);
-            parsedAPDU.equals(pdu);
             throw new RuntimeException("Parsed APDU does not equal given APDU");
         }
     }

--- a/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadPropertyMultipleRequestTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadPropertyMultipleRequestTest.java
@@ -114,15 +114,15 @@ public class ReadPropertyMultipleRequestTest {
 
     @Test
     public void requiredProperties() throws BACnetException {
-        final SequenceOf<ReadAccessSpecification> listOfReadAccessSpecs = new SequenceOf<>(
+        SequenceOf<ReadAccessSpecification> listOfReadAccessSpecs = new SequenceOf<>(
                 new ReadAccessSpecification(g0.getId(), PropertyIdentifier.required));
-        final ReadPropertyMultipleAck ack = (ReadPropertyMultipleAck) new ReadPropertyMultipleRequest(
+        ReadPropertyMultipleAck ack = (ReadPropertyMultipleAck) new ReadPropertyMultipleRequest(
                 listOfReadAccessSpecs).handle(localDevice, addr);
 
-        final List<ReadAccessResult> readAccessResults = ack.getListOfReadAccessResults().getValues();
+        List<ReadAccessResult> readAccessResults = ack.getListOfReadAccessResults().getValues();
         assertEquals(1, readAccessResults.size());
         assertEquals(g0.getId(), readAccessResults.get(0).getObjectIdentifier());
-        final List<Result> results = readAccessResults.get(0).getListOfResults().getValues();
+        List<Result> results = readAccessResults.get(0).getListOfResults().getValues();
         assertEquals(5, results.size());
         assertEquals(new Result(PropertyIdentifier.objectType, null, ObjectType.group), results.get(0));
         assertEquals(new Result(PropertyIdentifier.listOfGroupMembers, null, new SequenceOf<>()), results.get(1));
@@ -133,18 +133,44 @@ public class ReadPropertyMultipleRequestTest {
 
     @Test
     public void optionalProperties() throws BACnetException {
-        final SequenceOf<ReadAccessSpecification> listOfReadAccessSpecs = new SequenceOf<>(
+        SequenceOf<ReadAccessSpecification> listOfReadAccessSpecs = new SequenceOf<>(
                 new ReadAccessSpecification(g0.getId(), PropertyIdentifier.optional));
-        final ReadPropertyMultipleAck ack = (ReadPropertyMultipleAck) new ReadPropertyMultipleRequest(
+        ReadPropertyMultipleAck ack = (ReadPropertyMultipleAck) new ReadPropertyMultipleRequest(
                 listOfReadAccessSpecs).handle(localDevice, addr);
 
-        final List<ReadAccessResult> readAccessResults = ack.getListOfReadAccessResults().getValues();
+        List<ReadAccessResult> readAccessResults = ack.getListOfReadAccessResults().getValues();
         assertEquals(1, readAccessResults.size());
         assertEquals(g0.getId(), readAccessResults.get(0).getObjectIdentifier());
-        final List<Result> results = readAccessResults.get(0).getListOfResults().getValues();
+        List<Result> results = readAccessResults.get(0).getListOfResults().getValues();
         assertEquals(1, results.size());
         assertEquals(new Result(PropertyIdentifier.description, null, new CharacterString("my description")),
                 results.get(0));
+    }
+
+    /**
+     * Per addendum 135-2016bl-2: when a ReadPropertyMultiple request specifies OPTIONAL for an
+     * object that has no optional properties present, the response must be a valid ACK carrying
+     * a single ReadAccessResult with an empty List of Results. It must not be a NAK or an error
+     * response.
+     */
+    @Test
+    public void optionalProperties_objectHasNoOptionalPropertiesPresent_returnsEmptyResults() throws Exception {
+        // Create a bare Group object that has none of its type's optional properties set
+        // (description, auditLevel, auditableOperations, tags, profileLocation, profileName).
+        // The Group constructor doesn't populate any of these.
+        GroupObject g1 = localDevice.addObject(new GroupObject(localDevice, 1, "g1", new SequenceOf<>()));
+
+        SequenceOf<ReadAccessSpecification> listOfReadAccessSpecs = new SequenceOf<>(
+                new ReadAccessSpecification(g1.getId(), PropertyIdentifier.optional));
+        ReadPropertyMultipleAck ack = (ReadPropertyMultipleAck) new ReadPropertyMultipleRequest(
+                listOfReadAccessSpecs).handle(localDevice, addr);
+
+        List<ReadAccessResult> readAccessResults = ack.getListOfReadAccessResults().getValues();
+        assertEquals(1, readAccessResults.size());
+        assertEquals(g1.getId(), readAccessResults.get(0).getObjectIdentifier());
+        // Empty list of results — no properties returned, no error results either.
+        List<Result> results = readAccessResults.get(0).getListOfResults().getValues();
+        assertEquals(0, results.size());
     }
 
     @Test // 15.7.2 and standard test 135.1-2013 9.18.1.3
@@ -168,7 +194,7 @@ public class ReadPropertyMultipleRequestTest {
         //Property "description" exist in groupobject
         //Property "accessDoors" does not exist in groupobject
         //Object "analogInput" does not exist in device
-        final SequenceOf<ReadAccessSpecification> listOfReadAccessSpecs = new SequenceOf<>(
+        SequenceOf<ReadAccessSpecification> listOfReadAccessSpecs = new SequenceOf<>(
                 new ReadAccessSpecification(g0.getId(),
                         new SequenceOf<>(new PropertyReference(PropertyIdentifier.description),
                                 new PropertyReference(PropertyIdentifier.accessDoors))),
@@ -177,14 +203,14 @@ public class ReadPropertyMultipleRequestTest {
                                 new PropertyReference(PropertyIdentifier.objectName)))
         );
 
-        final ReadPropertyMultipleAck ack = (ReadPropertyMultipleAck) new ReadPropertyMultipleRequest(
+        ReadPropertyMultipleAck ack = (ReadPropertyMultipleAck) new ReadPropertyMultipleRequest(
                 listOfReadAccessSpecs).handle(localDevice, addr);
 
-        final List<ReadAccessResult> readAccessResults = ack.getListOfReadAccessResults().getValues();
+        List<ReadAccessResult> readAccessResults = ack.getListOfReadAccessResults().getValues();
         assertEquals(2, readAccessResults.size());
         //spec 0
         assertEquals(g0.getId(), readAccessResults.get(0).getObjectIdentifier());
-        final List<Result> results = readAccessResults.get(0).getListOfResults().getValues();
+        List<Result> results = readAccessResults.get(0).getListOfResults().getValues();
         assertEquals(2, results.size());
         assertEquals(new Result(PropertyIdentifier.description, null, new CharacterString("my description")),
                 results.get(0));
@@ -192,7 +218,7 @@ public class ReadPropertyMultipleRequestTest {
                 new ErrorClassAndCode(ErrorClass.property, ErrorCode.unknownProperty)), results.get(1));
         //spec 1
         assertEquals(new ObjectIdentifier(ObjectType.analogInput, 0), readAccessResults.get(1).getObjectIdentifier());
-        final List<Result> results1 = readAccessResults.get(1).getListOfResults().getValues();
+        List<Result> results1 = readAccessResults.get(1).getListOfResults().getValues();
         assertEquals(2, results1.size());
         assertEquals(new Result(PropertyIdentifier.description, null,
                 new ErrorClassAndCode(ErrorClass.object, ErrorCode.unknownObject)), results1.get(0));
@@ -202,27 +228,26 @@ public class ReadPropertyMultipleRequestTest {
 
     static class TestProprietary extends BaseType {
         private final UnsignedInteger testUnsigned;
-        private final com.serotonin.bacnet4j.type.primitive.Boolean testBoolean;
+        private final Boolean testBoolean;
 
         public TestProprietary(int testUnsigned, boolean testBoolean) {
-            this(new UnsignedInteger(testUnsigned), com.serotonin.bacnet4j.type.primitive.Boolean.valueOf(testBoolean));
+            this(new UnsignedInteger(testUnsigned), Boolean.valueOf(testBoolean));
         }
 
-        public TestProprietary(final UnsignedInteger testUnsigned,
-                final com.serotonin.bacnet4j.type.primitive.Boolean testBoolean) {
+        public TestProprietary(UnsignedInteger testUnsigned, Boolean testBoolean) {
             this.testUnsigned = testUnsigned;
             this.testBoolean = testBoolean;
         }
 
         @Override
-        public void write(final ByteQueue queue) {
+        public void write(ByteQueue queue) {
             write(queue, testUnsigned, 0);
             write(queue, testBoolean, 1);
         }
 
-        public TestProprietary(final ByteQueue queue) throws BACnetException {
+        public TestProprietary(ByteQueue queue) throws BACnetException {
             testUnsigned = read(queue, UnsignedInteger.class, 0);
-            testBoolean = read(queue, com.serotonin.bacnet4j.type.primitive.Boolean.class, 1);
+            testBoolean = read(queue, Boolean.class, 1);
         }
 
         public UnsignedInteger getTestUnsigned() {


### PR DESCRIPTION
https://radixiot.atlassian.net/browse/MANGO-2952

Adds tests to pin the library's compliance with the clarifications in 135-2016bl-2 (ReadPropertyMultiple response on OPTIONAL when the object has no optional properties). No production code changes — the implementation already produces the required empty-context-tag wire encoding.

Took the opportunity to also remove "final" cruft and fix some SQ notes