### PR TITLE
MANGO-2954 Align MS/TP implementation with rev 20 changes and master manager slave subordinate nomenclature

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ trendLogMult.writeProperty(PropertyIdentifier.recordCount, new UnsignedInteger(1
 ```
 
 - the device communicate control option DISABLE has been deprecated as per 135-2016bi-2
+- Default vendor renamed to Radix IoT LLC
+- Protocol revision increased to 20
 
 *Version 6.2.0*
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ trendLogMult.writeProperty(PropertyIdentifier.recordCount, new UnsignedInteger(1
 - the device communicate control option DISABLE has been deprecated as per 135-2016bi-2
 - Default vendor renamed to Radix IoT LLC
 - Protocol revision increased to 20
+- Many renamings on multiple levels (class, method, field, enum, etc.) to make BACnet4J compliant with MS/TP
+  nomenclature changes
 
 *Version 6.2.0*
 

--- a/src/main/java/com/serotonin/bacnet4j/npdu/mstp/Constants.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/mstp/Constants.java
@@ -28,6 +28,9 @@
 package com.serotonin.bacnet4j.npdu.mstp;
 
 public class Constants {
+    private Constants() {
+    }
+
     /**
      * This parameter represents the value of the Max_Info_Frames property of the node's Device object. The value
      * of Max_Info_Frames specifies the maximum number of information frames the node may send before it must
@@ -121,9 +124,9 @@ public class Constants {
     public static final int USAGE_DELAY = 15;
 
     /**
-     * The minimum time without a DataAvailable or ReceiveError event that a node must wait for a remote node to
+     * The time without a DataAvailable or ReceiveError event that a node must wait for a remote node to
      * begin using a token or replying to a Poll For Master frame: 20 milliseconds. (Implementations may use larger
-     * values for this timeout, not to exceed 100 milliseconds.)
+     * values for this timeout, not to exceed 35 milliseconds.)
      */
     public static final int USAGE_TIMEOUT = 20;
 

--- a/src/main/java/com/serotonin/bacnet4j/npdu/mstp/Constants.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/mstp/Constants.java
@@ -41,14 +41,14 @@ public class Constants {
     public static final int MAX_INFO_FRAMES = 1;
 
     /**
-     * This parameter represents the value of the Max_Master property of the node's Device object. The value of
-     * Max_Master specifies the highest allowable address for master nodes. The value of Max_Master shall be less
-     * than or equal to 127. If Max_Master is not writable in a node, its value shall be 127.
+     * This parameter represents the value of the Max_Manager property of the node's Device object. The value of
+     * Max_Manager specifies the highest allowable address for manager nodes. The value of Max_Manager shall be
+     * less than or equal to 127. If Max_Manager is not writable in a node, its value shall be 127.
      */
-    public static final int MAX_MASTER = 127;
+    public static final int MAX_MANAGER = 127;
 
     /**
-     * The number of tokens received or used before a Poll For Master cycle is executed: 50.
+     * The number of tokens received or used before a Poll For Manager cycle is executed: 50.
      */
     public static final int POLL = 50;
 
@@ -118,14 +118,14 @@ public class Constants {
     public static final int TURNAROUND = 40;
 
     /**
-     * The maximum time a node may wait after reception of the token or a Poll For Master frame before sending
+     * The maximum time a node may wait after reception of the token or a Poll For Manager frame before sending
      * the first octet of a frame: 15 milliseconds.
      */
     public static final int USAGE_DELAY = 15;
 
     /**
      * The time without a DataAvailable or ReceiveError event that a node must wait for a remote node to
-     * begin using a token or replying to a Poll For Master frame: 20 milliseconds. (Implementations may use larger
+     * begin using a token or replying to a Poll For Manager frame: 20 milliseconds. (Implementations may use larger
      * values for this timeout, not to exceed 35 milliseconds.)
      */
     public static final int USAGE_TIMEOUT = 20;

--- a/src/main/java/com/serotonin/bacnet4j/npdu/mstp/FrameType.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/mstp/FrameType.java
@@ -34,8 +34,8 @@ import org.apache.commons.lang3.ArrayUtils;
  */
 public enum FrameType {
     token(0), //
-    pollForMaster(1), //
-    replyToPollForMaster(2), //
+    pollForManager(1), //
+    replyToPollForManager(2), //
     testRequest(3), //
     testResponse(4), //
     bacnetDataExpectingReply(5), //
@@ -45,7 +45,7 @@ public enum FrameType {
 
     public final byte id;
 
-    private FrameType(int id) {
+    FrameType(int id) {
         this.id = (byte) id;
     }
 

--- a/src/main/java/com/serotonin/bacnet4j/npdu/mstp/ManagerNode.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/mstp/ManagerNode.java
@@ -470,8 +470,8 @@ public class ManagerNode extends MstpNode {
     }
 
     /**
-     * In the POLL_FOR_MANAGER state, the node listens for a reply to a previously sent Poll For Manager frame in order to
-     * find a successor node.
+     * In the POLL_FOR_MANAGER state, the node listens for a reply to a previously sent Poll For Manager frame in order
+     * to find a successor node.
      */
     private void pollForManager() {
         if (receivedValidFrame) {

--- a/src/main/java/com/serotonin/bacnet4j/npdu/mstp/ManagerNode.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/mstp/ManagerNode.java
@@ -40,12 +40,12 @@ import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 import com.serotonin.bacnet4j.util.sero.SerialPortWrapper;
 
-public class MasterNode extends MstpNode {
-    static final Logger LOG = LoggerFactory.getLogger(MasterNode.class);
+public class ManagerNode extends MstpNode {
+    static final Logger LOG = LoggerFactory.getLogger(ManagerNode.class);
 
 
-    protected enum MasterNodeState {
-        idle, useToken, waitForReply, doneWithToken, passToken, noToken, pollForMaster, answerDataRequest
+    protected enum ManagerNodeState {
+        idle, useToken, waitForReply, doneWithToken, passToken, noToken, pollForManager, answerDataRequest
     }
 
 
@@ -58,35 +58,35 @@ public class MasterNode extends MstpNode {
     protected byte nextStation;
 
     /**
-     * The MAC address of the node to which This Station last sent a Poll For Master. This is
+     * The MAC address of the node to which This Station last sent a Poll For Manager. This is
      * used during token maintenance.
      */
     protected byte pollStation;
 
     /**
-     * A counter of transmission retries used for Token and Poll For Master transmission.
+     * A counter of transmission retries used for Token and Poll For Manager transmission.
      */
     protected int retryCount;
 
     /**
-     * A Boolean flag set to TRUE by the master machine if this node is the only known master node.
+     * A Boolean flag set to TRUE by the manager machine if this node is the only known manager node.
      */
-    protected boolean soleMaster;
+    protected boolean soleManager;
 
     /**
      * The number of tokens received by this node. When this counter reaches the value Npoll, the node
-     * polls the address range between TS and NS for additional master nodes. TokenCount is set to one at
+     * polls the address range between TS and NS for additional manager nodes. TokenCount is set to one at
      * the end of the polling process.
      */
     protected int tokenCount;
 
-    protected int maxMaster = Constants.MAX_MASTER;
+    protected int maxManager = Constants.MAX_MANAGER;
 
     protected int maxInfoFrames = Constants.MAX_INFO_FRAMES;
 
     protected int usageTimeout = Constants.USAGE_TIMEOUT;
 
-    protected MasterNodeState state;
+    protected ManagerNodeState state;
 
     protected long replyDeadline;
     protected Frame replyFrame;
@@ -96,12 +96,12 @@ public class MasterNode extends MstpNode {
      */
     private boolean receivedToken;
 
-    public MasterNode(SerialPortWrapper wrapper, byte thisStation, int retryCount) throws IllegalArgumentException {
+    public ManagerNode(SerialPortWrapper wrapper, byte thisStation, int retryCount) throws IllegalArgumentException {
         super(wrapper, thisStation);
         validate(retryCount);
     }
 
-    public MasterNode(String portId, InputStream in, OutputStream out, byte thisStation, int retryCount)
+    public ManagerNode(String portId, InputStream in, OutputStream out, byte thisStation, int retryCount)
             throws IllegalArgumentException {
         super(portId, in, out, thisStation);
         validate(retryCount);
@@ -117,14 +117,14 @@ public class MasterNode extends MstpNode {
         nextStation = thisStation;
         pollStation = thisStation;
         tokenCount = Constants.POLL;
-        soleMaster = false;
-        state = MasterNodeState.idle;
+        soleManager = false;
+        state = ManagerNodeState.idle;
     }
 
-    public void setMaxMaster(int maxMaster) {
-        if (maxMaster > Constants.MAX_MASTER)
-            throw new IllegalArgumentException("Cannot be greater than " + Constants.MAX_MASTER);
-        this.maxMaster = maxMaster;
+    public void setMaxManager(int maxManager) {
+        if (maxManager > Constants.MAX_MANAGER)
+            throw new IllegalArgumentException("Cannot be greater than " + Constants.MAX_MANAGER);
+        this.maxManager = maxManager;
     }
 
     /**
@@ -155,7 +155,7 @@ public class MasterNode extends MstpNode {
         super.initialize(transport);
 
         transport.getLocalDevice().getDeviceObject().writePropertyInternal(PropertyIdentifier.maxManager,
-                new UnsignedInteger(maxMaster));
+                new UnsignedInteger(maxManager));
         transport.getLocalDevice().getDeviceObject().writePropertyInternal(PropertyIdentifier.maxInfoFrames,
                 new UnsignedInteger(maxInfoFrames));
     }
@@ -174,7 +174,7 @@ public class MasterNode extends MstpNode {
     @Override
     public void setReplyFrame(FrameType type, byte destination, byte[] data) {
         synchronized (this) {
-            if (state == MasterNodeState.answerDataRequest)
+            if (state == ManagerNodeState.answerDataRequest)
                 // If there is still time to reply immediately...
                 replyFrame = new Frame(type, destination, thisStation, data);
             else
@@ -187,28 +187,28 @@ public class MasterNode extends MstpNode {
     protected void doCycle() {
         readFrame();
 
-        if (state == MasterNodeState.idle)
+        if (state == ManagerNodeState.idle)
             idle();
 
-        if (state == MasterNodeState.useToken)
+        if (state == ManagerNodeState.useToken)
             useToken();
 
-        if (state == MasterNodeState.waitForReply)
+        if (state == ManagerNodeState.waitForReply)
             waitForReply();
 
-        if (state == MasterNodeState.doneWithToken)
+        if (state == ManagerNodeState.doneWithToken)
             doneWithToken();
 
-        if (state == MasterNodeState.passToken)
+        if (state == ManagerNodeState.passToken)
             passToken();
 
-        if (state == MasterNodeState.noToken)
+        if (state == ManagerNodeState.noToken)
             noToken();
 
-        if (state == MasterNodeState.pollForMaster)
-            pollForMaster();
+        if (state == ManagerNodeState.pollForManager)
+            pollForManager();
 
-        if (state == MasterNodeState.answerDataRequest)
+        if (state == ManagerNodeState.answerDataRequest)
             answerDataRequest();
     }
 
@@ -218,7 +218,7 @@ public class MasterNode extends MstpNode {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("idle:LostToken");
             }
-            state = MasterNodeState.noToken;
+            state = ManagerNodeState.noToken;
             activity = true;
         } else if (receivedInvalidFrame != null) {
             // ReceivedInvalidFrame
@@ -247,21 +247,21 @@ public class MasterNode extends MstpNode {
             // Test_Request, or a proprietary type that expects a reply.
             LOG.debug("{} idle:ReceivedUnwantedFrame Frame type should not be broadcast: {}", thisStation, type);
         } else if (frame.forStation(thisStation)
-                && type.oneOf(FrameType.replyToPollForMaster, FrameType.replyPostponed)) {
+                && type.oneOf(FrameType.replyToPollForManager, FrameType.replyPostponed)) {
             // ReceivedUnwantedFrame (d): DestinationAddress equals TS and FrameType is
-            // Reply To Poll For Master or Reply Postponed.
+            // Reply To Poll For Manager or Reply Postponed.
             LOG.debug("{} idle:ReceivedUnwantedFrame Unexpected reply frame: {}", thisStation, type);
         } else if (frame.forStation(thisStation) && type == FrameType.token) {
             // ReceivedToken
             receivedToken = true;
             LOG.debug("idle:ReceivedToken ({})", frame.getSourceAddress());
             frameCount = 0;
-            soleMaster = false;
-            state = MasterNodeState.useToken;
-        } else if (frame.forStation(thisStation) && type == FrameType.pollForMaster) {
+            soleManager = false;
+            state = ManagerNodeState.useToken;
+        } else if (frame.forStation(thisStation) && type == FrameType.pollForManager) {
             // ReceivedPFM
             LOG.debug("idle:ReceivedPFM ({})", frame.getSourceAddress());
-            sendFrame(FrameType.replyToPollForMaster, frame.getSourceAddress());
+            sendFrame(FrameType.replyToPollForManager, frame.getSourceAddress());
         } else if (frame.forStationOrBroadcast(thisStation)
                 && type.oneOf(FrameType.bacnetDataNotExpectingReply, FrameType.testResponse)) {
             // ReceivedDataNoReply
@@ -272,7 +272,7 @@ public class MasterNode extends MstpNode {
             // ReceivedDataNeedingReply
             LOG.debug("idle:ReceivedDataNeedingReply ({})", frame.getSourceAddress());
             receivedDataNeedingReply(frame);
-            state = MasterNodeState.answerDataRequest;
+            state = ManagerNodeState.answerDataRequest;
             replyDeadline = lastNonSilence + Constants.REPLY_DELAY;
         } else {
             // ReceivedUnwantedFrame (a): DestinationAddress is neither TS nor broadcast, or any
@@ -292,17 +292,17 @@ public class MasterNode extends MstpNode {
         if (frameToSend == null) {
             // NothingToSend
             frameCount = maxInfoFrames;
-            state = MasterNodeState.doneWithToken;
+            state = ManagerNodeState.doneWithToken;
         } else {
             activity = true;
             if (frameToSend.getFrameType().oneOf(FrameType.testResponse, FrameType.bacnetDataNotExpectingReply)) {
                 // SendNoWait
                 LOG.debug("useToken:SendNoWait ({})", frameToSend.getDestinationAddress());
-                state = MasterNodeState.doneWithToken;
+                state = ManagerNodeState.doneWithToken;
             } else if (frameToSend.getFrameType().oneOf(FrameType.testRequest, FrameType.bacnetDataExpectingReply)) {
                 // SendAndWait
                 LOG.debug("useToken:SendAndWait ({})", frameToSend.getDestinationAddress());
-                state = MasterNodeState.waitForReply;
+                state = ManagerNodeState.waitForReply;
             } else {
                 throw new RuntimeException("Unhandled frame type: " + frameToSend.getFrameType());
             }
@@ -317,12 +317,12 @@ public class MasterNode extends MstpNode {
             // ReplyTimeout - assume that the request has failed
             LOG.debug("waitForReply:ReplyTimeout");
             frameCount = maxInfoFrames;
-            state = MasterNodeState.doneWithToken;
+            state = ManagerNodeState.doneWithToken;
         } else if (receivedInvalidFrame != null) {
             // InvalidFrame
             LOG.debug("waitForReply:InvalidFrame: {} ({})", receivedInvalidFrame, frame.getSourceAddress());
             receivedInvalidFrame = null;
-            state = MasterNodeState.doneWithToken;
+            state = ManagerNodeState.doneWithToken;
             activity = true;
         } else if (receivedValidFrame) {
             activity = true;
@@ -339,13 +339,13 @@ public class MasterNode extends MstpNode {
                     // The reply to the message has been postponed until a later time.
                 }
 
-                state = MasterNodeState.doneWithToken;
+                state = ManagerNodeState.doneWithToken;
             } else if (!type.oneOf(FrameType.testResponse, FrameType.bacnetDataNotExpectingReply)) {
                 // ReceivedUnexpectedFrame
                 LOG.debug("{} waitForReply:ReceivedUnexpectedFrame ({})", thisStation, frame.getSourceAddress());
 
                 // This may indicate the presence of multiple tokens.
-                state = MasterNodeState.idle;
+                state = ManagerNodeState.idle;
             }
 
             receivedValidFrame = false;
@@ -353,7 +353,7 @@ public class MasterNode extends MstpNode {
     }
 
     /**
-     * The DONE_WITH_TOKEN state either sends another data frame, passes the token, or initiates a Poll For Master
+     * The DONE_WITH_TOKEN state either sends another data frame, passes the token, or initiates a Poll For Manager
      * cycle.
      */
     private void doneWithToken() {
@@ -361,36 +361,36 @@ public class MasterNode extends MstpNode {
         if (frameCount < maxInfoFrames) {
             // SendAnotherFrame
             LOG.debug("{} doneWithToken:SendAnotherFrame", thisStation);
-            state = MasterNodeState.useToken;
-        } else if (!soleMaster && nextStation == thisStation) {
+            state = ManagerNodeState.useToken;
+        } else if (!soleManager && nextStation == thisStation) {
             // NextStationUnknown
             pollStation = adjacentStation(thisStation);
             LOG.debug("{} doneWithToken:NextStationUnknown [{}]", thisStation, pollStation);
-            sendFrame(FrameType.pollForMaster, pollStation);
+            sendFrame(FrameType.pollForManager, pollStation);
             retryCount = 0;
-            state = MasterNodeState.pollForMaster;
-        } else if (tokenCount < Constants.POLL - 1 && soleMaster) {
-            // SoleMaster
-            LOG.debug("{} doneWithToken:SoleMaster", thisStation);
+            state = ManagerNodeState.pollForManager;
+        } else if (tokenCount < Constants.POLL - 1 && soleManager) {
+            // SoleManager
+            LOG.debug("{} doneWithToken:SoleManager", thisStation);
             frameCount = 0;
             tokenCount++;
-            state = MasterNodeState.useToken;
-        } else if (tokenCount < Constants.POLL - 1 && !soleMaster || nextStation == adjacentStation(thisStation)) {
+            state = ManagerNodeState.useToken;
+        } else if (tokenCount < Constants.POLL - 1 && !soleManager || nextStation == adjacentStation(thisStation)) {
             // SendToken
             LOG.debug("{} doneWithToken:SendToken [{}]", thisStation, nextStation);
             tokenCount++;
             sendFrame(FrameType.token, nextStation);
             retryCount = 0;
             eventCount = 0;
-            state = MasterNodeState.passToken;
+            state = ManagerNodeState.passToken;
         } else if (tokenCount >= Constants.POLL - 1 && adjacentStation(pollStation) != nextStation) {
             // SendMaintenancePFM
             pollStation = adjacentStation(pollStation);
             LOG.debug("{} doneWithToken:SendMaintenancePFM [{}]", thisStation, pollStation);
-            sendFrame(FrameType.pollForMaster, pollStation);
+            sendFrame(FrameType.pollForManager, pollStation);
             retryCount = 0;
-            state = MasterNodeState.pollForMaster;
-        } else if (tokenCount >= Constants.POLL - 1 && adjacentStation(pollStation) == nextStation && !soleMaster) {
+            state = ManagerNodeState.pollForManager;
+        } else if (tokenCount >= Constants.POLL - 1 && adjacentStation(pollStation) == nextStation && !soleManager) {
             // ResetMaintenancePFM
             LOG.debug("{} doneWithToken:ResetMaintenancePFM [{}]", thisStation, nextStation);
             pollStation = thisStation;
@@ -398,17 +398,17 @@ public class MasterNode extends MstpNode {
             retryCount = 0;
             eventCount = 0;
             tokenCount = 1;
-            state = MasterNodeState.passToken;
-        } else if (tokenCount >= Constants.POLL - 1 && adjacentStation(pollStation) == nextStation && soleMaster) {
-            // SoleMasterRestartMaintenancePFM
+            state = ManagerNodeState.passToken;
+        } else if (tokenCount >= Constants.POLL - 1 && adjacentStation(pollStation) == nextStation && soleManager) {
+            // SoleManagerRestartMaintenancePFM
             pollStation = adjacentStation(nextStation);
-            LOG.debug("{} doneWithToken:SoleMasterRestartMaintenancePFM [{}]", thisStation, pollStation);
-            sendFrame(FrameType.pollForMaster, pollStation);
+            LOG.debug("{} doneWithToken:SoleManagerRestartMaintenancePFM [{}]", thisStation, pollStation);
+            sendFrame(FrameType.pollForManager, pollStation);
             nextStation = thisStation;
             retryCount = 0;
             eventCount = 0;
             tokenCount = 1;
-            state = MasterNodeState.pollForMaster;
+            state = ManagerNodeState.pollForManager;
         }
     }
 
@@ -420,7 +420,7 @@ public class MasterNode extends MstpNode {
         if (silence() < usageTimeout && eventCount > Constants.MIN_OCTETS) {
             // SawTokenUser
             LOG.debug("{} passToken:SawTokenUser", thisStation);
-            state = MasterNodeState.idle;
+            state = ManagerNodeState.idle;
         } else if (silence() >= usageTimeout && retryCount < Constants.RETRY_TOKEN) {
             // RetrySendToken
             LOG.debug("{} passToken:RetrySendToken [{}]", thisStation, nextStation);
@@ -431,12 +431,12 @@ public class MasterNode extends MstpNode {
             // FindNewSuccessor
             pollStation = adjacentStation(nextStation);
             LOG.debug("{} passToken:FindNewSuccessor trying [{}]", thisStation, pollStation);
-            sendFrame(FrameType.pollForMaster, pollStation);
+            sendFrame(FrameType.pollForManager, pollStation);
             nextStation = thisStation;
             retryCount = 0;
             tokenCount = 0;
             eventCount = 0;
-            state = MasterNodeState.pollForMaster;
+            state = ManagerNodeState.pollForManager;
         }
     }
 
@@ -451,34 +451,34 @@ public class MasterNode extends MstpNode {
         if (silence < delay && eventCount > Constants.MIN_OCTETS) {
             // SawFrame
             LOG.debug("{} noToken:SawFrame", thisStation);
-            state = MasterNodeState.idle;
+            state = ManagerNodeState.idle;
             activity = true;
-        } else if (silence >= delay && silence < delay + Constants.SLOT // Silence is in this master's slot.
+        } else if (silence >= delay && silence < delay + Constants.SLOT // Silence is in this manager's slot.
                 // Silence is beyond all slots.
-                || silence > Constants.NO_TOKEN + Constants.SLOT * (maxMaster + 1L)) {
+                || silence > Constants.NO_TOKEN + Constants.SLOT * (maxManager + 1L)) {
             // GenerateToken
             pollStation = adjacentStation(thisStation);
             LOG.debug("{} noToken:GenerateToken [{}]", thisStation, pollStation);
-            sendFrame(FrameType.pollForMaster, pollStation);
+            sendFrame(FrameType.pollForManager, pollStation);
             nextStation = thisStation;
             tokenCount = 0;
             retryCount = 0;
             eventCount = 0;
-            state = MasterNodeState.pollForMaster;
+            state = ManagerNodeState.pollForManager;
             activity = true;
         }
     }
 
     /**
-     * In the POLL_FOR_MASTER state, the node listens for a reply to a previously sent Poll For Master frame in order to
+     * In the POLL_FOR_MANAGER state, the node listens for a reply to a previously sent Poll For Manager frame in order to
      * find a successor node.
      */
-    private void pollForMaster() {
+    private void pollForManager() {
         if (receivedValidFrame) {
-            if (frame.forStation(thisStation) && frame.getFrameType() == FrameType.replyToPollForMaster) {
+            if (frame.forStation(thisStation) && frame.getFrameType() == FrameType.replyToPollForManager) {
                 // ReceivedReplyToPFM
-                LOG.debug("{} pollForMaster:ReceivedReplyToPFM ({})", thisStation, frame.getSourceAddress());
-                soleMaster = false;
+                LOG.debug("{} pollForManager:ReceivedReplyToPFM ({})", thisStation, frame.getSourceAddress());
+                soleManager = false;
                 nextStation = frame.getSourceAddress();
                 eventCount = 0;
                 sendFrame(FrameType.token, nextStation);
@@ -486,49 +486,49 @@ public class MasterNode extends MstpNode {
                 tokenCount = 0;
                 retryCount = 0;
                 receivedValidFrame = false;
-                state = MasterNodeState.passToken;
+                state = ManagerNodeState.passToken;
             } else {
                 // ReceivedUnexpectedFrame
-                LOG.debug("{} pollForMaster:ReceivedUnexpectedFrame ({})", thisStation, frame.getSourceAddress());
+                LOG.debug("{} pollForManager:ReceivedUnexpectedFrame ({})", thisStation, frame.getSourceAddress());
                 receivedValidFrame = false;
-                state = MasterNodeState.idle;
+                state = ManagerNodeState.idle;
             }
             activity = true;
-        } else if (soleMaster && (silence() >= usageTimeout || receivedInvalidFrame != null)) {
-            // SoleMaster
-            LOG.debug("{} pollForMaster:SoleMaster", thisStation);
+        } else if (soleManager && (silence() >= usageTimeout || receivedInvalidFrame != null)) {
+            // SoleManager
+            LOG.debug("{} pollForManager:SoleManager", thisStation);
             frameCount = 0;
             receivedInvalidFrame = null;
-            state = MasterNodeState.useToken;
+            state = ManagerNodeState.useToken;
             activity = true;
-        } else if (!soleMaster) {
+        } else if (!soleManager) {
             boolean longCondition = silence() >= usageTimeout || receivedInvalidFrame != null;
             if (nextStation != thisStation && longCondition) {
                 // DoneWithPFM
-                LOG.debug("{} pollForMaster:DoneWithPFM [{}]", thisStation, nextStation);
+                LOG.debug("{} pollForManager:DoneWithPFM [{}]", thisStation, nextStation);
                 eventCount = 0;
                 sendFrame(FrameType.token, nextStation);
                 retryCount = 0;
                 receivedInvalidFrame = null;
-                state = MasterNodeState.passToken;
+                state = ManagerNodeState.passToken;
                 activity = true;
             } else if (nextStation == thisStation) {
                 if (adjacentStation(pollStation) != thisStation && longCondition) {
                     // SendNextPFM
                     pollStation = adjacentStation(pollStation);
-                    LOG.debug("{} pollForMaster:SendNextPFM [{}]", thisStation, pollStation);
-                    sendFrame(FrameType.pollForMaster, pollStation);
+                    LOG.debug("{} pollForManager:SendNextPFM [{}]", thisStation, pollStation);
+                    sendFrame(FrameType.pollForManager, pollStation);
                     retryCount = 0;
                     receivedInvalidFrame = null;
                     activity = true;
                 } else if (adjacentStation(pollStation) == thisStation && longCondition) {
-                    // DeclareSoleMaster
+                    // DeclareSoleManager
                     receivedToken = true;
-                    LOG.debug("{} pollForMaster:DeclareSoleMaster", thisStation);
-                    soleMaster = true;
+                    LOG.debug("{} pollForManager:DeclareSoleManager", thisStation);
+                    soleManager = true;
                     frameCount = 0;
                     receivedInvalidFrame = null;
-                    state = MasterNodeState.useToken;
+                    state = ManagerNodeState.useToken;
                     activity = true;
                 }
             }
@@ -546,7 +546,7 @@ public class MasterNode extends MstpNode {
                 LOG.debug("{} answerDataRequest:Reply", thisStation);
                 sendFrame(replyFrame);
                 replyFrame = null;
-                state = MasterNodeState.idle;
+                state = ManagerNodeState.idle;
                 activity = true;
             } else {
                 long now = clock.millis();
@@ -554,7 +554,7 @@ public class MasterNode extends MstpNode {
                     // DeferredReply
                     LOG.debug("{} answerDataRequest:DeferredReply ({})", thisStation, frame.getSourceAddress());
                     sendFrame(FrameType.replyPostponed, frame.getSourceAddress());
-                    state = MasterNodeState.idle;
+                    state = ManagerNodeState.idle;
                     activity = true;
                 } else {
                     // If the current time of the host was moved back, the above condition could cause an indefinite
@@ -571,7 +571,7 @@ public class MasterNode extends MstpNode {
 
     private byte adjacentStation(byte station) {
         int i = station & 0xff;
-        i = (i + 1) % (maxMaster + 1);
+        i = (i + 1) % (maxManager + 1);
         return (byte) i;
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/npdu/mstp/MasterNode.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/mstp/MasterNode.java
@@ -96,22 +96,19 @@ public class MasterNode extends MstpNode {
      */
     private boolean receivedToken;
 
-    //    private long lastTokenPossession;
-
-    public MasterNode(final SerialPortWrapper wrapper, final byte thisStation, final int retryCount)
-            throws IllegalArgumentException {
+    public MasterNode(SerialPortWrapper wrapper, byte thisStation, int retryCount) throws IllegalArgumentException {
         super(wrapper, thisStation);
         validate(retryCount);
     }
 
-    public MasterNode(final String portId, final InputStream in, final OutputStream out, final byte thisStation,
-            final int retryCount) throws IllegalArgumentException {
+    public MasterNode(String portId, InputStream in, OutputStream out, byte thisStation, int retryCount)
+            throws IllegalArgumentException {
         super(portId, in, out, thisStation);
         validate(retryCount);
     }
 
-    protected void validate(final int retryCount) {
-        final int is = thisStation & 0xff;
+    protected void validate(int retryCount) {
+        int is = thisStation & 0xff;
         if (is > 127)
             throw new IllegalArgumentException("thisStation cannot be greater than 127");
 
@@ -124,7 +121,7 @@ public class MasterNode extends MstpNode {
         state = MasterNodeState.idle;
     }
 
-    public void setMaxMaster(final int maxMaster) {
+    public void setMaxMaster(int maxMaster) {
         if (maxMaster > Constants.MAX_MASTER)
             throw new IllegalArgumentException("Cannot be greater than " + Constants.MAX_MASTER);
         this.maxMaster = maxMaster;
@@ -133,18 +130,18 @@ public class MasterNode extends MstpNode {
     /**
      * @param maxInfoFrames the maxInfoFrames to set
      */
-    public void setMaxInfoFrames(final int maxInfoFrames) {
+    public void setMaxInfoFrames(int maxInfoFrames) {
         if (maxInfoFrames < 1)
             throw new IllegalArgumentException("Cannot be less than 1");
         this.maxInfoFrames = maxInfoFrames;
     }
 
-    public void setUsageTimeout(final int usageTimeout) {
+    public void setUsageTimeout(int usageTimeout) {
         if (usageTimeout < 20) {
             throw new IllegalArgumentException("Cannot be less than 20");
         }
-        if (usageTimeout > 100) {
-            throw new IllegalArgumentException("Cannot be greater than 100");
+        if (usageTimeout > 35) {
+            throw new IllegalArgumentException("Cannot be greater than 35");
         }
         this.usageTimeout = usageTimeout;
     }
@@ -154,7 +151,7 @@ public class MasterNode extends MstpNode {
     }
 
     @Override
-    public void initialize(final Transport transport) throws Exception {
+    public void initialize(Transport transport) throws Exception {
         super.initialize(transport);
 
         transport.getLocalDevice().getDeviceObject().writePropertyInternal(PropertyIdentifier.maxManager,
@@ -163,19 +160,19 @@ public class MasterNode extends MstpNode {
                 new UnsignedInteger(maxInfoFrames));
     }
 
-    public void queueFrame(final FrameType type, final byte destination, final byte[] data) {
+    public void queueFrame(FrameType type, byte destination, byte[] data) {
         if (!type.oneOf(FrameType.bacnetDataExpectingReply, FrameType.bacnetDataNotExpectingReply,
                 FrameType.testRequest))
             throw new RuntimeException("Cannot send frame of type: " + type);
 
-        final Frame frame = new Frame(type, destination, thisStation, data);
+        Frame frame = new Frame(type, destination, thisStation, data);
         synchronized (framesToSend) {
             framesToSend.add(frame);
         }
     }
 
     @Override
-    public void setReplyFrame(final FrameType type, final byte destination, final byte[] data) {
+    public void setReplyFrame(FrameType type, byte destination, byte[] data) {
         synchronized (this) {
             if (state == MasterNodeState.answerDataRequest)
                 // If there is still time to reply immediately...
@@ -225,9 +222,7 @@ public class MasterNode extends MstpNode {
             activity = true;
         } else if (receivedInvalidFrame != null) {
             // ReceivedInvalidFrame
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("idle:Received invalid frame: " + receivedInvalidFrame);
-            }
+            LOG.debug("idle:Received invalid frame: {}", receivedInvalidFrame);
             receivedInvalidFrame = null;
             activity = true;
         } else if (receivedValidFrame) {
@@ -241,66 +236,57 @@ public class MasterNode extends MstpNode {
     }
 
     protected void frame() {
-        final FrameType type = frame.getFrameType();
+        FrameType type = frame.getFrameType();
 
         if (type == null) {
-            // ReceivedUnwantedFrame
-            if (LOG.isDebugEnabled())
-                LOG.debug(thisStation + " idle:Unknown frame type");
+            // ReceivedUnwantedFrame (c): FrameType has a value that is not known to this node.
+            LOG.debug("{} idle:ReceivedUnwantedFrame Unknown frame type", thisStation);
         } else if (frame.broadcast()
-                && type.oneOf(FrameType.token, FrameType.bacnetDataExpectingReply, FrameType.testRequest)) {
-            // ReceivedUnwantedFrame
-            if (LOG.isDebugEnabled())
-                LOG.debug("idle:ReceiveUnwantedFrame Frame type should not be broadcast: " + type);
+                && type.oneOf(FrameType.token, FrameType.testRequest, FrameType.bacnetDataExpectingReply)) {
+            // ReceivedUnwantedFrame (b): DestinationAddress is broadcast and FrameType is Token,
+            // Test_Request, or a proprietary type that expects a reply.
+            LOG.debug("{} idle:ReceivedUnwantedFrame Frame type should not be broadcast: {}", thisStation, type);
+        } else if (frame.forStation(thisStation)
+                && type.oneOf(FrameType.replyToPollForMaster, FrameType.replyPostponed)) {
+            // ReceivedUnwantedFrame (d): DestinationAddress equals TS and FrameType is
+            // Reply To Poll For Master or Reply Postponed.
+            LOG.debug("{} idle:ReceivedUnwantedFrame Unexpected reply frame: {}", thisStation, type);
         } else if (frame.forStation(thisStation) && type == FrameType.token) {
             // ReceivedToken
             receivedToken = true;
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("idle:ReceivedToken (" + frame.getSourceAddress() + ")");
-            }
+            LOG.debug("idle:ReceivedToken ({})", frame.getSourceAddress());
             frameCount = 0;
             soleMaster = false;
             state = MasterNodeState.useToken;
-            //
-            //            long now = clock.millis();
-            //            if (lastTokenPossession > 0)
-            //                debug("Since last token possession: " + (now - lastTokenPossession) + " ms");
-            //            else
-            //                debug("Received first token possession");
-            //            lastTokenPossession = now;
         } else if (frame.forStation(thisStation) && type == FrameType.pollForMaster) {
             // ReceivedPFM
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("idle:ReceivedPFM (" + frame.getSourceAddress() + ")");
-            }
+            LOG.debug("idle:ReceivedPFM ({})", frame.getSourceAddress());
             sendFrame(FrameType.replyToPollForMaster, frame.getSourceAddress());
         } else if (frame.forStationOrBroadcast(thisStation)
                 && type.oneOf(FrameType.bacnetDataNotExpectingReply, FrameType.testResponse)) {
             // ReceivedDataNoReply
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("idle:ReceivedDataNoReply (" + frame.getSourceAddress() + ")");
-            }
+            LOG.debug("idle:ReceivedDataNoReply ({})", frame.getSourceAddress());
             receivedDataNoReply(frame);
         } else if (frame.forStation(thisStation)
                 && type.oneOf(FrameType.bacnetDataExpectingReply, FrameType.testRequest)) {
             // ReceivedDataNeedingReply
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("idle:ReceivedDataNeedingReply (" + frame.getSourceAddress() + ")");
-            }
+            LOG.debug("idle:ReceivedDataNeedingReply ({})", frame.getSourceAddress());
             receivedDataNeedingReply(frame);
             state = MasterNodeState.answerDataRequest;
             replyDeadline = lastNonSilence + Constants.REPLY_DELAY;
         } else {
-            if (LOG.isDebugEnabled())
-                LOG.debug(thisStation + " idle:frame-other");
+            // ReceivedUnwantedFrame (a): DestinationAddress is neither TS nor broadcast, or any
+            // other frame not addressed to this node in a way this state handles.
+            LOG.debug("{} idle:ReceivedUnwantedFrame", thisStation);
         }
     }
 
     protected void useToken() {
         Frame frameToSend = null;
         synchronized (framesToSend) {
-            if (!framesToSend.isEmpty())
+            if (!framesToSend.isEmpty()) {
                 frameToSend = framesToSend.remove(0);
+            }
         }
 
         if (frameToSend == null) {
@@ -311,18 +297,15 @@ public class MasterNode extends MstpNode {
             activity = true;
             if (frameToSend.getFrameType().oneOf(FrameType.testResponse, FrameType.bacnetDataNotExpectingReply)) {
                 // SendNoWait
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("useToken:SendNoWait (" + frameToSend.getDestinationAddress() + ")");
-                }
+                LOG.debug("useToken:SendNoWait ({})", frameToSend.getDestinationAddress());
                 state = MasterNodeState.doneWithToken;
             } else if (frameToSend.getFrameType().oneOf(FrameType.testRequest, FrameType.bacnetDataExpectingReply)) {
                 // SendAndWait
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("useToken:SendAndWait (" + frameToSend.getDestinationAddress() + ")");
-                }
+                LOG.debug("useToken:SendAndWait ({})", frameToSend.getDestinationAddress());
                 state = MasterNodeState.waitForReply;
-            } else
+            } else {
                 throw new RuntimeException("Unhandled frame type: " + frameToSend.getFrameType());
+            }
 
             sendFrame(frameToSend);
             frameCount++;
@@ -332,44 +315,34 @@ public class MasterNode extends MstpNode {
     protected void waitForReply() {
         if (silence() > Constants.REPLY_TIMEOUT) {
             // ReplyTimeout - assume that the request has failed
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("waitForReply:ReplyTimeout");
-            }
+            LOG.debug("waitForReply:ReplyTimeout");
             frameCount = maxInfoFrames;
             state = MasterNodeState.doneWithToken;
         } else if (receivedInvalidFrame != null) {
             // InvalidFrame
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("waitForReply:InvalidFrame: " + receivedInvalidFrame + "(" + frame.getSourceAddress() + ")");
-            }
+            LOG.debug("waitForReply:InvalidFrame: {} ({})", receivedInvalidFrame, frame.getSourceAddress());
             receivedInvalidFrame = null;
             state = MasterNodeState.doneWithToken;
             activity = true;
         } else if (receivedValidFrame) {
             activity = true;
-            final FrameType type = frame.getFrameType();
+            FrameType type = frame.getFrameType();
 
             if (frame.forStation(thisStation)) {
                 if (type.oneOf(FrameType.testResponse, FrameType.bacnetDataNotExpectingReply)) {
                     // ReceivedReply
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug(thisStation + " waitForReply:ReceivedReply (" + frame.getSourceAddress() + ")");
-                    }
+                    LOG.debug("{} waitForReply:ReceivedReply ({})", thisStation, frame.getSourceAddress());
                     receivedDataNoReply(frame);
                 } else if (type.oneOf(FrameType.replyPostponed)) {
                     // ReceivedPostpone
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug(thisStation + " waitForReply:ReceivedPostpone (" + frame.getSourceAddress() + ")");
-                    }
+                    LOG.debug("{} waitForReply:ReceivedPostpone ({})", thisStation, frame.getSourceAddress());
                     // The reply to the message has been postponed until a later time.
                 }
 
                 state = MasterNodeState.doneWithToken;
             } else if (!type.oneOf(FrameType.testResponse, FrameType.bacnetDataNotExpectingReply)) {
                 // ReceivedUnexpectedFrame
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug(thisStation + " waitForReply:ReceivedUnexpectedFrame (" + frame.getSourceAddress() + ")");
-                }
+                LOG.debug("{} waitForReply:ReceivedUnexpectedFrame ({})", thisStation, frame.getSourceAddress());
 
                 // This may indicate the presence of multiple tokens.
                 state = MasterNodeState.idle;
@@ -387,32 +360,24 @@ public class MasterNode extends MstpNode {
         activity = true;
         if (frameCount < maxInfoFrames) {
             // SendAnotherFrame
-            if (LOG.isDebugEnabled()) {
-                LOG.debug(thisStation + " doneWithToken:SendAnotherFrame");
-            }
+            LOG.debug("{} doneWithToken:SendAnotherFrame", thisStation);
             state = MasterNodeState.useToken;
         } else if (!soleMaster && nextStation == thisStation) {
             // NextStationUnknown
             pollStation = adjacentStation(thisStation);
-            if (LOG.isDebugEnabled()) {
-                LOG.debug(thisStation + " doneWithToken:NextStationUnknown [" + pollStation + "]");
-            }
+            LOG.debug("{} doneWithToken:NextStationUnknown [{}]", thisStation, pollStation);
             sendFrame(FrameType.pollForMaster, pollStation);
             retryCount = 0;
             state = MasterNodeState.pollForMaster;
         } else if (tokenCount < Constants.POLL - 1 && soleMaster) {
             // SoleMaster
-            if (LOG.isDebugEnabled()) {
-                LOG.debug(thisStation + " doneWithToken:SoleMaster");
-            }
+            LOG.debug("{} doneWithToken:SoleMaster", thisStation);
             frameCount = 0;
             tokenCount++;
             state = MasterNodeState.useToken;
         } else if (tokenCount < Constants.POLL - 1 && !soleMaster || nextStation == adjacentStation(thisStation)) {
             // SendToken
-            if (LOG.isDebugEnabled()) {
-                LOG.debug(thisStation + " doneWithToken:SendToken [" + nextStation + "]");
-            }
+            LOG.debug("{} doneWithToken:SendToken [{}]", thisStation, nextStation);
             tokenCount++;
             sendFrame(FrameType.token, nextStation);
             retryCount = 0;
@@ -421,17 +386,13 @@ public class MasterNode extends MstpNode {
         } else if (tokenCount >= Constants.POLL - 1 && adjacentStation(pollStation) != nextStation) {
             // SendMaintenancePFM
             pollStation = adjacentStation(pollStation);
-            if (LOG.isDebugEnabled()) {
-                LOG.debug(thisStation + " doneWithToken:SendMaintenancePFM [" + pollStation + "]");
-            }
+            LOG.debug("{} doneWithToken:SendMaintenancePFM [{}]", thisStation, pollStation);
             sendFrame(FrameType.pollForMaster, pollStation);
             retryCount = 0;
             state = MasterNodeState.pollForMaster;
         } else if (tokenCount >= Constants.POLL - 1 && adjacentStation(pollStation) == nextStation && !soleMaster) {
             // ResetMaintenancePFM
-            if (LOG.isDebugEnabled()) {
-                LOG.debug(thisStation + " doneWithToken:ResetMaintenancePFM [" + nextStation + "]");
-            }
+            LOG.debug("{} doneWithToken:ResetMaintenancePFM [{}]", thisStation, nextStation);
             pollStation = thisStation;
             sendFrame(FrameType.token, nextStation);
             retryCount = 0;
@@ -441,9 +402,7 @@ public class MasterNode extends MstpNode {
         } else if (tokenCount >= Constants.POLL - 1 && adjacentStation(pollStation) == nextStation && soleMaster) {
             // SoleMasterRestartMaintenancePFM
             pollStation = adjacentStation(nextStation);
-            if (LOG.isDebugEnabled()) {
-                LOG.debug(thisStation + " doneWithToken:SoleMasterRestartMaintenancePFM [" + pollStation + "]");
-            }
+            LOG.debug("{} doneWithToken:SoleMasterRestartMaintenancePFM [{}]", thisStation, pollStation);
             sendFrame(FrameType.pollForMaster, pollStation);
             nextStation = thisStation;
             retryCount = 0;
@@ -460,22 +419,18 @@ public class MasterNode extends MstpNode {
         activity = true;
         if (silence() < usageTimeout && eventCount > Constants.MIN_OCTETS) {
             // SawTokenUser
-            if (LOG.isDebugEnabled())
-                LOG.debug(thisStation + " passToken:SawTokenUser");
+            LOG.debug("{} passToken:SawTokenUser", thisStation);
             state = MasterNodeState.idle;
         } else if (silence() >= usageTimeout && retryCount < Constants.RETRY_TOKEN) {
             // RetrySendToken
-            if (LOG.isDebugEnabled())
-                LOG.debug(thisStation + " passToken:RetrySendToken [" + nextStation + "]");
+            LOG.debug("{} passToken:RetrySendToken [{}]", thisStation, nextStation);
             retryCount++;
             sendFrame(FrameType.token, nextStation);
             eventCount = 0;
         } else if (silence() >= usageTimeout && retryCount >= Constants.RETRY_TOKEN) {
             // FindNewSuccessor
             pollStation = adjacentStation(nextStation);
-            if (LOG.isDebugEnabled()) {
-                LOG.debug(thisStation + " passToken:FindNewSuccessor trying [" + pollStation + "]");
-            }
+            LOG.debug("{} passToken:FindNewSuccessor trying [{}]", thisStation, pollStation);
             sendFrame(FrameType.pollForMaster, pollStation);
             nextStation = thisStation;
             retryCount = 0;
@@ -491,22 +446,19 @@ public class MasterNode extends MstpNode {
      * create a token.
      */
     private void noToken() {
-        final long silence = silence();
-        final long delay = Constants.NO_TOKEN + Constants.SLOT * (thisStation & 0xff);
+        long silence = silence();
+        long delay = Constants.NO_TOKEN + Constants.SLOT * (thisStation & 0xffL);
         if (silence < delay && eventCount > Constants.MIN_OCTETS) {
             // SawFrame
-            if (LOG.isDebugEnabled())
-                LOG.debug(thisStation + " noToken:SawFrame");
+            LOG.debug("{} noToken:SawFrame", thisStation);
             state = MasterNodeState.idle;
             activity = true;
         } else if (silence >= delay && silence < delay + Constants.SLOT // Silence is in this master's slot.
                 // Silence is beyond all slots.
-                || silence > Constants.NO_TOKEN + Constants.SLOT * (maxMaster + 1)) {
+                || silence > Constants.NO_TOKEN + Constants.SLOT * (maxMaster + 1L)) {
             // GenerateToken
             pollStation = adjacentStation(thisStation);
-            if (LOG.isDebugEnabled()) {
-                LOG.debug(thisStation + " noToken:GenerateToken [" + pollStation + "]");
-            }
+            LOG.debug("{} noToken:GenerateToken [{}]", thisStation, pollStation);
             sendFrame(FrameType.pollForMaster, pollStation);
             nextStation = thisStation;
             tokenCount = 0;
@@ -525,9 +477,7 @@ public class MasterNode extends MstpNode {
         if (receivedValidFrame) {
             if (frame.forStation(thisStation) && frame.getFrameType() == FrameType.replyToPollForMaster) {
                 // ReceivedReplyToPFM
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug(thisStation + " pollForMaster:ReceivedReplyToPFM (" + frame.getSourceAddress() + ")");
-                }
+                LOG.debug("{} pollForMaster:ReceivedReplyToPFM ({})", thisStation, frame.getSourceAddress());
                 soleMaster = false;
                 nextStation = frame.getSourceAddress();
                 eventCount = 0;
@@ -539,30 +489,23 @@ public class MasterNode extends MstpNode {
                 state = MasterNodeState.passToken;
             } else {
                 // ReceivedUnexpectedFrame
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug(
-                            thisStation + " pollForMaster:ReceivedUnexpectedFrame (" + frame.getSourceAddress() + ")");
-                }
+                LOG.debug("{} pollForMaster:ReceivedUnexpectedFrame ({})", thisStation, frame.getSourceAddress());
                 receivedValidFrame = false;
                 state = MasterNodeState.idle;
             }
             activity = true;
         } else if (soleMaster && (silence() >= usageTimeout || receivedInvalidFrame != null)) {
             // SoleMaster
-            if (LOG.isDebugEnabled()) {
-                LOG.debug(thisStation + " pollForMaster:SoleMaster");
-            }
+            LOG.debug("{} pollForMaster:SoleMaster", thisStation);
             frameCount = 0;
             receivedInvalidFrame = null;
             state = MasterNodeState.useToken;
             activity = true;
         } else if (!soleMaster) {
-            final boolean longCondition = silence() >= usageTimeout || receivedInvalidFrame != null;
+            boolean longCondition = silence() >= usageTimeout || receivedInvalidFrame != null;
             if (nextStation != thisStation && longCondition) {
                 // DoneWithPFM
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug(thisStation + " pollForMaster:DoneWithPFM [" + nextStation + "]");
-                }
+                LOG.debug("{} pollForMaster:DoneWithPFM [{}]", thisStation, nextStation);
                 eventCount = 0;
                 sendFrame(FrameType.token, nextStation);
                 retryCount = 0;
@@ -573,9 +516,7 @@ public class MasterNode extends MstpNode {
                 if (adjacentStation(pollStation) != thisStation && longCondition) {
                     // SendNextPFM
                     pollStation = adjacentStation(pollStation);
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug(thisStation + " pollForMaster:SendNextPFM [" + pollStation + "]");
-                    }
+                    LOG.debug("{} pollForMaster:SendNextPFM [{}]", thisStation, pollStation);
                     sendFrame(FrameType.pollForMaster, pollStation);
                     retryCount = 0;
                     receivedInvalidFrame = null;
@@ -583,8 +524,7 @@ public class MasterNode extends MstpNode {
                 } else if (adjacentStation(pollStation) == thisStation && longCondition) {
                     // DeclareSoleMaster
                     receivedToken = true;
-                    if (LOG.isDebugEnabled())
-                        LOG.debug(thisStation + " pollForMaster:DeclareSoleMaster");
+                    LOG.debug("{} pollForMaster:DeclareSoleMaster", thisStation);
                     soleMaster = true;
                     frameCount = 0;
                     receivedInvalidFrame = null;
@@ -603,29 +543,25 @@ public class MasterNode extends MstpNode {
         synchronized (this) {
             if (replyFrame != null) {
                 // Reply
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug(thisStation + " answerDataRequest:Reply");
-                }
+                LOG.debug("{} answerDataRequest:Reply", thisStation);
                 sendFrame(replyFrame);
                 replyFrame = null;
                 state = MasterNodeState.idle;
                 activity = true;
             } else {
-                final long now = clock.millis();
+                long now = clock.millis();
                 if (replyDeadline < now) {
                     // DeferredReply
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug(thisStation + " answerDataRequest:DeferredReply (" + frame.getSourceAddress() + ")");
-                    }
+                    LOG.debug("{} answerDataRequest:DeferredReply ({})", thisStation, frame.getSourceAddress());
                     sendFrame(FrameType.replyPostponed, frame.getSourceAddress());
                     state = MasterNodeState.idle;
                     activity = true;
                 } else {
                     // If the current time of the host was moved back, the above condition could cause an indefinite
                     // wait. So, we check if the reply deadline is too long, and correct if so.
-                    final long timeDiff = replyDeadline - now;
+                    long timeDiff = replyDeadline - now;
                     if (timeDiff > Constants.REPLY_DELAY) {
-                        LOG.warn("Correcting replyDeadline time because of timeDiff of " + timeDiff);
+                        LOG.warn("Correcting replyDeadline time because of timeDiff of {}", timeDiff);
                         replyDeadline = now + Constants.REPLY_DELAY;
                     }
                 }
@@ -633,7 +569,7 @@ public class MasterNode extends MstpNode {
         }
     }
 
-    private byte adjacentStation(final byte station) {
+    private byte adjacentStation(byte station) {
         int i = station & 0xff;
         i = (i + 1) % (maxMaster + 1);
         return (byte) i;

--- a/src/main/java/com/serotonin/bacnet4j/npdu/mstp/MstpNetwork.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/mstp/MstpNetwork.java
@@ -41,11 +41,11 @@ import com.serotonin.bacnet4j.util.sero.ByteQueue;
 public class MstpNetwork extends Network {
     private final MstpNode node;
 
-    public MstpNetwork(final MstpNode node) {
+    public MstpNetwork(MstpNode node) {
         this(node, 0);
     }
 
-    public MstpNetwork(final MstpNode node, final int localNetworkNumber) {
+    public MstpNetwork(MstpNode node, int localNetworkNumber) {
         super(localNetworkNumber);
         this.node = node;
         node.setNetwork(this);
@@ -61,7 +61,7 @@ public class MstpNetwork extends Network {
     }
 
     @Override
-    public void initialize(final Transport transport) throws Exception {
+    public void initialize(Transport transport) throws Exception {
         super.initialize(transport);
         node.initialize(transport);
     }
@@ -102,26 +102,26 @@ public class MstpNetwork extends Network {
     }
 
     @Override
-    public void sendNPDU(final Address recipient, final OctetString router, final ByteQueue npdu,
-            final boolean broadcast, final boolean expectsReply) throws BACnetException {
-        final byte[] data = npdu.popAll();
+    public void sendNPDU(Address recipient, OctetString router, ByteQueue npdu, boolean broadcast, boolean expectsReply)
+            throws BACnetException {
+        byte[] data = npdu.popAll();
 
-        final OctetString dest = getDestination(recipient, router);
-        final byte mstpAddress = MstpNetworkUtils.getMstpAddress(dest);
+        OctetString dest = getDestination(recipient, router);
+        byte mstpAddress = MstpNetworkUtils.getMstpAddress(dest);
 
         if (expectsReply) {
-            if (node instanceof SlaveNode)
-                throw new RuntimeException("Cannot originate a request from a slave node");
+            if (node instanceof SubordinateNode)
+                throw new RuntimeException("Cannot originate a request from a subordinate node");
 
-            ((MasterNode) node).queueFrame(FrameType.bacnetDataExpectingReply, mstpAddress, data);
+            ((ManagerNode) node).queueFrame(FrameType.bacnetDataExpectingReply, mstpAddress, data);
         } else
             node.setReplyFrame(FrameType.bacnetDataNotExpectingReply, mstpAddress, data);
     }
 
-    public void sendTestRequest(final byte destination) {
-        if (!(node instanceof MasterNode))
-            throw new RuntimeException("Only master nodes can send test requests");
-        ((MasterNode) node).queueFrame(FrameType.testRequest, destination, null);
+    public void sendTestRequest(byte destination) {
+        if (!(node instanceof ManagerNode))
+            throw new RuntimeException("Only manager nodes can send test requests");
+        ((ManagerNode) node).queueFrame(FrameType.testRequest, destination, null);
     }
 
     //
@@ -129,13 +129,12 @@ public class MstpNetwork extends Network {
     //
     // Incoming frames
     //
-    void receivedFrame(final Frame frame) {
+    void receivedFrame(Frame frame) {
         handleIncomingData(new ByteQueue(frame.getData()), MstpNetworkUtils.toOctetString(frame.getSourceAddress()));
     }
 
     @Override
-    protected NPDU handleIncomingDataImpl(final ByteQueue queue, final OctetString linkService)
-            throws MessageValidationException {
+    protected NPDU handleIncomingDataImpl(ByteQueue queue, OctetString linkService) throws MessageValidationException {
         return parseNpduData(queue, linkService);
     }
 
@@ -143,27 +142,27 @@ public class MstpNetwork extends Network {
     //
     // Convenience methods
     //
-    public Address getAddress(final byte station) {
+    public Address getAddress(byte station) {
         return MstpNetworkUtils.toAddress(getLocalNetworkNumber(), station);
     }
 
     @Override
     public int hashCode() {
-        final int prime = 31;
+        int prime = 31;
         int result = super.hashCode();
         result = prime * result + (node == null ? 0 : node.hashCode());
         return result;
     }
 
     @Override
-    public boolean equals(final Object obj) {
+    public boolean equals(Object obj) {
         if (this == obj)
             return true;
         if (!super.equals(obj))
             return false;
         if (getClass() != obj.getClass())
             return false;
-        final MstpNetwork other = (MstpNetwork) obj;
+        MstpNetwork other = (MstpNetwork) obj;
         if (node == null) {
             if (other.node != null)
                 return false;

--- a/src/main/java/com/serotonin/bacnet4j/npdu/mstp/RealtimeManagerNode.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/mstp/RealtimeManagerNode.java
@@ -38,23 +38,19 @@ import com.serotonin.bacnet4j.npdu.mstp.realtime.RealtimeDriver;
 import com.serotonin.bacnet4j.transport.Transport;
 import com.serotonin.bacnet4j.util.sero.StreamUtils;
 
-
 /**
- * MS/TP Master node using a real-time serial driver
+ * MS/TP Manager node using a real-time serial driver
  * installed in the linux Kernel.
- *
- * @author Terry Packer
  */
-public class RealtimeMasterNode extends MasterNode {
-
+public class RealtimeManagerNode extends ManagerNode {
     private final byte thisStation;
     private final RealtimeDriver driver;
     private final int baud;
     private int responseTimeoutMs = 1000;
     private long lastFrameSendTime; //Track response timeouts
 
-    public RealtimeMasterNode(final String portId, final File driver, final File configProgram, final byte thisStation,
-            final int retryCount, final int baud, int responseTimeoutMs) throws IllegalArgumentException {
+    public RealtimeManagerNode(String portId, File driver, File configProgram, byte thisStation, int retryCount,
+            int baud, int responseTimeoutMs) throws IllegalArgumentException {
         super(portId, null, null, (byte) 0xFF, retryCount);
         this.thisStation = thisStation;
         this.baud = baud;
@@ -63,28 +59,13 @@ public class RealtimeMasterNode extends MasterNode {
     }
 
     @Override
-    protected void validate(final int retryCount) {
+    protected void validate(int retryCount) {
         this.retryCount = retryCount;
         nextStation = thisStation;
         pollStation = thisStation;
         tokenCount = Constants.POLL;
-        soleMaster = false;
-        state = MasterNodeState.idle;
-    }
-
-    @Override
-    public void setMaxMaster(final int maxMaster) {
-        super.setMaxMaster(maxMaster);
-    }
-
-    @Override
-    public void setMaxInfoFrames(final int maxInfoFrames) {
-        super.setMaxInfoFrames(maxInfoFrames);
-    }
-
-    @Override
-    public void setUsageTimeout(final int usageTimeout) {
-        super.setUsageTimeout(usageTimeout);
+        soleManager = false;
+        state = ManagerNodeState.idle;
     }
 
     public void setResponseTimeoutMs(int responseTimeoutMs) {
@@ -92,14 +73,14 @@ public class RealtimeMasterNode extends MasterNode {
     }
 
     @Override
-    public void initialize(final Transport transport) throws Exception {
+    public void initialize(Transport transport) throws Exception {
         //Setup I/O
         File file = new File(portId);
         in = new FileInputStream(file);
         out = new FileOutputStream(file);
 
         //Configure Driver
-        this.driver.configure(portId, baud, thisStation, maxMaster, maxInfoFrames, usageTimeout);
+        this.driver.configure(portId, baud, thisStation, maxManager, maxInfoFrames, usageTimeout);
         super.initialize(transport);
     }
 
@@ -107,21 +88,18 @@ public class RealtimeMasterNode extends MasterNode {
     protected void doCycle() {
         readFrame();
 
-        if (state == MasterNodeState.idle)
+        if (state == ManagerNodeState.idle)
             idle();
 
-        if (state == MasterNodeState.useToken)
+        if (state == ManagerNodeState.useToken)
             useToken();
 
-        if (state == MasterNodeState.doneWithToken)
-            state = MasterNodeState.idle;
+        if (state == ManagerNodeState.doneWithToken)
+            state = ManagerNodeState.idle;
 
-        if (state == MasterNodeState.waitForReply)
+        if (state == ManagerNodeState.waitForReply)
             waitForReply();
 
-        //TODO Can't currently get to this state since we don't have 
-        // the frame type from the driver so we have to do this every time
-        //if (state == MasterNodeState.answerDataRequest)
         answerDataRequest();
     }
 
@@ -146,27 +124,25 @@ public class RealtimeMasterNode extends MasterNode {
             readCount = in.read(readArray);
             if (readCount > 0) {
                 bytesIn += readCount;
-                if (LOG.isTraceEnabled())
-                    LOG.trace(tracePrefix() + "in: " + StreamUtils.dumpArrayHex(readArray, 0, readCount));
+                if (LOG.isTraceEnabled()) {
+                    LOG.trace("{} in: {}", tracePrefix(), StreamUtils.dumpArrayHex(readArray, 0, readCount));
+                }
                 inputBuffer.push(readArray, 0, readCount);
                 eventCount += readCount;
                 int pos = 0;
-                //TODO How can we validate that this is an entire message?
                 frame.setSourceAddress(readArray[pos++]);
                 byte[] data = new byte[readCount - 1];
                 for (int i = 0; i < readCount - 1; i++) {
                     data[i] = readArray[pos++];
                 }
                 frame.setData(data);
-                if (LOG.isTraceEnabled())
-                    LOG.trace("in: " + frame);
+                LOG.trace("in: {}", frame);
                 receivedValidFrame = true;
             }
-        } catch (final IOException e) {
+        } catch (IOException e) {
             if (StringUtils.equals(e.getMessage(), "Stream closed."))
                 throw new RuntimeException(e);
-            if (LOG.isDebugEnabled())
-                LOG.debug(thisStation + " Input stream listener exception", e);
+            LOG.debug("{} Input stream listener exception", thisStation, e);
             receiveError = true;
         }
     }
@@ -175,19 +151,18 @@ public class RealtimeMasterNode extends MasterNode {
     protected void idle() {
         //Don't worry about invalid frames, assume we can use token if we didn't get a frame
         if (receivedValidFrame) {
-            if (LOG.isDebugEnabled())
-                LOG.debug(thisStation + " idle:receivedValidFrame");
+            LOG.debug("{} idle:receivedValidFrame", thisStation);
             frame();
             receivedValidFrame = false;
             activity = true;
         } else {
             //We can use the token
-            state = MasterNodeState.useToken;
+            state = ManagerNodeState.useToken;
         }
     }
 
     /* (non-Javadoc)
-     * @see com.serotonin.bacnet4j.npdu.mstp.MasterNode#frame()
+     * @see com.serotonin.bacnet4j.npdu.mstp.ManagerNode#frame()
      */
     @Override
     protected void frame() {
@@ -196,7 +171,7 @@ public class RealtimeMasterNode extends MasterNode {
         //TODO How to decide?  via NPDU or do we modify the driver
         //The idea here is that we assume the driver will always 
         // reply for us...?
-        //state = MasterNodeState.answerDataRequest;
+        //state = ManagerNodeState.answerDataRequest;
         //replyDeadline = lastNonSilence + Constants.REPLY_DELAY;
     }
 
@@ -204,19 +179,19 @@ public class RealtimeMasterNode extends MasterNode {
     protected void waitForReply() {
         if (clock.millis() > lastFrameSendTime + responseTimeoutMs) {
             if (LOG.isDebugEnabled())
-                LOG.debug(thisStation + " waitForReply:ReplyTimeout");
-            state = MasterNodeState.idle;
+                LOG.debug("{} waitForReply:ReplyTimeout", thisStation);
+            state = ManagerNodeState.idle;
         } else if (receivedValidFrame) {
             if (LOG.isDebugEnabled())
-                LOG.debug(thisStation + " waitForReply:ReceivedReply");
+                LOG.debug("{} waitForReply:ReceivedReply", thisStation);
             receivedDataNoReply(frame);
-            state = MasterNodeState.idle;
+            state = ManagerNodeState.idle;
             receivedValidFrame = false;
         }
     }
 
     /* (non-Javadoc)
-     * @see com.serotonin.bacnet4j.npdu.mstp.MasterNode#answerDataRequest()
+     * @see com.serotonin.bacnet4j.npdu.mstp.ManagerNode#answerDataRequest()
      */
     @Override
     protected void answerDataRequest() {
@@ -224,10 +199,10 @@ public class RealtimeMasterNode extends MasterNode {
             if (replyFrame != null) {
                 // Reply
                 if (LOG.isDebugEnabled())
-                    LOG.debug(thisStation + " answerDataRequest:Reply");
+                    LOG.debug("{} answerDataRequest:Reply", thisStation);
                 sendFrame(replyFrame);
                 replyFrame = null;
-                state = MasterNodeState.idle;
+                state = ManagerNodeState.idle;
                 activity = true;
             }
         }
@@ -235,11 +210,12 @@ public class RealtimeMasterNode extends MasterNode {
 
 
     @Override
-    protected void sendFrame(final Frame frame) {
-        LOG.info("Sending frame: " + frame);
+    protected void sendFrame(Frame frame) {
+        LOG.info("Sending frame: {}", frame);
         try {
-            if (LOG.isTraceEnabled())
-                LOG.trace(tracePrefix() + "out: " + frame);
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("{} out: {}", tracePrefix(), frame);
+            }
 
             // Header
             byte[] writeArray = new byte[5 + frame.getLength()];
@@ -262,8 +238,8 @@ public class RealtimeMasterNode extends MasterNode {
             out.flush();
             bytesOut += frame.getLength() + 10; //Imply the missing bytes that the driver will add
             lastFrameSendTime = clock.millis();
-            LOG.info("Sent frame " + frame);
-        } catch (final IOException e) {
+            LOG.info("Sent frame {}", frame);
+        } catch (IOException e) {
             // Only write the same error message once. Prevents logs from getting filled up unnecessarily with repeated
             // error messages.
             if (!StringUtils.equals(e.getMessage(), lastWriteError)) {

--- a/src/main/java/com/serotonin/bacnet4j/npdu/mstp/SubordinateNode.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/mstp/SubordinateNode.java
@@ -35,43 +35,43 @@ import org.slf4j.LoggerFactory;
 
 import com.serotonin.bacnet4j.util.sero.SerialPortWrapper;
 
-public class SlaveNode extends MstpNode {
-    private static final Logger LOG = LoggerFactory.getLogger(SlaveNode.class);
+public class SubordinateNode extends MstpNode {
+    private static final Logger LOG = LoggerFactory.getLogger(SubordinateNode.class);
 
 
-    private enum SlaveNodeState {
+    private enum SubordinateNodeState {
         idle, answerDataRequest
     }
 
 
-    private SlaveNodeState state;
+    private SubordinateNodeState state;
 
     private long replyDeadline;
     private Frame replyFrame;
 
-    public SlaveNode(final SerialPortWrapper wrapper, final byte thisStation) throws IllegalArgumentException {
+    public SubordinateNode(SerialPortWrapper wrapper, byte thisStation) throws IllegalArgumentException {
         super(wrapper, thisStation);
         validate();
     }
 
-    public SlaveNode(final String portId, final InputStream in, final OutputStream out, final byte thisStation)
+    public SubordinateNode(String portId, InputStream in, OutputStream out, byte thisStation)
             throws IllegalArgumentException {
         super(portId, in, out, thisStation);
         validate();
     }
 
     private void validate() {
-        final int is = thisStation & 0xff;
+        int is = thisStation & 0xff;
         if (is > 254)
             throw new IllegalArgumentException("thisStation cannot be greater than 254");
 
-        state = SlaveNodeState.idle;
+        state = SubordinateNodeState.idle;
     }
 
     @Override
-    public void setReplyFrame(final FrameType type, final byte destination, final byte[] data) {
+    public void setReplyFrame(FrameType type, byte destination, byte[] data) {
         synchronized (this) {
-            if (state == SlaveNodeState.answerDataRequest)
+            if (state == SubordinateNodeState.answerDataRequest)
                 // If there is still time to reply immediately...
                 replyFrame = new Frame(type, frame.getSourceAddress(), thisStation, data);
         }
@@ -81,10 +81,10 @@ public class SlaveNode extends MstpNode {
     protected void doCycle() {
         readFrame();
 
-        if (state == SlaveNodeState.idle)
+        if (state == SubordinateNodeState.idle)
             idle();
 
-        if (state == SlaveNodeState.answerDataRequest)
+        if (state == SubordinateNodeState.answerDataRequest)
             answerDataRequest();
     }
 
@@ -93,14 +93,11 @@ public class SlaveNode extends MstpNode {
      */
     private void idle() {
         if (receivedInvalidFrame != null) {
-            // ReceivedInvalidFrame
-            // debug("idle:ReceivedInvalidFrame");
-            if (LOG.isDebugEnabled())
-                LOG.debug("Received invalid frame: " + receivedInvalidFrame);
+            LOG.debug("Received invalid frame: {}", receivedInvalidFrame);
             receivedInvalidFrame = null;
             activity = true;
         } else if (receivedValidFrame) {
-            final FrameType type = frame.getFrameType();
+            FrameType type = frame.getFrameType();
 
             if (type == null) {
                 // ReceivedUnwantedFrame
@@ -109,26 +106,22 @@ public class SlaveNode extends MstpNode {
             } else if (frame.broadcast()
                     && type.oneOf(FrameType.token, FrameType.bacnetDataExpectingReply, FrameType.testRequest)) {
                 // ReceivedUnwantedFrame
-                if (LOG.isDebugEnabled())
-                    LOG.debug("Frame type should not be broadcast: " + type);
-            } else if (type.oneOf(FrameType.pollForMaster)) {
+                LOG.debug("Frame type should not be broadcast: {}", type);
+            } else if (type.oneOf(FrameType.pollForManager)) {
                 // ReceivedUnwantedFrame
                 // It happens
-            } else if (type.oneOf(FrameType.token, FrameType.pollForMaster, FrameType.replyToPollForMaster,
+            } else if (type.oneOf(FrameType.token, FrameType.pollForManager, FrameType.replyToPollForManager,
                     FrameType.replyPostponed)) {
                 // ReceivedUnwantedFrame
-                if (LOG.isDebugEnabled())
-                    LOG.debug("Received unwanted frame type: " + type);
+                LOG.debug("Received unwanted frame type: {}", type);
             } else if (frame.forStationOrBroadcast(thisStation)
                     && type.oneOf(FrameType.bacnetDataNotExpectingReply, FrameType.testResponse)) {
                 // ReceivedDataNoReply
-                //                debug("idle:ReceivedDataNoReply");
                 receivedDataNoReply(frame);
             } else if (frame.forStation(thisStation)
                     && type.oneOf(FrameType.bacnetDataExpectingReply, FrameType.testRequest)) {
                 // ReceivedDataNeedingReply
-                //                debug("idle:ReceivedDataNeedingReply");
-                state = SlaveNodeState.answerDataRequest;
+                state = SubordinateNodeState.answerDataRequest;
                 replyDeadline = lastNonSilence + Constants.REPLY_DELAY;
                 replyFrame = null;
                 receivedDataNeedingReply(frame);
@@ -147,17 +140,14 @@ public class SlaveNode extends MstpNode {
         synchronized (this) {
             if (replyFrame != null) {
                 // Reply
-                //                debug("answerDataRequest:Reply");
                 sendFrame(replyFrame);
                 replyFrame = null;
-                state = SlaveNodeState.idle;
+                state = SubordinateNodeState.idle;
                 activity = true;
             } else if (replyDeadline >= clock.millis()) {
                 // CannotReply
-                //                debug("answerDataRequest:CannotReply");
-                if (LOG.isDebugEnabled())
-                    LOG.debug("Failed to respond to request: " + frame);
-                state = SlaveNodeState.idle;
+                LOG.debug("Failed to respond to request: {}", frame);
+                state = SubordinateNodeState.idle;
                 activity = true;
             }
         }

--- a/src/main/java/com/serotonin/bacnet4j/npdu/mstp/realtime/RealtimeDriver.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/mstp/realtime/RealtimeDriver.java
@@ -37,8 +37,6 @@ import org.slf4j.LoggerFactory;
 /**
  * IOCTL JNA Wrapper To handle IOCTL calls to proprietary
  * Realtime MS/TP Driver
- *
- * @author Terry Packer
  */
 public class RealtimeDriver {
     static final Logger LOG = LoggerFactory.getLogger(RealtimeDriver.class);
@@ -51,18 +49,8 @@ public class RealtimeDriver {
         this.configProgram = configProgram;
     }
 
-    /**
-     * @param portId
-     * @param baud
-     * @param thisStation
-     * @throws InterruptedException
-     * @throws IOException
-     */
-    public void configure(String portId, int baud, byte thisStation, int maxMaster, int maxInfoFrames, int usageTimeout)
-            throws InterruptedException, IOException {
-        //TODO Redirect output to LOGs
-        //TODO Create a setuid wrapper to call insmod to load the driver if not running as root
-
+    public void configure(String portId, int baud, byte thisStation, int maxManager, int maxInfoFrames,
+            int usageTimeout) throws InterruptedException, IOException {
         //modprobe the driver
         ProcessBuilder pb = new ProcessBuilder("insmod",
                 driver.getAbsolutePath());
@@ -77,7 +65,7 @@ public class RealtimeDriver {
                 "-d" + portId,
                 "-b" + baud,
                 "-t" + thisStation,
-                "-m" + maxMaster,
+                "-m" + maxManager,
                 "-f" + maxInfoFrames,
                 "-u" + usageTimeout);
         pb.redirectError(Redirect.INHERIT);

--- a/src/main/java/com/serotonin/bacnet4j/obj/DeviceObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/DeviceObject.java
@@ -35,7 +35,7 @@ import com.serotonin.bacnet4j.RemoteDevice;
 import com.serotonin.bacnet4j.enums.MaxApduLength;
 import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.npdu.Network;
-import com.serotonin.bacnet4j.npdu.mstp.MasterNode;
+import com.serotonin.bacnet4j.npdu.mstp.ManagerNode;
 import com.serotonin.bacnet4j.npdu.mstp.MstpNetwork;
 import com.serotonin.bacnet4j.npdu.mstp.MstpNode;
 import com.serotonin.bacnet4j.obj.mixin.ActiveCovSubscriptionMixin;
@@ -310,10 +310,10 @@ public class DeviceObject extends BACnetObject {
     @Override
     protected boolean validateProperty(ValueSource valueSource, PropertyValue value) throws BACnetServiceException {
         if (value.getPropertyIdentifier().equals(PropertyIdentifier.maxManager)) {
-            MasterNode masterNode = getMasterNode();
-            if (masterNode != null) {
-                UnsignedInteger maxMaster = value.getValue();
-                if (masterNode.getThisStation() > maxMaster.intValue()) {
+            ManagerNode managerNode = getManagerNode();
+            if (managerNode != null) {
+                UnsignedInteger maxManager = value.getValue();
+                if (managerNode.getThisStation() > maxManager.intValue()) {
                     throw new BACnetServiceException(ErrorClass.property, ErrorCode.valueOutOfRange);
                 }
             }
@@ -329,25 +329,25 @@ public class DeviceObject extends BACnetObject {
             getLocalDevice().getPersistence()
                     .saveEncodable(getPersistenceKey(PropertyIdentifier.restartNotificationRecipients), newValue);
         } else if (pid.equals(PropertyIdentifier.maxManager)) {
-            MasterNode masterNode = getMasterNode();
-            if (masterNode != null) {
-                UnsignedInteger maxMaster = (UnsignedInteger) newValue;
-                masterNode.setMaxMaster(maxMaster.intValue());
+            ManagerNode managerNode = getManagerNode();
+            if (managerNode != null) {
+                UnsignedInteger maxManager = (UnsignedInteger) newValue;
+                managerNode.setMaxManager(maxManager.intValue());
             }
         } else if (pid.equals(PropertyIdentifier.maxInfoFrames)) {
-            MasterNode masterNode = getMasterNode();
-            if (masterNode != null) {
+            ManagerNode managerNode = getManagerNode();
+            if (managerNode != null) {
                 UnsignedInteger maxInfoFrames = (UnsignedInteger) newValue;
-                masterNode.setMaxInfoFrames(maxInfoFrames.intValue());
+                managerNode.setMaxInfoFrames(maxInfoFrames.intValue());
             }
         }
     }
 
-    private MasterNode getMasterNode() {
+    private ManagerNode getManagerNode() {
         Network network = getLocalDevice().getNetwork();
         if (network instanceof MstpNetwork mstp) {
             MstpNode node = mstp.getNode();
-            if (node instanceof MasterNode manager) {
+            if (node instanceof ManagerNode manager) {
                 return manager;
             }
         }

--- a/src/main/java/com/serotonin/bacnet4j/obj/DeviceObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/DeviceObject.java
@@ -79,16 +79,15 @@ import com.serotonin.bacnet4j.type.primitive.Unsigned16;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
 public class DeviceObject extends BACnetObject {
-    private static final int VENDOR_ID = 865; //Infinite Automation Systems, Inc.
+    private static final int VENDOR_ID = 865; // Radix IoT LLC
 
-    public DeviceObject(final LocalDevice localDevice, final int instanceNumber) {
+    public DeviceObject(LocalDevice localDevice, int instanceNumber) {
         super(localDevice, ObjectType.device, instanceNumber, "BACnet4J device " + instanceNumber);
 
         writePropertyInternal(PropertyIdentifier.maxApduLengthAccepted,
                 new UnsignedInteger(MaxApduLength.UP_TO_1476.getMaxLengthInt()));
         writePropertyInternal(PropertyIdentifier.vendorIdentifier, new UnsignedInteger(VENDOR_ID));
-        writePropertyInternal(PropertyIdentifier.vendorName,
-                new CharacterString("Infinite Automation Systems, Inc."));
+        writePropertyInternal(PropertyIdentifier.vendorName, new CharacterString("Radix IoT LLC"));
         writePropertyInternal(PropertyIdentifier.segmentationSupported, Segmentation.segmentedBoth);
         writePropertyInternal(PropertyIdentifier.maxSegmentsAccepted, new UnsignedInteger(Integer.MAX_VALUE));
         writePropertyInternal(PropertyIdentifier.apduSegmentTimeout,
@@ -98,7 +97,7 @@ public class DeviceObject extends BACnetObject {
         writePropertyInternal(PropertyIdentifier.objectList, new BACnetArray<ObjectIdentifier>());
 
         // Set up the supported services indicators. Remove lines as services get implemented.
-        final ServicesSupported servicesSupported = new ServicesSupported();
+        ServicesSupported servicesSupported = new ServicesSupported();
         servicesSupported.setAcknowledgeAlarm(true);
         servicesSupported.setConfirmedCovNotification(true);
         servicesSupported.setConfirmedEventNotification(true);
@@ -150,7 +149,7 @@ public class DeviceObject extends BACnetObject {
         writePropertyInternal(PropertyIdentifier.protocolServicesSupported, servicesSupported);
 
         // Set up the object types supported.
-        final ObjectTypesSupported objectTypesSupported = new ObjectTypesSupported();
+        ObjectTypesSupported objectTypesSupported = new ObjectTypesSupported();
         objectTypesSupported.set(ObjectType.analogInput, true);
         objectTypesSupported.set(ObjectType.analogOutput, true);
         objectTypesSupported.set(ObjectType.analogValue, true);
@@ -225,7 +224,7 @@ public class DeviceObject extends BACnetObject {
         writePropertyInternal(PropertyIdentifier.firmwareRevision, new CharacterString("not set"));
         writePropertyInternal(PropertyIdentifier.applicationSoftwareVersion, new CharacterString(LocalDevice.VERSION));
         writePropertyInternal(PropertyIdentifier.protocolVersion, new UnsignedInteger(1));
-        writePropertyInternal(PropertyIdentifier.protocolRevision, new UnsignedInteger(19));
+        writePropertyInternal(PropertyIdentifier.protocolRevision, new UnsignedInteger(20));
 
         UnsignedInteger databaseRevision = getLocalDevice().getPersistence()
                 .loadEncodable(getPersistenceKey(PropertyIdentifier.databaseRevision), UnsignedInteger.class);
@@ -259,18 +258,18 @@ public class DeviceObject extends BACnetObject {
         addMixin(new ObjectListMixin(this));
     }
 
-    public DeviceObject supportTimeSynchronization(final SequenceOf<Recipient> timeSynchronizationRecipients,
-            final SequenceOf<Recipient> utcTimeSynchronizationRecipients, final int timeSynchronizationInterval,
-            final boolean alignIntervals, final int intervalOffset) {
-        final TimeSynchronizationMixin m = new TimeSynchronizationMixin(this, timeSynchronizationRecipients,
+    public DeviceObject supportTimeSynchronization(SequenceOf<Recipient> timeSynchronizationRecipients,
+            SequenceOf<Recipient> utcTimeSynchronizationRecipients, int timeSynchronizationInterval,
+            boolean alignIntervals, int intervalOffset) {
+        TimeSynchronizationMixin m = new TimeSynchronizationMixin(this, timeSynchronizationRecipients,
                 utcTimeSynchronizationRecipients, timeSynchronizationInterval, alignIntervals, intervalOffset);
         addMixin(m);
         m.update();
         return this;
     }
 
-    public DeviceObject supportIntrinsicReporting(final int notificationClass, final EventTransitionBits eventEnable,
-            final NotifyType notifyType) {
+    public DeviceObject supportIntrinsicReporting(int notificationClass, EventTransitionBits eventEnable,
+            NotifyType notifyType) {
         Objects.requireNonNull(eventEnable);
         Objects.requireNonNull(notifyType);
 
@@ -285,21 +284,21 @@ public class DeviceObject extends BACnetObject {
     }
 
     @Override
-    protected void beforeReadProperty(final PropertyIdentifier pid) {
+    protected void beforeReadProperty(PropertyIdentifier pid) {
         if (pid.equals(PropertyIdentifier.localTime)) {
             set(PropertyIdentifier.localTime, new Time(getLocalDevice()));
         } else if (pid.equals(PropertyIdentifier.localDate)) {
             set(PropertyIdentifier.localDate, new Date(getLocalDevice()));
         } else if (pid.equals(PropertyIdentifier.utcOffset)) {
-            final int offsetMillis = TimeZone.getDefault().getOffset(getLocalDevice().getClock().millis());
+            int offsetMillis = TimeZone.getDefault().getOffset(getLocalDevice().getClock().millis());
             writePropertyInternal(PropertyIdentifier.utcOffset, new SignedInteger(offsetMillis / 1000 / 60));
         } else if (pid.equals(PropertyIdentifier.daylightSavingsStatus)) {
-            final boolean dst = TimeZone.getDefault()
+            boolean dst = TimeZone.getDefault()
                     .inDaylightTime(new java.util.Date(getLocalDevice().getClock().millis()));
             writePropertyInternal(PropertyIdentifier.daylightSavingsStatus, Boolean.valueOf(dst));
         } else if (pid.equals(PropertyIdentifier.deviceAddressBinding)) {
-            final SequenceOf<AddressBinding> bindings = new SequenceOf<>();
-            for (final RemoteDevice d : getLocalDevice().getRemoteDevices()) {
+            SequenceOf<AddressBinding> bindings = new SequenceOf<>();
+            for (RemoteDevice d : getLocalDevice().getRemoteDevices()) {
                 if (d != null) {
                     bindings.add(new AddressBinding(d.getObjectIdentifier(), d.getAddress()));
                 }
@@ -309,12 +308,11 @@ public class DeviceObject extends BACnetObject {
     }
 
     @Override
-    protected boolean validateProperty(final ValueSource valueSource, final PropertyValue value)
-            throws BACnetServiceException {
+    protected boolean validateProperty(ValueSource valueSource, PropertyValue value) throws BACnetServiceException {
         if (value.getPropertyIdentifier().equals(PropertyIdentifier.maxManager)) {
-            final MasterNode masterNode = getMasterNode();
+            MasterNode masterNode = getMasterNode();
             if (masterNode != null) {
-                final UnsignedInteger maxMaster = value.getValue();
+                UnsignedInteger maxMaster = value.getValue();
                 if (masterNode.getThisStation() > maxMaster.intValue()) {
                     throw new BACnetServiceException(ErrorClass.property, ErrorCode.valueOutOfRange);
                 }
@@ -325,31 +323,30 @@ public class DeviceObject extends BACnetObject {
     }
 
     @Override
-    protected void afterWriteProperty(final PropertyIdentifier pid, final Encodable oldValue,
-            final Encodable newValue) {
+    protected void afterWriteProperty(PropertyIdentifier pid, Encodable oldValue, Encodable newValue) {
         if (pid.equals(PropertyIdentifier.restartNotificationRecipients)) {
             // Persist the new list.
             getLocalDevice().getPersistence()
                     .saveEncodable(getPersistenceKey(PropertyIdentifier.restartNotificationRecipients), newValue);
         } else if (pid.equals(PropertyIdentifier.maxManager)) {
-            final MasterNode masterNode = getMasterNode();
+            MasterNode masterNode = getMasterNode();
             if (masterNode != null) {
-                final UnsignedInteger maxMaster = (UnsignedInteger) newValue;
+                UnsignedInteger maxMaster = (UnsignedInteger) newValue;
                 masterNode.setMaxMaster(maxMaster.intValue());
             }
         } else if (pid.equals(PropertyIdentifier.maxInfoFrames)) {
-            final MasterNode masterNode = getMasterNode();
+            MasterNode masterNode = getMasterNode();
             if (masterNode != null) {
-                final UnsignedInteger maxInfoFrames = (UnsignedInteger) newValue;
+                UnsignedInteger maxInfoFrames = (UnsignedInteger) newValue;
                 masterNode.setMaxInfoFrames(maxInfoFrames.intValue());
             }
         }
     }
 
     private MasterNode getMasterNode() {
-        final Network network = getLocalDevice().getNetwork();
+        Network network = getLocalDevice().getNetwork();
         if (network instanceof MstpNetwork mstp) {
-            final MstpNode node = mstp.getNode();
+            MstpNode node = mstp.getNode();
             if (node instanceof MasterNode manager) {
                 return manager;
             }

--- a/src/test/java/com/serotonin/bacnet4j/Mstp.java
+++ b/src/test/java/com/serotonin/bacnet4j/Mstp.java
@@ -38,7 +38,7 @@ import com.serotonin.bacnet4j.apdu.ConfirmedRequest;
 import com.serotonin.bacnet4j.apdu.UnconfirmedRequest;
 import com.serotonin.bacnet4j.npdu.NPDU;
 import com.serotonin.bacnet4j.npdu.Network;
-import com.serotonin.bacnet4j.npdu.mstp.MasterNode;
+import com.serotonin.bacnet4j.npdu.mstp.ManagerNode;
 import com.serotonin.bacnet4j.npdu.mstp.MstpNetwork;
 import com.serotonin.bacnet4j.type.constructed.ServicesSupported;
 import com.serotonin.bacnet4j.type.primitive.OctetString;
@@ -58,7 +58,7 @@ public class Mstp {
         //        final String s = hex("1,0,30,3,c,c,2,2,dd,d6,19,4c,29,0,3e,21,68,3f,e2,3b");
 
         final Network network = new MstpNetwork(
-                new MasterNode(null, new ByteArrayInputStream(new byte[0]), new ByteArrayOutputStream(), (byte) 0, 2));
+                new ManagerNode(null, new ByteArrayInputStream(new byte[0]), new ByteArrayOutputStream(), (byte) 0, 2));
         final NPDU npdu = network.parseNpduData(new ByteQueue(s), new OctetString(new byte[] {1}));
         final ServicesSupported servicesSupported = new ServicesSupported();
         servicesSupported.setAll(true);

--- a/src/test/java/com/serotonin/bacnet4j/adhoc/IpManagerTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/adhoc/IpManagerTest.java
@@ -25,61 +25,60 @@
  * See www.radixiot.com for commercial license options.
  */
 
-package com.serotonin.bacnet4j.adhoc.rs485;
+package com.serotonin.bacnet4j.adhoc;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.serotonin.bacnet4j.LocalDevice;
 import com.serotonin.bacnet4j.RemoteDevice;
 import com.serotonin.bacnet4j.event.IAmListener;
 import com.serotonin.bacnet4j.exception.BACnetException;
 import com.serotonin.bacnet4j.npdu.Network;
-import com.serotonin.bacnet4j.npdu.mstp.Constants;
-import com.serotonin.bacnet4j.npdu.mstp.MasterNode;
-import com.serotonin.bacnet4j.npdu.mstp.MstpNetwork;
+import com.serotonin.bacnet4j.npdu.ip.IpNetworkBuilder;
 import com.serotonin.bacnet4j.service.unconfirmed.WhoIsRequest;
 import com.serotonin.bacnet4j.transport.DefaultTransport;
 import com.serotonin.bacnet4j.transport.Transport;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
 import com.serotonin.bacnet4j.type.primitive.CharacterString;
 import com.serotonin.bacnet4j.util.DiscoveryUtils;
-import com.serotonin.bacnet4j.util.JsscSerialPortInputStream;
-import com.serotonin.bacnet4j.util.JsscSerialPortOutputStream;
-
-import jssc.SerialPort;
 
 /**
- * Run up an MSTP Master and do a WhoIs
+ * Example of creating an Ip Manager
  */
-public class MasterTest {
+public class IpManagerTest {
+    static final Logger LOG = LoggerFactory.getLogger(IpManagerTest.class);
 
-    public static void main(final String[] args) throws Exception {
-        //Setup Serial Port
-        final SerialPort serialPort = new SerialPort("/dev/cu.usbserial-A101OGX5");
-        boolean b = serialPort.openPort();
-        b = serialPort.setParams(SerialPort.BAUDRATE_38400, SerialPort.DATABITS_8, SerialPort.STOPBITS_1,
-                SerialPort.PARITY_NONE);
+    public static void main(String[] args) {
+        new IpManagerTest().runWhoIs();
+    }
 
-        try (JsscSerialPortInputStream in = new JsscSerialPortInputStream(serialPort);
-                JsscSerialPortOutputStream out = new JsscSerialPortOutputStream(serialPort)) {
-            //Create Local Device
-            MasterNode masterNode = new MasterNode("test", in, out, (byte) 0, 1);
-            masterNode.setMaxInfoFrames(Constants.MAX_INFO_FRAMES);
-            masterNode.setMaxMaster(Constants.MAX_MASTER);
-            masterNode.setUsageTimeout(Constants.USAGE_TIMEOUT);
-            Network network = new MstpNetwork(masterNode, 0);
-            Transport transport = new DefaultTransport(network);
-            transport.setTimeout(Transport.DEFAULT_TIMEOUT);
-            transport.setSegTimeout(Transport.DEFAULT_SEG_TIMEOUT);
-            transport.setSegWindow(Transport.DEFAULT_SEG_WINDOW);
-            transport.setRetries(Transport.DEFAULT_RETRIES);
+    public LocalDevice createIpLocalDevice() {
+        Network network = new IpNetworkBuilder()
+                .withLocalBindAddress("0.0.0.0")
+                .withBroadcast("255.255.255.255", 24)
+                .withPort(47808)
+                .withLocalNetworkNumber(5)
+                .withReuseAddress(true)
+                .build();
 
-            LocalDevice localDevice = new LocalDevice(0, transport);
-            localDevice.getDeviceObject()
-                    .writePropertyInternal(PropertyIdentifier.objectName, new CharacterString("Test"));
-            //localDevice.getDeviceObject().writePropertyInternal(PropertyIdentifier.vendorName, new CharacterString("InfiniteAutomation"));
-            localDevice.getDeviceObject()
-                    .writePropertyInternal(PropertyIdentifier.modelName, new CharacterString("BACnet4J"));
+        Transport transport = new DefaultTransport(network);
+        transport.setTimeout(Transport.DEFAULT_TIMEOUT);
+        transport.setSegTimeout(Transport.DEFAULT_SEG_TIMEOUT);
+        transport.setSegWindow(Transport.DEFAULT_SEG_WINDOW);
+        transport.setRetries(1);
 
+        LocalDevice localDevice = new LocalDevice(99, transport);
+        localDevice.getDeviceObject().writePropertyInternal(PropertyIdentifier.objectName, new CharacterString("Test"));
+        localDevice.getDeviceObject()
+                .writePropertyInternal(PropertyIdentifier.modelName, new CharacterString("BACnet4J"));
 
+        return localDevice;
+    }
+
+    public void runWhoIs() {
+        try {
+            LocalDevice localDevice = createIpLocalDevice();
             //Create listener
             IAmListener listener = (RemoteDevice d) -> {
                 try {
@@ -105,8 +104,8 @@ public class MasterTest {
             }
             localDevice.terminate();
 
-        } finally {
-            serialPort.closePort();
+        } catch (Exception e) {
+            e.printStackTrace();
         }
     }
 }

--- a/src/test/java/com/serotonin/bacnet4j/adhoc/rs485/ManagerTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/adhoc/rs485/ManagerTest.java
@@ -25,63 +25,59 @@
  * See www.radixiot.com for commercial license options.
  */
 
-package com.serotonin.bacnet4j.adhoc;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+package com.serotonin.bacnet4j.adhoc.rs485;
 
 import com.serotonin.bacnet4j.LocalDevice;
 import com.serotonin.bacnet4j.RemoteDevice;
 import com.serotonin.bacnet4j.event.IAmListener;
 import com.serotonin.bacnet4j.exception.BACnetException;
 import com.serotonin.bacnet4j.npdu.Network;
-import com.serotonin.bacnet4j.npdu.ip.IpNetworkBuilder;
+import com.serotonin.bacnet4j.npdu.mstp.Constants;
+import com.serotonin.bacnet4j.npdu.mstp.ManagerNode;
+import com.serotonin.bacnet4j.npdu.mstp.MstpNetwork;
 import com.serotonin.bacnet4j.service.unconfirmed.WhoIsRequest;
 import com.serotonin.bacnet4j.transport.DefaultTransport;
 import com.serotonin.bacnet4j.transport.Transport;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
 import com.serotonin.bacnet4j.type.primitive.CharacterString;
 import com.serotonin.bacnet4j.util.DiscoveryUtils;
+import com.serotonin.bacnet4j.util.JsscSerialPortInputStream;
+import com.serotonin.bacnet4j.util.JsscSerialPortOutputStream;
+
+import jssc.SerialPort;
 
 /**
- * Example of creating an Ip Master
+ * Run up an MSTP Manager and do a WhoIs
  */
-public class IpMasterTest {
-
-    static final Logger LOG = LoggerFactory.getLogger(IpMasterTest.class);
-
+public class ManagerTest {
     public static void main(final String[] args) throws Exception {
-        new IpMasterTest().runWhoIs();
-    }
+        //Setup Serial Port
+        final SerialPort serialPort = new SerialPort("/dev/cu.usbserial-A101OGX5");
+        serialPort.openPort();
+        serialPort.setParams(SerialPort.BAUDRATE_38400, SerialPort.DATABITS_8, SerialPort.STOPBITS_1,
+                SerialPort.PARITY_NONE);
 
-    public LocalDevice createIpLocalDevice() throws Exception {
-        Network network = network = new IpNetworkBuilder()
-                .withLocalBindAddress("0.0.0.0")
-                .withBroadcast("255.255.255.255", 24)
-                .withPort(47808)
-                .withLocalNetworkNumber(5)
-                .withReuseAddress(true)
-                .build();
+        try (JsscSerialPortInputStream in = new JsscSerialPortInputStream(serialPort);
+                JsscSerialPortOutputStream out = new JsscSerialPortOutputStream(serialPort)) {
+            //Create Local Device
+            ManagerNode managerNode = new ManagerNode("test", in, out, (byte) 0, 1);
+            managerNode.setMaxInfoFrames(Constants.MAX_INFO_FRAMES);
+            managerNode.setMaxManager(Constants.MAX_MANAGER);
+            managerNode.setUsageTimeout(Constants.USAGE_TIMEOUT);
+            Network network = new MstpNetwork(managerNode, 0);
+            Transport transport = new DefaultTransport(network);
+            transport.setTimeout(Transport.DEFAULT_TIMEOUT);
+            transport.setSegTimeout(Transport.DEFAULT_SEG_TIMEOUT);
+            transport.setSegWindow(Transport.DEFAULT_SEG_WINDOW);
+            transport.setRetries(Transport.DEFAULT_RETRIES);
 
-        Transport transport = new DefaultTransport(network);
-        transport.setTimeout(Transport.DEFAULT_TIMEOUT);
-        transport.setSegTimeout(Transport.DEFAULT_SEG_TIMEOUT);
-        transport.setSegWindow(Transport.DEFAULT_SEG_WINDOW);
-        transport.setRetries(1);
+            LocalDevice localDevice = new LocalDevice(0, transport);
+            localDevice.getDeviceObject()
+                    .writePropertyInternal(PropertyIdentifier.objectName, new CharacterString("Test"));
+            localDevice.getDeviceObject()
+                    .writePropertyInternal(PropertyIdentifier.modelName, new CharacterString("BACnet4J"));
 
-        LocalDevice localDevice = new LocalDevice(99, transport);
-        localDevice.getDeviceObject().writePropertyInternal(PropertyIdentifier.objectName, new CharacterString("Test"));
-        //localDevice.getDeviceObject().writePropertyInternal(PropertyIdentifier.vendorName, new CharacterString("InfiniteAutomation"));
-        localDevice.getDeviceObject()
-                .writePropertyInternal(PropertyIdentifier.modelName, new CharacterString("BACnet4J"));
 
-        return localDevice;
-    }
-
-    public void runWhoIs() {
-        try {
-
-            LocalDevice localDevice = createIpLocalDevice();
             //Create listener
             IAmListener listener = (RemoteDevice d) -> {
                 try {
@@ -107,8 +103,8 @@ public class IpMasterTest {
             }
             localDevice.terminate();
 
-        } catch (Exception e) {
-            e.printStackTrace();
+        } finally {
+            serialPort.closePort();
         }
     }
 }

--- a/src/test/java/com/serotonin/bacnet4j/adhoc/rs485/PortTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/adhoc/rs485/PortTest.java
@@ -30,9 +30,9 @@ package com.serotonin.bacnet4j.adhoc.rs485;
 import java.util.Arrays;
 
 import com.serotonin.bacnet4j.LocalDevice;
-import com.serotonin.bacnet4j.npdu.mstp.MasterNode;
+import com.serotonin.bacnet4j.npdu.mstp.ManagerNode;
 import com.serotonin.bacnet4j.npdu.mstp.MstpNetwork;
-import com.serotonin.bacnet4j.npdu.mstp.SlaveNode;
+import com.serotonin.bacnet4j.npdu.mstp.SubordinateNode;
 import com.serotonin.bacnet4j.transport.DefaultTransport;
 import com.serotonin.bacnet4j.transport.Transport;
 import com.serotonin.bacnet4j.util.JsscSerialPortInputStream;
@@ -45,10 +45,10 @@ import jssc.SerialPortException;
 import jssc.SerialPortList;
 
 public class PortTest {
-    public static void main(final String[] args) throws Exception {
+    public static void main(String[] args) throws Exception {
         System.out.println(Arrays.toString(SerialPortList.getPortNames()));
 
-        final SerialPort serialPort = new SerialPort("/dev/cu.usbserial-A101OGX5");
+        SerialPort serialPort = new SerialPort("/dev/cu.usbserial-A101OGX5");
         boolean b = serialPort.openPort();
         System.out.println(b);
         b = serialPort.setParams(SerialPort.BAUDRATE_38400, SerialPort.DATABITS_8, SerialPort.STOPBITS_1,
@@ -56,28 +56,28 @@ public class PortTest {
         System.out.println(b);
 
         //        listen(serialPort);
-        //        slave(serialPort);
-        master(serialPort);
+        //        subordinate(serialPort);
+        manager(serialPort);
 
         b = serialPort.closePort();
         System.out.println(b);
     }
 
-    static void master(final SerialPort serialPort) throws Exception {
+    static void manager(SerialPort serialPort) throws Exception {
         try (JsscSerialPortInputStream in = new JsscSerialPortInputStream(serialPort);
                 JsscSerialPortOutputStream out = new JsscSerialPortOutputStream(serialPort)) {
-            final MasterNode node = new MasterNode("test", in, out, (byte) 3, 2);
+            ManagerNode node = new ManagerNode("test", in, out, (byte) 3, 2);
             node.setMaxInfoFrames(5);
             node.setUsageTimeout(100);
-            final MstpNetwork network = new MstpNetwork(node, 0);
-            final Transport transport = new DefaultTransport(network);
-            final LocalDevice ld = new LocalDevice(1970, transport);
+            MstpNetwork network = new MstpNetwork(node, 0);
+            Transport transport = new DefaultTransport(network);
+            LocalDevice ld = new LocalDevice(1970, transport);
             ld.initialize();
             System.out.println(prefix() + "Initialized");
 
             for (int i = 0; i < 10; i++) {
                 System.out.println(prefix() + "Discovering");
-                final RemoteDeviceDiscoverer rdd = ld.startRemoteDeviceDiscovery((r) -> {
+                RemoteDeviceDiscoverer rdd = ld.startRemoteDeviceDiscovery((r) -> {
                     System.out.println(prefix() + "Device: " + r + ", " + r.getName());
                 });
 
@@ -95,13 +95,13 @@ public class PortTest {
         }
     }
 
-    static void slave(final SerialPort serialPort) throws Exception {
+    static void subordinate(SerialPort serialPort) throws Exception {
         try (JsscSerialPortInputStream in = new JsscSerialPortInputStream(serialPort);
                 JsscSerialPortOutputStream out = new JsscSerialPortOutputStream(serialPort)) {
-            final SlaveNode node = new SlaveNode("test", in, out, (byte) 3);
-            final MstpNetwork network = new MstpNetwork(node, 0);
-            final Transport transport = new DefaultTransport(network);
-            final LocalDevice ld = new LocalDevice(1968, transport);
+            SubordinateNode node = new SubordinateNode("test", in, out, (byte) 3);
+            MstpNetwork network = new MstpNetwork(node, 0);
+            Transport transport = new DefaultTransport(network);
+            LocalDevice ld = new LocalDevice(1968, transport);
             ld.initialize();
 
             ld.startRemoteDeviceDiscovery((r) -> {
@@ -116,14 +116,14 @@ public class PortTest {
         }
     }
 
-    static void listen(final SerialPort serialPort) throws SerialPortException {
+    static void listen(SerialPort serialPort) throws SerialPortException {
         while (true) {
-            //            final byte[] buf = serialPort.readBytes();
+            //             byte[] buf = serialPort.readBytes();
             //            if (buf != null) {
             //                System.out.println(Arrays.toString(buf));
             //            }
 
-            final String s = serialPort.readHexString();
+            String s = serialPort.readHexString();
             if (s != null) {
                 System.out.println(prefix() + s.toLowerCase());
                 //            } else {

--- a/src/test/java/com/serotonin/bacnet4j/adhoc/rs485/PortTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/adhoc/rs485/PortTest.java
@@ -77,18 +77,14 @@ public class PortTest {
 
             for (int i = 0; i < 10; i++) {
                 System.out.println(prefix() + "Discovering");
-                RemoteDeviceDiscoverer rdd = ld.startRemoteDeviceDiscovery((r) -> {
-                    System.out.println(prefix() + "Device: " + r + ", " + r.getName());
-                });
+                RemoteDeviceDiscoverer rdd = ld.startRemoteDeviceDiscovery(r ->
+                        System.out.println(prefix() + "Device: " + r + ", " + r.getName()));
 
                 ThreadUtils.sleep(6000);
 
                 System.out.println(rdd.getRemoteDevices());
                 rdd.stop();
             }
-
-            //            System.out.println(node.getBytesIn());
-            //            System.out.println(node.getBytesOut());
 
             System.out.println(prefix() + "Terminating");
             ld.terminate();
@@ -104,9 +100,7 @@ public class PortTest {
             LocalDevice ld = new LocalDevice(1968, transport);
             ld.initialize();
 
-            ld.startRemoteDeviceDiscovery((r) -> {
-                System.out.println(r.getInstanceNumber());
-            });
+            ld.startRemoteDeviceDiscovery(r -> System.out.println(r.getInstanceNumber()));
 
             ThreadUtils.sleep(10000);
             System.out.println(node.getBytesIn());
@@ -118,16 +112,9 @@ public class PortTest {
 
     static void listen(SerialPort serialPort) throws SerialPortException {
         while (true) {
-            //             byte[] buf = serialPort.readBytes();
-            //            if (buf != null) {
-            //                System.out.println(Arrays.toString(buf));
-            //            }
-
             String s = serialPort.readHexString();
             if (s != null) {
                 System.out.println(prefix() + s.toLowerCase());
-                //            } else {
-                //                System.out.println("null was returned");
             }
         }
     }

--- a/src/test/java/com/serotonin/bacnet4j/npdu/mstp/ManagerNodeTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/npdu/mstp/ManagerNodeTest.java
@@ -1,0 +1,185 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2025 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
+package com.serotonin.bacnet4j.npdu.mstp;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class ManagerNodeTest {
+    private static final byte TS = 0x05;
+
+    private RecordingManagerNode node;
+
+    @Before
+    public void setUp() {
+        node = new RecordingManagerNode();
+    }
+
+    // ---------- bm-1 C3: setUsageTimeout bounds ----------
+
+    @Test
+    public void setUsageTimeout_lowerBound_accepted() {
+        node.setUsageTimeout(20);
+        assertEquals(20, node.usageTimeout);
+    }
+
+    @Test
+    public void setUsageTimeout_upperBound_accepted() {
+        node.setUsageTimeout(35);
+        assertEquals(35, node.usageTimeout);
+    }
+
+    @Test
+    public void setUsageTimeout_belowLowerBound_rejected() {
+        try {
+            node.setUsageTimeout(19);
+            fail("Expected IllegalArgumentException");
+        } catch (final IllegalArgumentException expected) {
+            // ok
+        }
+    }
+
+    @Test
+    public void setUsageTimeout_aboveUpperBound_rejected() {
+        try {
+            node.setUsageTimeout(36);
+            fail("Expected IllegalArgumentException");
+        } catch (final IllegalArgumentException expected) {
+            // ok
+        }
+    }
+
+    // ---------- bm-3 C7: ReceivedUnwantedFrame IDLE-state cases ----------
+
+    // Case (a): DestinationAddress is not TS and not broadcast.
+    @Test
+    public void idle_unwantedFrame_case_a_wrongDestination() {
+        prepareFrame(FrameType.token, (byte) 0x42, (byte) 0x03);
+        node.idle();
+
+        assertEquals(ManagerNode.ManagerNodeState.idle, node.state);
+        assertFalse(node.receivedValidFrame);
+        assertNull(node.receivedInvalidFrame);
+        assertTrue("no frame should have been sent", node.sentFrames.isEmpty());
+    }
+
+    // Case (b): DestinationAddress is broadcast and FrameType is Token, Test_Request, or a
+    // proprietary type that expects a reply (BACnetDataExpectingReply).
+    @Test
+    public void idle_unwantedFrame_case_b_broadcastToken() {
+        prepareFrame(FrameType.token, Constants.BROADCAST, (byte) 0x03);
+        node.idle();
+        assertUnwanted();
+    }
+
+    @Test
+    public void idle_unwantedFrame_case_b_broadcastTestRequest() {
+        prepareFrame(FrameType.testRequest, Constants.BROADCAST, (byte) 0x03);
+        node.idle();
+        assertUnwanted();
+    }
+
+    @Test
+    public void idle_unwantedFrame_case_b_broadcastDataExpectingReply() {
+        prepareFrame(FrameType.bacnetDataExpectingReply, Constants.BROADCAST, (byte) 0x03);
+        node.idle();
+        assertUnwanted();
+    }
+
+    // Case (c): FrameType is not known to this node (unknown byte outside 0..7).
+    @Test
+    public void idle_unwantedFrame_case_c_unknownFrameType() {
+        node.frame.reset();
+        node.frame.setFrameType(FrameType.forId((byte) 0x20));
+        node.frame.setDestinationAddress(TS);
+        node.frame.setSourceAddress((byte) 0x03);
+        node.receivedValidFrame = true;
+        node.idle();
+        assertUnwanted();
+    }
+
+    // Case (d): DestinationAddress equals TS and FrameType is Reply To Poll For Manager or
+    // Reply Postponed.
+    @Test
+    public void idle_unwantedFrame_case_d_replyToPollForManager() {
+        prepareFrame(FrameType.replyToPollForManager, TS, (byte) 0x03);
+        node.idle();
+        assertUnwanted();
+    }
+
+    @Test
+    public void idle_unwantedFrame_case_d_replyPostponed() {
+        prepareFrame(FrameType.replyPostponed, TS, (byte) 0x03);
+        node.idle();
+        assertUnwanted();
+    }
+
+    // ---------- helpers ----------
+
+    private void prepareFrame(final FrameType type, final byte destination, final byte source) {
+        node.frame.reset();
+        node.frame.setFrameType(type);
+        node.frame.setDestinationAddress(destination);
+        node.frame.setSourceAddress(source);
+        node.receivedValidFrame = true;
+    }
+
+    private void assertUnwanted() {
+        assertEquals("state must remain IDLE", ManagerNode.ManagerNodeState.idle, node.state);
+        assertFalse("receivedValidFrame must be cleared", node.receivedValidFrame);
+        assertNull("no invalid-frame flag should be set", node.receivedInvalidFrame);
+        assertTrue("no frame should have been sent", node.sentFrames.isEmpty());
+    }
+
+    private static class RecordingManagerNode extends ManagerNode {
+        final List<Frame> sentFrames = new ArrayList<>();
+
+        RecordingManagerNode() {
+            super("test", new ByteArrayInputStream(new byte[0]), new ByteArrayOutputStream(), TS, 1);
+            this.clock = Clock.systemUTC();
+            this.lastNonSilence = this.clock.millis();
+        }
+
+        @Override
+        protected void sendFrame(final Frame frame) {
+            sentFrames.add(frame.copy());
+        }
+    }
+}

--- a/src/test/java/com/serotonin/bacnet4j/util/PropertyUtilsTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/util/PropertyUtilsTest.java
@@ -83,8 +83,8 @@ public class PropertyUtilsTest {
         addObjects(d6);
     }
 
-    private static void addObjects(final LocalDevice d) throws Exception {
-        final int id = d.getInstanceNumber();
+    private static void addObjects(LocalDevice d) throws Exception {
+        int id = d.getInstanceNumber();
         d.writePropertyInternal(PropertyIdentifier.objectName, str("d" + id));
         d.addObject(new BinaryValueObject(d, 0, "ai0", BinaryPV.active, false).writePropertyInternal(
                         PropertyIdentifier.inactiveText, str("inactiveText"))
@@ -97,15 +97,15 @@ public class PropertyUtilsTest {
                 .writePropertyInternal(PropertyIdentifier.activeText, str("activeText")));
     }
 
-    private static CharacterString str(final String s) {
+    private static CharacterString str(String s) {
         return new CharacterString(s);
     }
 
-    private static ObjectIdentifier oid(final ObjectType objectType, final int instanceNumber) {
+    private static ObjectIdentifier oid(ObjectType objectType, int instanceNumber) {
         return new ObjectIdentifier(objectType, instanceNumber);
     }
 
-    private static UnsignedInteger uint(final int value) {
+    private static UnsignedInteger uint(int value) {
         return new UnsignedInteger(value);
     }
 
@@ -125,14 +125,14 @@ public class PropertyUtilsTest {
      */
     @Test
     public void happy() {
-        final DeviceObjectPropertyValues callbackValues = new DeviceObjectPropertyValues();
-        final ReadListener callback = (progress, deviceId, oid, pid, pin, value) -> {
+        DeviceObjectPropertyValues callbackValues = new DeviceObjectPropertyValues();
+        ReadListener callback = (progress, deviceId, oid, pid, pin, value) -> {
             callbackValues.add(deviceId, oid, pid, pin, value);
             return false;
         };
 
         // The values specified here...
-        final DeviceObjectPropertyReferences refs = new DeviceObjectPropertyReferences() //
+        DeviceObjectPropertyReferences refs = new DeviceObjectPropertyReferences() //
                 .add(2, ObjectType.device, 2, PropertyIdentifier.objectName) //
                 .addIndex(2, ObjectType.device, 2, PropertyIdentifier.objectList, 2) //
                 .add(2, ObjectType.binaryValue, 0, PropertyIdentifier.inactiveText, PropertyIdentifier.activeText) //
@@ -151,7 +151,7 @@ public class PropertyUtilsTest {
                 .add(4, ObjectType.binaryValue, 2, PropertyIdentifier.inactiveText, PropertyIdentifier.activeText);
 
         // ... must also be specified here.
-        final DeviceObjectPropertyValues expectedValues = new DeviceObjectPropertyValues() //
+        DeviceObjectPropertyValues expectedValues = new DeviceObjectPropertyValues() //
                 .add(2, ObjectType.device, 2, PropertyIdentifier.objectName, null, str("d2")) //
                 .add(2, ObjectType.device, 2, PropertyIdentifier.objectList, 2,
                         new ObjectIdentifier(ObjectType.binaryValue, 0)) //
@@ -182,7 +182,7 @@ public class PropertyUtilsTest {
                 .add(4, ObjectType.binaryValue, 2, PropertyIdentifier.inactiveText, null, str("inactiveText")) //
                 .add(4, ObjectType.binaryValue, 2, PropertyIdentifier.activeText, null, str("activeText"));
 
-        final DeviceObjectPropertyValues actualValues = PropertyUtils.readProperties(d1, refs, callback);
+        DeviceObjectPropertyValues actualValues = PropertyUtils.readProperties(d1, refs, callback);
 
         assertEquals(expectedValues.size(), callbackValues.size());
         assertEquals(expectedValues, callbackValues);
@@ -262,7 +262,7 @@ public class PropertyUtilsTest {
                 .add(6, ObjectType.binaryValue, 2, PropertyIdentifier.inactiveText, null, str("inactiveText")) //
                 .add(6, ObjectType.binaryValue, 2, PropertyIdentifier.activeText, null, str("activeText"));
 
-        final DeviceObjectPropertyValues actualValues2 = PropertyUtils.readProperties(d1, refs, callback);
+        DeviceObjectPropertyValues actualValues2 = PropertyUtils.readProperties(d1, refs, callback);
 
         assertEquals(expectedValues.size(), callbackValues.size());
         assertEquals(expectedValues, callbackValues);
@@ -288,24 +288,24 @@ public class PropertyUtilsTest {
      */
     @Test
     public void timeout() {
-        final DeviceObjectPropertyValues callbackValues = new DeviceObjectPropertyValues();
-        final ReadListener callback = (progress, deviceId, oid, pid, pin, value) -> {
+        DeviceObjectPropertyValues callbackValues = new DeviceObjectPropertyValues();
+        ReadListener callback = (progress, deviceId, oid, pid, pin, value) -> {
             callbackValues.add(deviceId, oid, pid, pin, value);
             return false;
         };
 
         // The values specified here...
-        final DeviceObjectPropertyReferences refs = new DeviceObjectPropertyReferences() //
+        DeviceObjectPropertyReferences refs = new DeviceObjectPropertyReferences() //
                 .add(6, ObjectType.device, 6, PropertyIdentifier.objectName) //
                 .add(7, ObjectType.device, 7, PropertyIdentifier.objectName);
 
         // ... must also be specified here.
-        final DeviceObjectPropertyValues expectedValues = new DeviceObjectPropertyValues() //
+        DeviceObjectPropertyValues expectedValues = new DeviceObjectPropertyValues() //
                 .add(6, ObjectType.device, 6, PropertyIdentifier.objectName, null, str("d6")) //
                 .add(7, ObjectType.device, 7, PropertyIdentifier.objectName, null,
                         new ErrorClassAndCode(ErrorClass.device, ErrorCode.timeout));
 
-        final DeviceObjectPropertyValues actualValues = PropertyUtils.readProperties(d1, refs, callback, 1200);
+        DeviceObjectPropertyValues actualValues = PropertyUtils.readProperties(d1, refs, callback, 1200);
 
         assertEquals(expectedValues.size(), callbackValues.size());
         assertEquals(expectedValues, callbackValues);
@@ -320,14 +320,14 @@ public class PropertyUtilsTest {
     @Test
     public void addressChangeWithIAm() throws Exception {
         // The values specified here...
-        final DeviceObjectPropertyReferences refs = new DeviceObjectPropertyReferences() //
+        DeviceObjectPropertyReferences refs = new DeviceObjectPropertyReferences() //
                 .add(6, ObjectType.device, 6, PropertyIdentifier.objectName);
 
         // ... must also be specified here.
-        final DeviceObjectPropertyValues expectedValues = new DeviceObjectPropertyValues() //
+        DeviceObjectPropertyValues expectedValues = new DeviceObjectPropertyValues() //
                 .add(6, ObjectType.device, 6, PropertyIdentifier.objectName, null, str("d6"));
 
-        final DeviceObjectPropertyValues actualValues = PropertyUtils.readProperties(d1, refs, null);
+        DeviceObjectPropertyValues actualValues = PropertyUtils.readProperties(d1, refs, null);
 
         assertEquals(expectedValues, actualValues);
         assertEquals(str("d6"),
@@ -348,10 +348,10 @@ public class PropertyUtilsTest {
      */
     @Test
     public void addressChange() throws Exception {
-        final DeviceObjectPropertyReferences refs = new DeviceObjectPropertyReferences() //
+        DeviceObjectPropertyReferences refs = new DeviceObjectPropertyReferences() //
                 .add(6, ObjectType.device, 6, PropertyIdentifier.objectName);
 
-        final DeviceObjectPropertyValues expectedValues = new DeviceObjectPropertyValues() //
+        DeviceObjectPropertyValues expectedValues = new DeviceObjectPropertyValues() //
                 .add(6, ObjectType.device, 6, PropertyIdentifier.objectName, null, str("d6"));
 
         DeviceObjectPropertyValues actualValues = PropertyUtils.readProperties(d1, refs, null, 3000);
@@ -390,38 +390,38 @@ public class PropertyUtilsTest {
 
     @Test
     public void deviceProperties() {
-        final DeviceObjectPropertyReferences refs = new DeviceObjectPropertyReferences() //
+        DeviceObjectPropertyReferences refs = new DeviceObjectPropertyReferences() //
                 .add(2, ObjectType.device, 2, PropertyIdentifier.systemStatus) //
                 .add(2, ObjectType.device, 2, PropertyIdentifier.maxApduLengthAccepted) //
                 .add(2, ObjectType.device, 2, PropertyIdentifier.vendorName);
 
-        final DeviceObjectPropertyValues expectedValues = new DeviceObjectPropertyValues() //
+        DeviceObjectPropertyValues expectedValues = new DeviceObjectPropertyValues() //
                 .add(2, ObjectType.device, 2, PropertyIdentifier.systemStatus, null, DeviceStatus.operational) //
                 .add(2, ObjectType.device, 2, PropertyIdentifier.maxApduLengthAccepted, null,
                         new UnsignedInteger(1476)) //
                 .add(2, ObjectType.device, 2, PropertyIdentifier.vendorName, null,
-                        str("Infinite Automation Systems, Inc."));
+                        str("Radix IoT LLC"));
 
-        final DeviceObjectPropertyValues actualValues = PropertyUtils.readProperties(d1, refs, null, 3000);
+        DeviceObjectPropertyValues actualValues = PropertyUtils.readProperties(d1, refs, null, 3000);
 
         assertEquals(expectedValues, actualValues);
     }
 
     @Test
     public void unknownObjectInReadMultiple() {
-        final DeviceObjectPropertyReferences refs = new DeviceObjectPropertyReferences() //
+        DeviceObjectPropertyReferences refs = new DeviceObjectPropertyReferences() //
                 .add(2, ObjectType.device, 2, PropertyIdentifier.systemStatus) //
                 .add(2, ObjectType.device, 2, PropertyIdentifier.maxApduLengthAccepted) //
                 .add(2, ObjectType.analogInput, 2, PropertyIdentifier.vendorName);
 
-        final DeviceObjectPropertyValues expectedValues = new DeviceObjectPropertyValues() //
+        DeviceObjectPropertyValues expectedValues = new DeviceObjectPropertyValues() //
                 .add(2, ObjectType.device, 2, PropertyIdentifier.systemStatus, null, DeviceStatus.operational) //
                 .add(2, ObjectType.device, 2, PropertyIdentifier.maxApduLengthAccepted, null,
                         new UnsignedInteger(1476)) //
                 .add(2, ObjectType.analogInput, 2, PropertyIdentifier.vendorName, null,
                         new ErrorClassAndCode(ErrorClass.object, ErrorCode.unknownObject));
 
-        final DeviceObjectPropertyValues actualValues = PropertyUtils.readProperties(d1, refs, null, 3000);
+        DeviceObjectPropertyValues actualValues = PropertyUtils.readProperties(d1, refs, null, 3000);
 
         assertEquals(expectedValues, actualValues);
     }


### PR DESCRIPTION
https://radixiot.atlassian.net/browse/MANGO-2954

Addenda bm and ce — MS/TP updates and nomenclature refresh

Code changes here have no production effect, including logic changes in the state machine code.

BACnet4J now claims protocol version 20 compliance (up from 19)

- First commit: Addendum 135-2016bm — MS/TP data-link corrections: reduces the allowed upper bound of T_usage_timeout from 100 ms to 35 ms, and adds explicit ReceivedUnwantedFrame handling in the IDLE state per clause 9.5.6.2 (cases a–d, including the new (d) for Reply-To-PFM/Reply-Postponed frames addressed to TS). Documentation-only PICS additions from bm-2 are not applicable to this library.
- Second commit: Addendum 135-2020ce-1 — MS/TP language replacement: renames the data-link classes and identifiers to the "manager/subordinate" terminology. MasterNode → ManagerNode, SlaveNode → SubordinateNode, RealtimeMasterNode → RealtimeManagerNode; enums MasterNodeState/SlaveNodeState and enum values pollForMaster/replyToPollForMaster renamed accordingly; Constants.MAX_MASTER → MAX_MANAGER; setMaxMaster → setMaxManager; getMasterNode → getManagerNode. Breaking change for library consumers.
- Wire encoding is unchanged: frame type IDs (0x01, 0x02), property identifiers (64), and MAX_MANAGER=127 all keep their numeric values. Javadoc, log messages, and state-machine transition labels are updated to match the current spec text.

Includes cleanup of "final" dross, as well as many SQ notes