### PR TITLE
MANGO-2953 Correct LifeSafetyPoint and LifeSafetyZone out of service behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ trendLogMult.writeProperty(PropertyIdentifier.recordCount, new UnsignedInteger(1
   nomenclature changes
 - Names of engineering units have been changed to align with the spec
 - CharacterStringObject was renamed to CharacterStringValueObject
+- LifeSafetyPoint and LifeSafetyZone now handle `trackingValue` and `reliability` properly according to out of service
+  rules.
 
 *Version 6.2.0*
 

--- a/src/main/java/com/serotonin/bacnet4j/obj/LifeSafetyPointObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/LifeSafetyPointObject.java
@@ -34,6 +34,7 @@ import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.obj.mixin.HasStatusFlagsMixin;
 import com.serotonin.bacnet4j.obj.mixin.LifeSafetyMixin;
 import com.serotonin.bacnet4j.obj.mixin.ReadOnlyPropertyMixin;
+import com.serotonin.bacnet4j.obj.mixin.WritablePropertyOutOfServiceMixin;
 import com.serotonin.bacnet4j.obj.mixin.event.IntrinsicReportingMixin;
 import com.serotonin.bacnet4j.obj.mixin.event.eventAlgo.ChangeOfLifeSafetyAlgo;
 import com.serotonin.bacnet4j.obj.mixin.event.faultAlgo.FaultLifeSafetyAlgo;
@@ -58,10 +59,9 @@ import com.serotonin.bacnet4j.type.primitive.Real;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
 public class LifeSafetyPointObject extends BACnetObject implements LifeSafety {
-    public LifeSafetyPointObject(final LocalDevice localDevice, final int instanceNumber, final String name,
-            final LifeSafetyState presentValue, final LifeSafetyMode mode, final boolean outOfService,
-            final SequenceOf<LifeSafetyMode> acceptedModes, final LifeSafetyOperation operationExpected,
-            final SilencedState silenced) throws BACnetServiceException {
+    public LifeSafetyPointObject(LocalDevice localDevice, int instanceNumber, String name, LifeSafetyState presentValue,
+            LifeSafetyMode mode, boolean outOfService, SequenceOf<LifeSafetyMode> acceptedModes,
+            LifeSafetyOperation operationExpected, SilencedState silenced) throws BACnetServiceException {
         super(localDevice, ObjectType.lifeSafetyPoint, instanceNumber, name);
 
         Objects.requireNonNull(presentValue);
@@ -70,7 +70,7 @@ public class LifeSafetyPointObject extends BACnetObject implements LifeSafety {
         Objects.requireNonNull(operationExpected);
         Objects.requireNonNull(silenced);
 
-        final ValueSource valueSource = new ValueSource(new DeviceObjectReference(localDevice.getId(), getId()));
+        ValueSource valueSource = new ValueSource(new DeviceObjectReference(localDevice.getId(), getId()));
 
         writePropertyInternal(PropertyIdentifier.eventState, EventState.normal);
         writePropertyInternal(PropertyIdentifier.presentValue, presentValue);
@@ -85,15 +85,20 @@ public class LifeSafetyPointObject extends BACnetObject implements LifeSafety {
 
         // Mixins
         addMixin(new HasStatusFlagsMixin(this));
+        // Per addendum 135-2016bl-3: Tracking_Value and Reliability are writable only when
+        // Out_Of_Service is TRUE. When in service, these properties are driven by the input
+        // or process and must not be written by network clients.
+        addMixin(new WritablePropertyOutOfServiceMixin(this,
+                PropertyIdentifier.trackingValue, PropertyIdentifier.reliability));
         addMixin(new LifeSafetyMixin(this));
         addMixin(new ReadOnlyPropertyMixin(this, PropertyIdentifier.acceptedModes, PropertyIdentifier.ackedTransitions,
                 PropertyIdentifier.eventTimeStamps, PropertyIdentifier.eventMessageTexts));
     }
 
-    public LifeSafetyPointObject supportIntrinsicReporting(final int timeDelay, final int notificationClass,
-            final BACnetArray<LifeSafetyState> lifeSafetyAlarmValues, final BACnetArray<LifeSafetyState> alarmValues,
-            final BACnetArray<LifeSafetyState> faultValues, final EventTransitionBits eventEnable,
-            final NotifyType notifyType, final UnsignedInteger timeDelayNormal) {
+    public LifeSafetyPointObject supportIntrinsicReporting(int timeDelay, int notificationClass,
+            BACnetArray<LifeSafetyState> lifeSafetyAlarmValues, BACnetArray<LifeSafetyState> alarmValues,
+            BACnetArray<LifeSafetyState> faultValues, EventTransitionBits eventEnable, NotifyType notifyType,
+            UnsignedInteger timeDelayNormal) {
         Objects.requireNonNull(lifeSafetyAlarmValues);
         Objects.requireNonNull(alarmValues);
         Objects.requireNonNull(eventEnable);

--- a/src/main/java/com/serotonin/bacnet4j/obj/LifeSafetyZoneObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/LifeSafetyZoneObject.java
@@ -34,6 +34,7 @@ import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.obj.mixin.HasStatusFlagsMixin;
 import com.serotonin.bacnet4j.obj.mixin.LifeSafetyMixin;
 import com.serotonin.bacnet4j.obj.mixin.ReadOnlyPropertyMixin;
+import com.serotonin.bacnet4j.obj.mixin.WritablePropertyOutOfServiceMixin;
 import com.serotonin.bacnet4j.obj.mixin.event.IntrinsicReportingMixin;
 import com.serotonin.bacnet4j.obj.mixin.event.eventAlgo.ChangeOfLifeSafetyAlgo;
 import com.serotonin.bacnet4j.obj.mixin.event.faultAlgo.FaultLifeSafetyAlgo;
@@ -56,11 +57,10 @@ import com.serotonin.bacnet4j.type.primitive.Boolean;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
 public class LifeSafetyZoneObject extends BACnetObject implements LifeSafety {
-    public LifeSafetyZoneObject(final LocalDevice localDevice, final int instanceNumber, final String name,
-            final LifeSafetyState presentValue, final LifeSafetyMode mode, final boolean outOfService,
-            final SequenceOf<LifeSafetyMode> acceptedModes, final LifeSafetyOperation operationExpected,
-            final SilencedState silenced, final SequenceOf<DeviceObjectReference> zoneMembers)
-            throws BACnetServiceException {
+    public LifeSafetyZoneObject(LocalDevice localDevice, int instanceNumber, String name, LifeSafetyState presentValue,
+            LifeSafetyMode mode, boolean outOfService, SequenceOf<LifeSafetyMode> acceptedModes,
+            LifeSafetyOperation operationExpected, SilencedState silenced,
+            SequenceOf<DeviceObjectReference> zoneMembers) throws BACnetServiceException {
         super(localDevice, ObjectType.lifeSafetyZone, instanceNumber, name);
 
         Objects.requireNonNull(presentValue);
@@ -70,7 +70,7 @@ public class LifeSafetyZoneObject extends BACnetObject implements LifeSafety {
         Objects.requireNonNull(silenced);
         Objects.requireNonNull(zoneMembers);
 
-        final ValueSource valueSource = new ValueSource(new DeviceObjectReference(localDevice.getId(), getId()));
+        ValueSource valueSource = new ValueSource(new DeviceObjectReference(localDevice.getId(), getId()));
 
         writePropertyInternal(PropertyIdentifier.eventState, EventState.normal);
         writePropertyInternal(PropertyIdentifier.presentValue, presentValue);
@@ -86,15 +86,20 @@ public class LifeSafetyZoneObject extends BACnetObject implements LifeSafety {
 
         // Mixins
         addMixin(new HasStatusFlagsMixin(this));
+        // Per addendum 135-2016bl-3: Tracking_Value and Reliability are writable only when
+        // Out_Of_Service is TRUE. When in service, these properties are driven by the input
+        // or process and must not be written by network clients.
+        addMixin(new WritablePropertyOutOfServiceMixin(this,
+                PropertyIdentifier.trackingValue, PropertyIdentifier.reliability));
         addMixin(new LifeSafetyMixin(this));
         addMixin(new ReadOnlyPropertyMixin(this, PropertyIdentifier.acceptedModes, PropertyIdentifier.ackedTransitions,
                 PropertyIdentifier.eventTimeStamps, PropertyIdentifier.eventMessageTexts));
     }
 
-    public LifeSafetyZoneObject supportIntrinsicReporting(final int timeDelay, final int notificationClass,
-            final BACnetArray<LifeSafetyState> lifeSafetyAlarmValues, final BACnetArray<LifeSafetyState> alarmValues,
-            final BACnetArray<LifeSafetyState> faultValues, final EventTransitionBits eventEnable,
-            final NotifyType notifyType, final UnsignedInteger timeDelayNormal) {
+    public LifeSafetyZoneObject supportIntrinsicReporting(int timeDelay, int notificationClass,
+            BACnetArray<LifeSafetyState> lifeSafetyAlarmValues, BACnetArray<LifeSafetyState> alarmValues,
+            BACnetArray<LifeSafetyState> faultValues, EventTransitionBits eventEnable, NotifyType notifyType,
+            UnsignedInteger timeDelayNormal) {
         Objects.requireNonNull(lifeSafetyAlarmValues);
         Objects.requireNonNull(alarmValues);
         Objects.requireNonNull(eventEnable);

--- a/src/main/java/com/serotonin/bacnet4j/obj/mixin/WritablePropertyOutOfServiceMixin.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/mixin/WritablePropertyOutOfServiceMixin.java
@@ -27,6 +27,7 @@
 
 package com.serotonin.bacnet4j.obj.mixin;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -42,25 +43,21 @@ import com.serotonin.bacnet4j.type.primitive.Boolean;
 
 /**
  * Allows writing of the given properties only when the object is out of service.
- *
- * @author Matthew
  */
 public class WritablePropertyOutOfServiceMixin extends AbstractMixin {
     private final Set<PropertyIdentifier> pids = new HashSet<>();
 
-    public WritablePropertyOutOfServiceMixin(final BACnetObject bo, final PropertyIdentifier... pids) {
+    public WritablePropertyOutOfServiceMixin(BACnetObject bo, PropertyIdentifier... pids) {
         super(bo);
-        for (final PropertyIdentifier pid : pids)
-            this.pids.add(pid);
+        this.pids.addAll(Arrays.asList(pids));
     }
 
     @Override
-    protected boolean validateProperty(final ValueSource valueSource, final PropertyValue value)
+    protected boolean validateProperty(ValueSource valueSource, PropertyValue value)
             throws BACnetServiceException {
-        final Boolean outOfService = get(PropertyIdentifier.outOfService);
-        if (!outOfService.booleanValue()) {
-            if (pids.contains(value.getPropertyIdentifier()))
-                throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
+        Boolean outOfService = get(PropertyIdentifier.outOfService);
+        if (!outOfService.booleanValue() && pids.contains(value.getPropertyIdentifier())) {
+            throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
         }
         return false;
     }

--- a/src/test/java/com/serotonin/bacnet4j/obj/LifeSafetyPointObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/LifeSafetyPointObjectTest.java
@@ -27,6 +27,7 @@
 
 package com.serotonin.bacnet4j.obj;
 
+import static com.serotonin.bacnet4j.TestUtils.assertBACnetServiceException;
 import static com.serotonin.bacnet4j.TestUtils.awaitEquals;
 import static com.serotonin.bacnet4j.TestUtils.quiesce;
 import static org.junit.Assert.assertEquals;
@@ -48,6 +49,8 @@ import com.serotonin.bacnet4j.type.constructed.SequenceOf;
 import com.serotonin.bacnet4j.type.constructed.StatusFlags;
 import com.serotonin.bacnet4j.type.constructed.TimeStamp;
 import com.serotonin.bacnet4j.type.enumerated.EngineeringUnits;
+import com.serotonin.bacnet4j.type.enumerated.ErrorClass;
+import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
 import com.serotonin.bacnet4j.type.enumerated.EventState;
 import com.serotonin.bacnet4j.type.enumerated.EventType;
 import com.serotonin.bacnet4j.type.enumerated.LifeSafetyMode;
@@ -69,7 +72,6 @@ import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
 public class LifeSafetyPointObjectTest extends AbstractTest {
     private LifeSafetyPointObject lsp;
-    private NotificationClassObject nc;
     private EventNotifListener listener;
 
     @Override
@@ -78,10 +80,10 @@ public class LifeSafetyPointObjectTest extends AbstractTest {
                 d1, 0, "lsp", LifeSafetyState.quiet, LifeSafetyMode.on, false,
                 new SequenceOf<>(LifeSafetyMode.on, LifeSafetyMode.off, LifeSafetyMode.enabled),
                 LifeSafetyOperation.none, SilencedState.unsilenced));
-        nc = d1.addObject(new NotificationClassObject(
+        var nc = d1.addObject(new NotificationClassObject(
                 d1, 17, "nc17", 100, 5, 200, new EventTransitionBits(false, false, false)));
 
-        final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
+        SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
         recipients.add(new Destination(new Recipient(rd2.getAddress()), new UnsignedInteger(10), Boolean.TRUE,
                 new EventTransitionBits(true, true, true)));
 
@@ -196,8 +198,6 @@ public class LifeSafetyPointObjectTest extends AbstractTest {
 
     /**
      * Tests the timing of when notifications are sent. Normal to offnormal immediately after a mode change.
-     *
-     * @throws Exception
      */
     @Test
     public void changeOfLifeSafetyAlgoA2() throws Exception {
@@ -430,11 +430,11 @@ public class LifeSafetyPointObjectTest extends AbstractTest {
     @SuppressWarnings("unchecked")
     @Test
     public void algorithmicReporting() throws Exception {
-        final DeviceObjectPropertyReference pvRef =
+        DeviceObjectPropertyReference pvRef =
                 new DeviceObjectPropertyReference(1, lsp.getId(), PropertyIdentifier.presentValue);
-        final DeviceObjectPropertyReference modeRef =
+        DeviceObjectPropertyReference modeRef =
                 new DeviceObjectPropertyReference(1, lsp.getId(), PropertyIdentifier.mode);
-        final EventEnrollmentObject ee = d1.addObject(new EventEnrollmentObject(
+        EventEnrollmentObject ee = d1.addObject(new EventEnrollmentObject(
                 d1, 0, "ee", pvRef, NotifyType.alarm,
                 new EventParameter(new ChangeOfLifeSafety(new UnsignedInteger(30),
                         new BACnetArray<>(LifeSafetyState.tamper, LifeSafetyState.testSupervisory), //
@@ -592,16 +592,16 @@ public class LifeSafetyPointObjectTest extends AbstractTest {
         lsp.supportCovReporting();
 
         // Create a COV listener to catch the notifications.
-        final CovNotifListener listener = new CovNotifListener();
-        d2.getEventHandler().addListener(listener);
+        CovNotifListener covListener = new CovNotifListener();
+        d2.getEventHandler().addListener(covListener);
 
         //
         // Subscribe for notifications. Doing so should cause an initial notification to be sent.
         d2.send(rd1,
                         new SubscribeCOVRequest(new UnsignedInteger(987), lsp.getId(), Boolean.FALSE, new UnsignedInteger(600)))
                 .get();
-        awaitEquals(1, listener::getNotifCount);
-        CovNotifListener.Notif notif = listener.removeNotif();
+        awaitEquals(1, covListener::getNotifCount);
+        CovNotifListener.Notif notif = covListener.removeNotif();
         assertEquals(new UnsignedInteger(987), notif.subscriberProcessIdentifier());
         assertEquals(d1.getId(), notif.initiatingDevice());
         assertEquals(lsp.getId(), notif.monitoredObjectIdentifier());
@@ -616,8 +616,8 @@ public class LifeSafetyPointObjectTest extends AbstractTest {
         clock.plusMinutes(2);
 
         lsp.writePropertyInternal(PropertyIdentifier.presentValue, LifeSafetyState.blocked);
-        awaitEquals(1, listener::getNotifCount);
-        notif = listener.removeNotif();
+        awaitEquals(1, covListener::getNotifCount);
+        notif = covListener.removeNotif();
         assertEquals(new UnsignedInteger(987), notif.subscriberProcessIdentifier());
         assertEquals(d1.getId(), notif.initiatingDevice());
         assertEquals(lsp.getId(), notif.monitoredObjectIdentifier());
@@ -633,5 +633,49 @@ public class LifeSafetyPointObjectTest extends AbstractTest {
 
         assertEquals(new Real(150), lsp.get(PropertyIdentifier.directReading));
         assertEquals(EngineeringUnits.ampereSeconds, lsp.get(PropertyIdentifier.units));
+    }
+
+    // =========================================================================================
+    // Addendum 135-2016bl-3: Out_Of_Service semantics for Life Safety Point.
+    // Tracking_Value and Reliability shall be writable only when Out_Of_Service is TRUE.
+    // =========================================================================================
+
+    @Test
+    public void trackingValue_writeWhenInService_isDenied() {
+        // Object was constructed with outOfService=false in afterInit().
+        assertEquals(Boolean.FALSE, lsp.get(PropertyIdentifier.outOfService));
+
+        assertBACnetServiceException(() -> lsp.writeProperty(null,
+                        new PropertyValue(PropertyIdentifier.trackingValue, LifeSafetyState.tamper)),
+                ErrorClass.property, ErrorCode.writeAccessDenied);
+    }
+
+    @Test
+    public void trackingValue_writeWhenOutOfService_isAllowed() throws Exception {
+        lsp.writePropertyInternal(PropertyIdentifier.outOfService, Boolean.TRUE);
+
+        lsp.writeProperty(null,
+                new PropertyValue(PropertyIdentifier.trackingValue, LifeSafetyState.tamper));
+
+        assertEquals(LifeSafetyState.tamper, lsp.get(PropertyIdentifier.trackingValue));
+    }
+
+    @Test
+    public void reliability_writeWhenInService_isDenied() {
+        assertEquals(Boolean.FALSE, lsp.get(PropertyIdentifier.outOfService));
+
+        assertBACnetServiceException(() -> lsp.writeProperty(null,
+                        new PropertyValue(PropertyIdentifier.reliability, Reliability.unreliableOther)),
+                ErrorClass.property, ErrorCode.writeAccessDenied);
+    }
+
+    @Test
+    public void reliability_writeWhenOutOfService_isAllowed() throws Exception {
+        lsp.writePropertyInternal(PropertyIdentifier.outOfService, Boolean.TRUE);
+
+        lsp.writeProperty(null,
+                new PropertyValue(PropertyIdentifier.reliability, Reliability.unreliableOther));
+
+        assertEquals(Reliability.unreliableOther, lsp.get(PropertyIdentifier.reliability));
     }
 }

--- a/src/test/java/com/serotonin/bacnet4j/obj/LifeSafetyZoneObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/LifeSafetyZoneObjectTest.java
@@ -76,7 +76,6 @@ import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
 public class LifeSafetyZoneObjectTest extends AbstractTest {
     private LifeSafetyZoneObject lsz;
-    private NotificationClassObject nc;
     private EventNotifListener listener;
 
     @Override
@@ -85,10 +84,10 @@ public class LifeSafetyZoneObjectTest extends AbstractTest {
                 d1, 0, "lsz", LifeSafetyState.quiet, LifeSafetyMode.on, false,
                 new SequenceOf<>(LifeSafetyMode.on, LifeSafetyMode.off, LifeSafetyMode.enabled),
                 LifeSafetyOperation.none, SilencedState.unsilenced, new SequenceOf<>()));
-        nc = d1.addObject(new NotificationClassObject(
+        var nc = d1.addObject(new NotificationClassObject(
                 d1, 17, "nc17", 100, 5, 200, new EventTransitionBits(false, false, false)));
 
-        final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
+        SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
         recipients.add(new Destination(new Recipient(rd2.getAddress()), new UnsignedInteger(10), Boolean.TRUE,
                 new EventTransitionBits(true, true, true)));
 
@@ -204,8 +203,6 @@ public class LifeSafetyZoneObjectTest extends AbstractTest {
 
     /**
      * Tests the timing of when notifications are sent. Normal to offnormal immediately after a mode change.
-     *
-     * @throws Exception
      */
     @Test
     public void changeOfLifeSafetyAlgoA2() throws Exception {
@@ -295,7 +292,7 @@ public class LifeSafetyZoneObjectTest extends AbstractTest {
         assertEquals(Boolean.FALSE, notif.ackRequired());
         assertEquals(EventState.normal, notif.fromState());
         assertEquals(EventState.fault, notif.toState());
-        ChangeOfReliabilityNotif cor = ((NotificationParameters) notif.eventValues()).getParameter();
+        ChangeOfReliabilityNotif cor = notif.eventValues().getParameter();
         assertEquals(Reliability.multiStateFault, cor.getReliability());
         assertEquals(new StatusFlags(true, true, false, false), cor.getStatusFlags());
         assertEquals(3, cor.getPropertyValues().size());
@@ -328,7 +325,7 @@ public class LifeSafetyZoneObjectTest extends AbstractTest {
         assertEquals(Boolean.FALSE, notif.ackRequired());
         assertEquals(EventState.fault, notif.fromState());
         assertEquals(EventState.fault, notif.toState());
-        cor = ((NotificationParameters) notif.eventValues()).getParameter();
+        cor = notif.eventValues().getParameter();
         assertEquals(Reliability.multiStateFault, cor.getReliability());
         assertEquals(new StatusFlags(true, true, false, false), cor.getStatusFlags());
         assertEquals(3, cor.getPropertyValues().size());
@@ -369,7 +366,7 @@ public class LifeSafetyZoneObjectTest extends AbstractTest {
         assertEquals(Boolean.FALSE, notif.ackRequired());
         assertEquals(EventState.fault, notif.fromState());
         assertEquals(EventState.fault, notif.toState());
-        cor = ((NotificationParameters) notif.eventValues()).getParameter();
+        cor = notif.eventValues().getParameter();
         assertEquals(Reliability.multiStateFault, cor.getReliability());
         assertEquals(new StatusFlags(true, true, false, false), cor.getStatusFlags());
         assertEquals(3, cor.getPropertyValues().size());
@@ -405,7 +402,7 @@ public class LifeSafetyZoneObjectTest extends AbstractTest {
         assertEquals(Boolean.FALSE, notif.ackRequired());
         assertEquals(EventState.fault, notif.fromState());
         assertEquals(EventState.normal, notif.toState());
-        cor = ((NotificationParameters) notif.eventValues()).getParameter();
+        cor = notif.eventValues().getParameter();
         assertEquals(Reliability.noFaultDetected, cor.getReliability());
         assertEquals(new StatusFlags(false, false, false, false), cor.getStatusFlags());
         assertEquals(3, cor.getPropertyValues().size());
@@ -439,11 +436,11 @@ public class LifeSafetyZoneObjectTest extends AbstractTest {
     @SuppressWarnings("unchecked")
     @Test
     public void algorithmicReporting() throws Exception {
-        final DeviceObjectPropertyReference pvRef =
+        DeviceObjectPropertyReference pvRef =
                 new DeviceObjectPropertyReference(1, lsz.getId(), PropertyIdentifier.presentValue);
-        final DeviceObjectPropertyReference modeRef =
+        DeviceObjectPropertyReference modeRef =
                 new DeviceObjectPropertyReference(1, lsz.getId(), PropertyIdentifier.mode);
-        final EventEnrollmentObject ee = d1.addObject(new EventEnrollmentObject(
+        EventEnrollmentObject ee = d1.addObject(new EventEnrollmentObject(
                 d1, 0, "ee", pvRef, NotifyType.alarm,
                 new EventParameter(new ChangeOfLifeSafety(new UnsignedInteger(30),
                         new BACnetArray<>(LifeSafetyState.tamper, LifeSafetyState.testSupervisory), //
@@ -541,7 +538,7 @@ public class LifeSafetyZoneObjectTest extends AbstractTest {
         assertEquals(Boolean.FALSE, notif.ackRequired());
         assertEquals(EventState.offnormal, notif.fromState());
         assertEquals(EventState.fault, notif.toState());
-        ChangeOfReliabilityNotif cor = ((NotificationParameters) notif.eventValues()).getParameter();
+        ChangeOfReliabilityNotif cor = notif.eventValues().getParameter();
         assertEquals(Reliability.multiStateFault, cor.getReliability());
         assertEquals(new StatusFlags(true, true, false, false), cor.getStatusFlags());
         assertEquals(4, cor.getPropertyValues().size());
@@ -580,7 +577,7 @@ public class LifeSafetyZoneObjectTest extends AbstractTest {
         assertEquals(Boolean.FALSE, notif.ackRequired());
         assertEquals(EventState.fault, notif.fromState());
         assertEquals(EventState.normal, notif.toState());
-        cor = ((NotificationParameters) notif.eventValues()).getParameter();
+        cor = notif.eventValues().getParameter();
         assertEquals(Reliability.noFaultDetected, cor.getReliability());
         assertEquals(new StatusFlags(false, false, false, false), cor.getStatusFlags());
         assertEquals(4, cor.getPropertyValues().size());
@@ -602,16 +599,16 @@ public class LifeSafetyZoneObjectTest extends AbstractTest {
         lsz.supportCovReporting();
 
         // Create a COV listener to catch the notifications.
-        final CovNotifListener listener = new CovNotifListener();
-        d2.getEventHandler().addListener(listener);
+        CovNotifListener covListener = new CovNotifListener();
+        d2.getEventHandler().addListener(covListener);
 
         //
         // Subscribe for notifications. Doing so should cause an initial notification to be sent.
         d2.send(rd1,
                         new SubscribeCOVRequest(new UnsignedInteger(987), lsz.getId(), Boolean.FALSE, new UnsignedInteger(600)))
                 .get();
-        awaitEquals(1, listener::getNotifCount);
-        CovNotifListener.Notif notif = listener.removeNotif();
+        awaitEquals(1, covListener::getNotifCount);
+        CovNotifListener.Notif notif = covListener.removeNotif();
         assertEquals(new UnsignedInteger(987), notif.subscriberProcessIdentifier());
         assertEquals(d1.getId(), notif.initiatingDevice());
         assertEquals(lsz.getId(), notif.monitoredObjectIdentifier());
@@ -626,8 +623,8 @@ public class LifeSafetyZoneObjectTest extends AbstractTest {
         clock.plusMinutes(2);
 
         lsz.writePropertyInternal(PropertyIdentifier.presentValue, LifeSafetyState.blocked);
-        awaitEquals(1, listener::getNotifCount);
-        notif = listener.removeNotif(0);
+        awaitEquals(1, covListener::getNotifCount);
+        notif = covListener.removeNotif(0);
         assertEquals(new UnsignedInteger(987), notif.subscriberProcessIdentifier());
         assertEquals(d1.getId(), notif.initiatingDevice());
         assertEquals(lsz.getId(), notif.monitoredObjectIdentifier());
@@ -677,5 +674,48 @@ public class LifeSafetyZoneObjectTest extends AbstractTest {
                         new DeviceObjectReference(new ObjectIdentifier(ObjectType.device, 10),
                                 new ObjectIdentifier(ObjectType.loop, 0))))), ErrorClass.property,
                 ErrorCode.unsupportedObjectType);
+    }
+
+    // =========================================================================================
+    // Addendum 135-2016bl-3: Out_Of_Service semantics for Life Safety Zone.
+    // Tracking_Value and Reliability shall be writable only when Out_Of_Service is TRUE.
+    // =========================================================================================
+
+    @Test
+    public void trackingValue_writeWhenInService_isDenied() {
+        assertEquals(Boolean.FALSE, lsz.get(PropertyIdentifier.outOfService));
+
+        assertBACnetServiceException(() -> lsz.writeProperty(null,
+                        new PropertyValue(PropertyIdentifier.trackingValue, LifeSafetyState.tamper)),
+                ErrorClass.property, ErrorCode.writeAccessDenied);
+    }
+
+    @Test
+    public void trackingValue_writeWhenOutOfService_isAllowed() throws Exception {
+        lsz.writePropertyInternal(PropertyIdentifier.outOfService, Boolean.TRUE);
+
+        lsz.writeProperty(null,
+                new PropertyValue(PropertyIdentifier.trackingValue, LifeSafetyState.tamper));
+
+        assertEquals(LifeSafetyState.tamper, lsz.get(PropertyIdentifier.trackingValue));
+    }
+
+    @Test
+    public void reliability_writeWhenInService_isDenied() {
+        assertEquals(Boolean.FALSE, lsz.get(PropertyIdentifier.outOfService));
+
+        assertBACnetServiceException(() -> lsz.writeProperty(null,
+                        new PropertyValue(PropertyIdentifier.reliability, Reliability.unreliableOther)),
+                ErrorClass.property, ErrorCode.writeAccessDenied);
+    }
+
+    @Test
+    public void reliability_writeWhenOutOfService_isAllowed() throws Exception {
+        lsz.writePropertyInternal(PropertyIdentifier.outOfService, Boolean.TRUE);
+
+        lsz.writeProperty(null,
+                new PropertyValue(PropertyIdentifier.reliability, Reliability.unreliableOther));
+
+        assertEquals(Reliability.unreliableOther, lsz.get(PropertyIdentifier.reliability));
     }
 }


### PR DESCRIPTION
https://radixiot.atlassian.net/browse/MANGO-2953

Applies the clarification from addendum 135-2016bl-3 to the LifeSafety object types. Per bl-3, Tracking_Value and Reliability shall be writable only when Out_Of_Service = TRUE. Prior to this change, both properties were freely writable at any time on LifeSafetyPointObject and LifeSafetyZoneObject.

Also removed "final" debris clean up SQ notes.