### PR TITLE
MANGO-2996 Modify Logging Objects to Allow for Extremely Large Logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ trendLogMult.writeProperty(PropertyIdentifier.recordCount, new UnsignedInteger(1
 - CharacterStringObject was renamed to CharacterStringValueObject
 - LifeSafetyPoint and LifeSafetyZone now handle `trackingValue` and `reliability` properly according to out of service
   rules.
+- Changes for compliance with addendum 135-2016bi-3 regarding extremely large logs
 
 *Version 6.2.0*
 

--- a/src/main/java/com/serotonin/bacnet4j/obj/EventLogObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/EventLogObject.java
@@ -135,12 +135,20 @@ public class EventLogObject extends LogBase {
             Boolean oldStopWhenFull = (Boolean) oldValue;
             Boolean stopWhenFull = (Boolean) newValue;
             if (!oldStopWhenFull.booleanValue() && stopWhenFull.booleanValue()) {
-                // Turning StopWhenFull on.
+                // Turning StopWhenFull on. If the buffer is full — either by Record_Count reaching Buffer_Size,
+                // or (per bi-3) Buffer_Size holds the unknown-size sentinel and no space is available — discard
+                // the oldest record, set Enable to FALSE, record the event.
                 Unsigned32 bufferSize = get(PropertyIdentifier.bufferSize);
-                if (buffer.size() >= bufferSize.intValue()) {
+                if (isBufferFull(bufferSize)) {
                     synchronized (buffer) {
-                        while (buffer.size() >= bufferSize.intValue())
+                        if (bufferSize.longValue() == BUFFER_SIZE_UNKNOWN) {
+                            // Sentinel mode: fullness is signaled by the buffer, not by a fixed count. A single
+                            // discard is the spec-mandated action.
                             buffer.remove();
+                        } else {
+                            while (buffer.size() >= bufferSize.intValue())
+                                buffer.remove();
+                        }
                     }
                     updateRecordCount();
                     writePropertyInternal(PropertyIdentifier.enable, Boolean.FALSE);
@@ -148,10 +156,13 @@ public class EventLogObject extends LogBase {
             }
         } else if (PropertyIdentifier.bufferSize.equals(pid)) {
             Unsigned32 bufferSize = (Unsigned32) newValue;
-            // In case the buffer size was reduced, remove extra entries in the buffer.
-            synchronized (buffer) {
-                while (buffer.size() >= bufferSize.intValue())
-                    buffer.remove();
+            // In case the buffer size was reduced, remove extra entries in the buffer. Skip when the value is the
+            // reserved "unknown size" sentinel — that means there is no fixed cap.
+            if (bufferSize.longValue() != BUFFER_SIZE_UNKNOWN) {
+                synchronized (buffer) {
+                    while (buffer.size() >= bufferSize.intValue())
+                        buffer.remove();
+                }
             }
             updateRecordCount();
         }

--- a/src/main/java/com/serotonin/bacnet4j/obj/EventLogObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/EventLogObject.java
@@ -138,21 +138,6 @@ public class EventLogObject extends LogBase {
         getLocalDevice().getEventHandler().removeListener(eventListener);
     }
 
-    //    @Override
-    //    protected void evaluateLogDisabled() {
-    //        // Don't evaluate until instantiation is complete.
-    //        if (buffer != null) {
-    //            DateTime now = getNow();
-    //            boolean newValue = !allowLogging(now);
-    //            if (logDisabled != newValue) {
-    //                logDisabled = newValue;
-    //                if (logDisabled)
-    //                    // Only write a log status if the log is disabled.
-    //                    addLogRecordImpl(new EventLogRecord(now, new LogStatus(logDisabled, false, false)));
-    //            }
-    //        }
-    //    }
-
     @Override
     protected void evaluateLogDisabled() {
         // Don't evaluate until instantiation is complete.

--- a/src/main/java/com/serotonin/bacnet4j/obj/EventLogObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/EventLogObject.java
@@ -35,7 +35,6 @@ import com.serotonin.bacnet4j.obj.logBuffer.ILogRecord;
 import com.serotonin.bacnet4j.obj.logBuffer.LinkedListLogBuffer;
 import com.serotonin.bacnet4j.obj.logBuffer.LogBuffer;
 import com.serotonin.bacnet4j.service.confirmed.ConfirmedEventNotificationRequest;
-import com.serotonin.bacnet4j.type.Encodable;
 import com.serotonin.bacnet4j.type.constructed.DateTime;
 import com.serotonin.bacnet4j.type.constructed.EventLogRecord;
 import com.serotonin.bacnet4j.type.constructed.EventTransitionBits;
@@ -50,7 +49,6 @@ import com.serotonin.bacnet4j.type.notificationParameters.NotificationParameters
 import com.serotonin.bacnet4j.type.primitive.Boolean;
 import com.serotonin.bacnet4j.type.primitive.CharacterString;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
-import com.serotonin.bacnet4j.type.primitive.Unsigned32;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
 public class EventLogObject extends LogBase {
@@ -129,51 +127,8 @@ public class EventLogObject extends LogBase {
     }
 
     @Override
-    protected void afterWriteProperty(PropertyIdentifier pid, Encodable oldValue, Encodable newValue) {
-        super.afterWriteProperty(pid, oldValue, newValue);
-        if (PropertyIdentifier.stopWhenFull.equals(pid)) {
-            Boolean oldStopWhenFull = (Boolean) oldValue;
-            Boolean stopWhenFull = (Boolean) newValue;
-            if (!oldStopWhenFull.booleanValue() && stopWhenFull.booleanValue()) {
-                // Turning StopWhenFull on. If the buffer is full — either by Record_Count reaching Buffer_Size,
-                // or (per bi-3) Buffer_Size holds the unknown-size sentinel and no space is available — discard
-                // the oldest record, set Enable to FALSE, record the event.
-                Unsigned32 bufferSize = get(PropertyIdentifier.bufferSize);
-                if (isBufferFull(bufferSize)) {
-                    synchronized (buffer) {
-                        if (bufferSize.longValue() == BUFFER_SIZE_UNKNOWN) {
-                            // Sentinel mode: fullness is signaled by the buffer, not by a fixed count. A single
-                            // discard is the spec-mandated action.
-                            buffer.remove();
-                        } else {
-                            while (buffer.size() >= bufferSize.intValue())
-                                buffer.remove();
-                        }
-                    }
-                    updateRecordCount();
-                    writePropertyInternal(PropertyIdentifier.enable, Boolean.FALSE);
-                }
-            }
-        } else if (PropertyIdentifier.bufferSize.equals(pid)) {
-            Unsigned32 bufferSize = (Unsigned32) newValue;
-            // In case the buffer size was reduced, remove extra entries in the buffer. Skip when the value is the
-            // reserved "unknown size" sentinel — that means there is no fixed cap.
-            if (bufferSize.longValue() != BUFFER_SIZE_UNKNOWN) {
-                synchronized (buffer) {
-                    while (buffer.size() >= bufferSize.intValue())
-                        buffer.remove();
-                }
-            }
-            updateRecordCount();
-        }
-    }
-
-    @Override
     protected void purge() {
-        synchronized (buffer) {
-            buffer.clear();
-        }
-        writePropertyInternal(PropertyIdentifier.recordsSinceNotification, Unsigned32.ZERO);
+        super.purge();
         addLogRecordImpl(new EventLogRecord(getNow(), new LogStatus(logDisabled, true, false)));
     }
 
@@ -183,29 +138,27 @@ public class EventLogObject extends LogBase {
         getLocalDevice().getEventHandler().removeListener(eventListener);
     }
 
-    private synchronized void addLogRecord(EventLogRecord rec) {
-        // Check if logging is allowed.
-        if (logDisabled)
-            return;
-
-        // Add the new record.
-        addLogRecordImpl(rec);
-
-        fullCheck();
-    }
+    //    @Override
+    //    protected void evaluateLogDisabled() {
+    //        // Don't evaluate until instantiation is complete.
+    //        if (buffer != null) {
+    //            DateTime now = getNow();
+    //            boolean newValue = !allowLogging(now);
+    //            if (logDisabled != newValue) {
+    //                logDisabled = newValue;
+    //                if (logDisabled)
+    //                    // Only write a log status if the log is disabled.
+    //                    addLogRecordImpl(new EventLogRecord(now, new LogStatus(logDisabled, false, false)));
+    //            }
+    //        }
+    //    }
 
     @Override
     protected void evaluateLogDisabled() {
         // Don't evaluate until instantiation is complete.
         if (buffer != null) {
-            DateTime now = getNow();
-            boolean newValue = !allowLogging(now);
-            if (logDisabled != newValue) {
-                logDisabled = newValue;
-                if (logDisabled)
-                    // Only write a log status if the log is disabled.
-                    addLogRecordImpl(new EventLogRecord(now, new LogStatus(logDisabled, false, false)));
-            }
+            updateLogDisabled(now ->
+                    addLogRecordImpl(new EventLogRecord(now, new LogStatus(true, false, false))));
         }
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/obj/LogBase.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/LogBase.java
@@ -206,8 +206,6 @@ public abstract class LogBase extends BACnetObject {
      */
     protected abstract void evaluateLogDisabled();
 
-    protected abstract void purge();
-
     @Override
     protected void beforeReadProperty(PropertyIdentifier pid) throws BACnetServiceException {
         if (PropertyIdentifier.logBuffer.equals(pid)) {
@@ -257,6 +255,40 @@ public abstract class LogBase extends BACnetObject {
             Unsigned32 recordCount = (Unsigned32) newValue;
             if (recordCount.intValue() == 0)
                 purge();
+        } else if (PropertyIdentifier.stopWhenFull.equals(pid)) {
+            Boolean oldStopWhenFull = (Boolean) oldValue;
+            Boolean stopWhenFull = (Boolean) newValue;
+            if (!oldStopWhenFull.booleanValue() && stopWhenFull.booleanValue()) {
+                // Turning StopWhenFull on. If the buffer is full — either by Record_Count reaching Buffer_Size,
+                // or (per bi-3) Buffer_Size holds the unknown-size sentinel and no space is available — discard
+                // the oldest record, set Enable to FALSE, record the event.
+                Unsigned32 bufferSize = get(PropertyIdentifier.bufferSize);
+                if (isBufferFull(bufferSize)) {
+                    doWithBuffer(buffer -> {
+                        if (bufferSize.longValue() == BUFFER_SIZE_UNKNOWN) {
+                            // Sentinel mode: fullness is signaled by the buffer, not by a fixed count. A single
+                            // discard is the spec-mandated action.
+                            buffer.remove();
+                        } else {
+                            while (buffer.size() >= bufferSize.intValue())
+                                buffer.remove();
+                        }
+                    });
+                    updateRecordCount();
+                    writePropertyInternal(PropertyIdentifier.enable, Boolean.FALSE);
+                }
+            }
+        } else if (PropertyIdentifier.bufferSize.equals(pid)) {
+            Unsigned32 bufferSize = (Unsigned32) newValue;
+            // In case the buffer size was reduced, remove extra entries in the buffer. Skip when the value is the
+            // reserved "unknown size" sentinel — that means there is no fixed cap.
+            if (bufferSize.longValue() != BUFFER_SIZE_UNKNOWN) {
+                doWithBuffer(buffer -> {
+                    while (buffer.size() >= bufferSize.intValue())
+                        buffer.remove();
+                });
+            }
+            updateRecordCount();
         }
     }
 
@@ -353,5 +385,33 @@ public abstract class LogBase extends BACnetObject {
             totalRecordCount = new Unsigned32(1);
         rec.setSequenceNumber(totalRecordCount.longValue());
         writePropertyInternal(PropertyIdentifier.totalRecordCount, totalRecordCount);
+    }
+
+    protected synchronized void addLogRecord(ILogRecord rec) {
+        // Check if logging is allowed.
+        if (logDisabled)
+            return;
+
+        // Add the new record.
+        addLogRecordImpl(rec);
+
+        fullCheck();
+    }
+
+    protected void purge() {
+        doWithBuffer(LogBuffer::clear);
+        writePropertyInternal(PropertyIdentifier.recordsSinceNotification, Unsigned32.ZERO);
+    }
+
+    protected void updateLogDisabled(Consumer<DateTime> writeLogStatus) {
+        DateTime now = getNow();
+        boolean newValue = !allowLogging(now);
+        if (logDisabled != newValue) {
+            logDisabled = newValue;
+            if (logDisabled) {
+                // Only write a log status if the log is disabled.
+                writeLogStatus.accept(now);
+            }
+        }
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/obj/LogBase.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/LogBase.java
@@ -103,9 +103,8 @@ public abstract class LogBase extends BACnetObject {
      */
     protected boolean hasSpaceForAnotherRecord() {
         AtomicBoolean hasSpaceForAnotherRecord = new AtomicBoolean(false);
-        doWithBuffer(buffer -> {
-            hasSpaceForAnotherRecord.set(buffer.hasSpaceForAnotherRecord());
-        });
+        doWithBuffer(buffer ->
+                hasSpaceForAnotherRecord.set(buffer.hasSpaceForAnotherRecord()));
         return hasSpaceForAnotherRecord.get();
     }
 

--- a/src/main/java/com/serotonin/bacnet4j/obj/LogBase.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/LogBase.java
@@ -30,6 +30,7 @@ package com.serotonin.bacnet4j.obj;
 import java.util.Objects;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 import com.serotonin.bacnet4j.LocalDevice;
@@ -65,6 +66,12 @@ import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
  * Buffer_Size / Record_Count validation, the mixin setup, and the intrinsic-reporting scaffolding.
  */
 public abstract class LogBase extends BACnetObject {
+    /**
+     * Reserved Buffer_Size value indicating that the buffer size is unknown and constrained solely by currently
+     * available resources. See addendum 135-2016bi-3.
+     */
+    public static final long BUFFER_SIZE_UNKNOWN = 0xFFFFFFFFL;
+
     protected boolean logDisabled;
     protected ScheduledFuture<?> startTimeFuture;
     protected ScheduledFuture<?> stopTimeFuture;
@@ -87,6 +94,19 @@ public abstract class LogBase extends BACnetObject {
         set(PropertyIdentifier.totalRecordCount, Unsigned32.ZERO);
         set(PropertyIdentifier.statusFlags, new StatusFlags(false, false, false, false));
         set(PropertyIdentifier.reliability, Reliability.noFaultDetected);
+    }
+
+    /**
+     * Reports whether the underlying log buffer has room for another record. Concrete subclasses delegate to their
+     * LogBuffer. Used when Buffer_Size holds the reserved sentinel {@link #BUFFER_SIZE_UNKNOWN} — see
+     * addendum 135-2016bi-3.
+     */
+    protected boolean hasSpaceForAnotherRecord() {
+        AtomicBoolean hasSpaceForAnotherRecord = new AtomicBoolean(false);
+        doWithBuffer(buffer -> {
+            hasSpaceForAnotherRecord.set(buffer.hasSpaceForAnotherRecord());
+        });
+        return hasSpaceForAnotherRecord.get();
     }
 
     /**
@@ -202,7 +222,7 @@ public abstract class LogBase extends BACnetObject {
             Boolean stopWhenFull = get(PropertyIdentifier.stopWhenFull);
             Unsigned32 bufferSize = get(PropertyIdentifier.bufferSize);
 
-            if (enable.booleanValue() && stopWhenFull.booleanValue() && bufferSize.intValue() == bufferSize()) {
+            if (enable.booleanValue() && stopWhenFull.booleanValue() && isBufferFull(bufferSize)) {
                 throw new BACnetServiceException(ErrorClass.object, ErrorCode.logBufferFull);
             }
         } else if (PropertyIdentifier.startTime.equals(value.getPropertyIdentifier()) //
@@ -249,9 +269,31 @@ public abstract class LogBase extends BACnetObject {
     protected void fullCheck() {
         Boolean stopWhenFull = get(PropertyIdentifier.stopWhenFull);
         Unsigned32 bufferSize = get(PropertyIdentifier.bufferSize);
-        if (stopWhenFull.booleanValue() && bufferSize() == bufferSize.intValue() - 1) {
+        if (stopWhenFull.booleanValue() && isBufferFullAfterNext(bufferSize)) {
             writePropertyInternal(PropertyIdentifier.enable, Boolean.FALSE);
         }
+    }
+
+    /**
+     * True if Record_Count equals Buffer_Size, or Buffer_Size is the reserved sentinel value and the buffer cannot
+     * accept another record. Per addendum 135-2016bi-3.
+     */
+    protected boolean isBufferFull(Unsigned32 bufferSize) {
+        if (bufferSize.longValue() == BUFFER_SIZE_UNKNOWN) {
+            return !hasSpaceForAnotherRecord();
+        }
+        return bufferSize() >= bufferSize.longValue();
+    }
+
+    /**
+     * True if adding one more record would fill the buffer — either the current fill is one below Buffer_Size, or
+     * Buffer_Size is the reserved sentinel value and the buffer cannot accept another record. Per bi-3.
+     */
+    protected boolean isBufferFullAfterNext(Unsigned32 bufferSize) {
+        if (bufferSize.longValue() == BUFFER_SIZE_UNKNOWN) {
+            return !hasSpaceForAnotherRecord();
+        }
+        return bufferSize() >= bufferSize.longValue() - 1;
     }
 
     protected boolean allowLogging(DateTime now) {
@@ -286,8 +328,9 @@ public abstract class LogBase extends BACnetObject {
         Unsigned32 bufferSize = get(PropertyIdentifier.bufferSize);
 
         doWithBuffer(buf -> {
-            // Don't add more to the buffer than capacity.
-            if (buf.size() == bufferSize.intValue()) {
+            // Don't add more to the buffer than capacity. Also covers the bi-3 unknown-size case where the buffer
+            // itself signals exhaustion.
+            if (isBufferFull(bufferSize)) {
                 // Buffer is already full. Drop the oldest record.
                 buf.remove();
             }

--- a/src/main/java/com/serotonin/bacnet4j/obj/TrendLogBase.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/TrendLogBase.java
@@ -34,17 +34,15 @@ import com.serotonin.bacnet4j.LocalDevice;
 import com.serotonin.bacnet4j.obj.mixin.PollingDelegate;
 import com.serotonin.bacnet4j.type.Encodable;
 import com.serotonin.bacnet4j.type.constructed.DateTime;
+import com.serotonin.bacnet4j.type.constructed.EventTransitionBits;
 import com.serotonin.bacnet4j.type.enumerated.LoggingType;
+import com.serotonin.bacnet4j.type.enumerated.NotifyType;
 import com.serotonin.bacnet4j.type.enumerated.ObjectType;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
 import com.serotonin.bacnet4j.type.primitive.Boolean;
+import com.serotonin.bacnet4j.type.primitive.Unsigned32;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
-/**
- * Base for the periodic-sampling log objects (Trend Log and Trend Log Multiple). Adds the polling
- * / triggering / interval-alignment concerns on top of the buffer-and-schedule primitives provided
- * by {@link LogBase}.
- */
 public abstract class TrendLogBase extends LogBase {
     protected PollingDelegate pollingDelegate;
     protected ScheduledFuture<?> pollingFuture;
@@ -78,8 +76,7 @@ public abstract class TrendLogBase extends LogBase {
 
     @Override
     protected void baseSupportIntrinsicReporting(int notificationThreshold, int notificationClass,
-            com.serotonin.bacnet4j.type.constructed.EventTransitionBits eventEnable,
-            com.serotonin.bacnet4j.type.enumerated.NotifyType notifyType) {
+            EventTransitionBits eventEnable, NotifyType notifyType) {
         super.baseSupportIntrinsicReporting(notificationThreshold, notificationClass, eventEnable, notifyType);
         updateMonitoredProperty();
     }

--- a/src/main/java/com/serotonin/bacnet4j/obj/TrendLogBase.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/TrendLogBase.java
@@ -40,10 +40,13 @@ import com.serotonin.bacnet4j.type.enumerated.NotifyType;
 import com.serotonin.bacnet4j.type.enumerated.ObjectType;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
 import com.serotonin.bacnet4j.type.primitive.Boolean;
-import com.serotonin.bacnet4j.type.primitive.Unsigned32;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
 public abstract class TrendLogBase extends LogBase {
+    protected boolean logDisabled;
+    protected ScheduledFuture<?> startTimeFuture;
+    protected ScheduledFuture<?> stopTimeFuture;
+
     protected PollingDelegate pollingDelegate;
     protected ScheduledFuture<?> pollingFuture;
 

--- a/src/main/java/com/serotonin/bacnet4j/obj/TrendLogBase.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/TrendLogBase.java
@@ -43,10 +43,6 @@ import com.serotonin.bacnet4j.type.primitive.Boolean;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
 public abstract class TrendLogBase extends LogBase {
-    protected boolean logDisabled;
-    protected ScheduledFuture<?> startTimeFuture;
-    protected ScheduledFuture<?> stopTimeFuture;
-
     protected PollingDelegate pollingDelegate;
     protected ScheduledFuture<?> pollingFuture;
 

--- a/src/main/java/com/serotonin/bacnet4j/obj/TrendLogMultipleObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/TrendLogMultipleObject.java
@@ -59,8 +59,6 @@ import com.serotonin.bacnet4j.type.enumerated.NotifyType;
 import com.serotonin.bacnet4j.type.enumerated.ObjectType;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
 import com.serotonin.bacnet4j.type.error.ErrorClassAndCode;
-import com.serotonin.bacnet4j.type.primitive.Boolean;
-import com.serotonin.bacnet4j.type.primitive.Unsigned32;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 import com.serotonin.bacnet4j.util.DeviceObjectPropertyReferences;
 import com.serotonin.bacnet4j.util.DeviceObjectPropertyValues;
@@ -173,49 +171,12 @@ public class TrendLogMultipleObject extends TrendLogBase {
 
         if (PropertyIdentifier.logInterval.equals(pid)) {
             updateLoggingType();
-        } else if (PropertyIdentifier.stopWhenFull.equals(pid)) {
-            Boolean oldStopWhenFull = (Boolean) oldValue;
-            Boolean stopWhenFull = (Boolean) newValue;
-            if (!oldStopWhenFull.booleanValue() && stopWhenFull.booleanValue()) {
-                // Turning StopWhenFull on. If the buffer is full — either by Record_Count reaching Buffer_Size,
-                // or (per bi-3) Buffer_Size holds the unknown-size sentinel and no space is available — discard
-                // the oldest record, set Enable to FALSE, record the event.
-                Unsigned32 bufferSize = get(PropertyIdentifier.bufferSize);
-                if (isBufferFull(bufferSize)) {
-                    synchronized (buffer) {
-                        if (bufferSize.longValue() == BUFFER_SIZE_UNKNOWN) {
-                            // Sentinel mode: fullness is signaled by the buffer, not by a fixed count. A single
-                            // discard is the spec-mandated action.
-                            buffer.remove();
-                        } else {
-                            while (buffer.size() >= bufferSize.intValue())
-                                buffer.remove();
-                        }
-                    }
-                    updateRecordCount();
-                    writePropertyInternal(PropertyIdentifier.enable, Boolean.FALSE);
-                }
-            }
-        } else if (PropertyIdentifier.bufferSize.equals(pid)) {
-            Unsigned32 bufferSize = (Unsigned32) newValue;
-            // In case the buffer size was reduced, remove extra entries in the buffer. Skip when the value is the
-            // reserved "unknown size" sentinel — that means there is no fixed cap.
-            if (bufferSize.longValue() != BUFFER_SIZE_UNKNOWN) {
-                synchronized (buffer) {
-                    while (buffer.size() >= bufferSize.intValue())
-                        buffer.remove();
-                }
-            }
-            updateRecordCount();
         }
     }
 
     @Override
     protected void purge() {
-        synchronized (buffer) {
-            buffer.clear();
-        }
-        writePropertyInternal(PropertyIdentifier.recordsSinceNotification, Unsigned32.ZERO);
+        super.purge();
         addLogRecordImpl(new LogMultipleRecord(getNow(), new LogData(new LogStatus(logDisabled, true, false))));
     }
 
@@ -291,29 +252,12 @@ public class TrendLogMultipleObject extends TrendLogBase {
         addLogRecord(rec);
     }
 
-    private synchronized void addLogRecord(LogMultipleRecord rec) {
-        // Check if logging is allowed.
-        if (logDisabled)
-            return;
-
-        // Add the new record.
-        addLogRecordImpl(rec);
-
-        fullCheck();
-    }
-
     @Override
     protected void evaluateLogDisabled() {
         // Don't evaluate until instantiation is complete.
         if (buffer != null) {
-            DateTime now = getNow();
-            boolean newValue = !allowLogging(now);
-            if (logDisabled != newValue) {
-                logDisabled = newValue;
-                if (logDisabled)
-                    // Only write a log status if the log is disabled.
-                    addLogRecordImpl(new LogMultipleRecord(now, new LogData(new LogStatus(logDisabled, false, false))));
-            }
+            updateLogDisabled(now ->
+                    addLogRecordImpl(new LogMultipleRecord(now, new LogData(new LogStatus(true, false, false)))));
         }
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/obj/TrendLogMultipleObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/TrendLogMultipleObject.java
@@ -177,12 +177,20 @@ public class TrendLogMultipleObject extends TrendLogBase {
             Boolean oldStopWhenFull = (Boolean) oldValue;
             Boolean stopWhenFull = (Boolean) newValue;
             if (!oldStopWhenFull.booleanValue() && stopWhenFull.booleanValue()) {
-                // Turning StopWhenFull on.
+                // Turning StopWhenFull on. If the buffer is full — either by Record_Count reaching Buffer_Size,
+                // or (per bi-3) Buffer_Size holds the unknown-size sentinel and no space is available — discard
+                // the oldest record, set Enable to FALSE, record the event.
                 Unsigned32 bufferSize = get(PropertyIdentifier.bufferSize);
-                if (buffer.size() >= bufferSize.intValue()) {
+                if (isBufferFull(bufferSize)) {
                     synchronized (buffer) {
-                        while (buffer.size() >= bufferSize.intValue())
+                        if (bufferSize.longValue() == BUFFER_SIZE_UNKNOWN) {
+                            // Sentinel mode: fullness is signaled by the buffer, not by a fixed count. A single
+                            // discard is the spec-mandated action.
                             buffer.remove();
+                        } else {
+                            while (buffer.size() >= bufferSize.intValue())
+                                buffer.remove();
+                        }
                     }
                     updateRecordCount();
                     writePropertyInternal(PropertyIdentifier.enable, Boolean.FALSE);
@@ -190,10 +198,13 @@ public class TrendLogMultipleObject extends TrendLogBase {
             }
         } else if (PropertyIdentifier.bufferSize.equals(pid)) {
             Unsigned32 bufferSize = (Unsigned32) newValue;
-            // In case the buffer size was reduced, remove extra entries in the buffer.
-            synchronized (buffer) {
-                while (buffer.size() >= bufferSize.intValue())
-                    buffer.remove();
+            // In case the buffer size was reduced, remove extra entries in the buffer. Skip when the value is the
+            // reserved "unknown size" sentinel — that means there is no fixed cap.
+            if (bufferSize.longValue() != BUFFER_SIZE_UNKNOWN) {
+                synchronized (buffer) {
+                    while (buffer.size() >= bufferSize.intValue())
+                        buffer.remove();
+                }
             }
             updateRecordCount();
         }

--- a/src/main/java/com/serotonin/bacnet4j/obj/TrendLogObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/TrendLogObject.java
@@ -67,7 +67,6 @@ import com.serotonin.bacnet4j.type.enumerated.Reliability;
 import com.serotonin.bacnet4j.type.error.ErrorClassAndCode;
 import com.serotonin.bacnet4j.type.primitive.Boolean;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
-import com.serotonin.bacnet4j.type.primitive.Unsigned32;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 import com.serotonin.bacnet4j.util.DeviceObjectPropertyReferences;
 import com.serotonin.bacnet4j.util.DeviceObjectPropertyValues;
@@ -213,40 +212,6 @@ public class TrendLogObject extends TrendLogBase {
             }
 
             updateLoggingType();
-        } else if (PropertyIdentifier.stopWhenFull.equals(pid)) {
-            Boolean oldStopWhenFull = (Boolean) oldValue;
-            Boolean stopWhenFull = (Boolean) newValue;
-            if (!oldStopWhenFull.booleanValue() && stopWhenFull.booleanValue()) {
-                // Turning StopWhenFull on. If the buffer is full — either by Record_Count reaching Buffer_Size,
-                // or (per bi-3) Buffer_Size holds the unknown-size sentinel and no space is available — discard
-                // the oldest record, set Enable to FALSE, record the event.
-                Unsigned32 bufferSize = get(PropertyIdentifier.bufferSize);
-                if (isBufferFull(bufferSize)) {
-                    synchronized (buffer) {
-                        if (bufferSize.longValue() == BUFFER_SIZE_UNKNOWN) {
-                            // Sentinel mode: fullness is signaled by the buffer, not by a fixed count. A single
-                            // discard is the spec-mandated action.
-                            buffer.remove();
-                        } else {
-                            while (buffer.size() >= bufferSize.intValue())
-                                buffer.remove();
-                        }
-                    }
-                    updateRecordCount();
-                    writePropertyInternal(PropertyIdentifier.enable, Boolean.FALSE);
-                }
-            }
-        } else if (PropertyIdentifier.bufferSize.equals(pid)) {
-            Unsigned32 bufferSize = (Unsigned32) newValue;
-            // In case the buffer size was reduced, remove extra entries in the buffer. Skip when the value is the
-            // reserved "unknown size" sentinel — that means there is no fixed cap.
-            if (bufferSize.longValue() != BUFFER_SIZE_UNKNOWN) {
-                synchronized (buffer) {
-                    while (buffer.size() >= bufferSize.intValue())
-                        buffer.remove();
-                }
-            }
-            updateRecordCount();
         } else if (pid.isOneOf(PropertyIdentifier.covResubscriptionInterval, PropertyIdentifier.clientCovIncrement)) {
             LoggingType loggingType = get(PropertyIdentifier.loggingType);
             if (loggingType.equals(LoggingType.cov)) {
@@ -257,10 +222,7 @@ public class TrendLogObject extends TrendLogBase {
 
     @Override
     protected void purge() {
-        synchronized (buffer) {
-            buffer.clear();
-        }
-        writePropertyInternal(PropertyIdentifier.recordsSinceNotification, Unsigned32.ZERO);
+        super.purge();
         addLogRecordImpl(new LogRecord(getNow(), new LogStatus(logDisabled, true, false), null));
     }
 
@@ -487,29 +449,12 @@ public class TrendLogObject extends TrendLogBase {
         }
     }
 
-    private synchronized void addLogRecord(LogRecord rec) {
-        // Check if logging is allowed.
-        if (logDisabled)
-            return;
-
-        // Add the new record.
-        addLogRecordImpl(rec);
-
-        fullCheck();
-    }
-
     @Override
     protected void evaluateLogDisabled() {
         // Don't evaluate until instantiation is complete.
         if (buffer != null) {
-            DateTime now = getNow();
-            boolean newValue = !allowLogging(now);
-            if (logDisabled != newValue) {
-                logDisabled = newValue;
-                if (logDisabled)
-                    // Only write a log status if the log is disabled.
-                    addLogRecordImpl(new LogRecord(now, new LogStatus(logDisabled, false, false), null));
-            }
+            updateLogDisabled(now ->
+                    addLogRecordImpl(new LogRecord(now, new LogStatus(true, false, false), null)));
         }
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/obj/TrendLogObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/TrendLogObject.java
@@ -217,12 +217,20 @@ public class TrendLogObject extends TrendLogBase {
             Boolean oldStopWhenFull = (Boolean) oldValue;
             Boolean stopWhenFull = (Boolean) newValue;
             if (!oldStopWhenFull.booleanValue() && stopWhenFull.booleanValue()) {
-                // Turning StopWhenFull on.
+                // Turning StopWhenFull on. If the buffer is full — either by Record_Count reaching Buffer_Size,
+                // or (per bi-3) Buffer_Size holds the unknown-size sentinel and no space is available — discard
+                // the oldest record, set Enable to FALSE, record the event.
                 Unsigned32 bufferSize = get(PropertyIdentifier.bufferSize);
-                if (buffer.size() >= bufferSize.intValue()) {
+                if (isBufferFull(bufferSize)) {
                     synchronized (buffer) {
-                        while (buffer.size() >= bufferSize.intValue())
+                        if (bufferSize.longValue() == BUFFER_SIZE_UNKNOWN) {
+                            // Sentinel mode: fullness is signaled by the buffer, not by a fixed count. A single
+                            // discard is the spec-mandated action.
                             buffer.remove();
+                        } else {
+                            while (buffer.size() >= bufferSize.intValue())
+                                buffer.remove();
+                        }
                     }
                     updateRecordCount();
                     writePropertyInternal(PropertyIdentifier.enable, Boolean.FALSE);
@@ -230,10 +238,13 @@ public class TrendLogObject extends TrendLogBase {
             }
         } else if (PropertyIdentifier.bufferSize.equals(pid)) {
             Unsigned32 bufferSize = (Unsigned32) newValue;
-            // In case the buffer size was reduced, remove extra entries in the buffer.
-            synchronized (buffer) {
-                while (buffer.size() >= bufferSize.intValue())
-                    buffer.remove();
+            // In case the buffer size was reduced, remove extra entries in the buffer. Skip when the value is the
+            // reserved "unknown size" sentinel — that means there is no fixed cap.
+            if (bufferSize.longValue() != BUFFER_SIZE_UNKNOWN) {
+                synchronized (buffer) {
+                    while (buffer.size() >= bufferSize.intValue())
+                        buffer.remove();
+                }
             }
             updateRecordCount();
         } else if (pid.isOneOf(PropertyIdentifier.covResubscriptionInterval, PropertyIdentifier.clientCovIncrement)) {

--- a/src/main/java/com/serotonin/bacnet4j/obj/logBuffer/LogBuffer.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/logBuffer/LogBuffer.java
@@ -35,46 +35,42 @@ import com.serotonin.bacnet4j.util.sero.ByteQueue;
  * Base class for all implementations of log buffers. The class extends Encodable so that it can be one of its host
  * object's properties, but the property is not network readable. It's elements, however, are network readable via the
  * ReadRange request.
- *
- * TODO a disk-based log buffer might be nice.
- *
- * @author Matthew
+ * <p>
+ * A disk-based log buffer might be nice.
  */
-abstract public class LogBuffer<E extends ILogRecord> extends Encodable implements RangeReadable<E> {
+public abstract class LogBuffer<E extends ILogRecord> extends Encodable implements RangeReadable<E> {
     @Override
-    public void write(final ByteQueue queue) {
+    public void write(ByteQueue queue) {
         throw new RuntimeException("not actually encodable");
     }
 
     @Override
-    public void write(final ByteQueue queue, final int contextId) {
+    public void write(ByteQueue queue, int contextId) {
         throw new RuntimeException("not actually encodable");
     }
-
-    /**
-     * Returns the current size of the buffer.
-     */
-    @Override
-    abstract public int size();
 
     /**
      * Clears the buffer of all of its records.
      */
-    abstract public void clear();
+    public abstract void clear();
 
     /**
      * Adds the given record to the buffer
      */
-    abstract public void add(E record);
+    public abstract void add(E rec);
 
     /**
      * Removes the oldest record from the buffer, or does nothing if the buffer is empty.
      */
-    abstract public void remove();
+    public abstract void remove();
 
     /**
-     * Returns the record at the given index where 0 is the oldest.
+     * Reports whether the buffer has room for another record. Default implementation returns true — the in-memory
+     * buffer is bounded only by JVM heap. Storage-backed implementations override to signal exhaustion, which drives
+     * the LOG_BUFFER_FULL / discard-oldest behavior when Buffer_Size is the reserved sentinel value 2^32-1 per
+     * addendum 135-2016bi-3.
      */
-    @Override
-    abstract public E get(int index);
+    public boolean hasSpaceForAnotherRecord() {
+        return true;
+    }
 }

--- a/src/test/java/com/serotonin/bacnet4j/obj/EventLogObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/EventLogObjectTest.java
@@ -31,6 +31,7 @@ import static com.serotonin.bacnet4j.TestUtils.advanceClock;
 import static com.serotonin.bacnet4j.TestUtils.assertBACnetServiceException;
 import static com.serotonin.bacnet4j.TestUtils.awaitEquals;
 import static com.serotonin.bacnet4j.TestUtils.quiesce;
+import static com.serotonin.bacnet4j.obj.TrendLogBase.BUFFER_SIZE_UNKNOWN;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -553,5 +554,44 @@ public class EventLogObjectTest extends AbstractTest {
         el.writeProperty(null, new PropertyValue(PropertyIdentifier.recordCount, Unsigned32.ZERO));
         assertEquals(1, el.getBuffer().size());
         assertEquals(new LogStatus(false, true, false), el.getBuffer().get(0).getLogStatus());
+    }
+
+    // ---------- bi-3: extremely large logs — Buffer_Size = 0xFFFFFFFF sentinel ----------
+
+
+    private static class TestExhaustibleLogBuffer extends LinkedListLogBuffer<EventLogRecord> {
+        boolean spaceExhausted;
+
+        @Override
+        public boolean hasSpaceForAnotherRecord() {
+            return !spaceExhausted;
+        }
+    }
+
+    @Test
+    public void bi3_bufferSizeUnknown_enableWhileFullYieldsLogBufferFull() throws Exception {
+        TestExhaustibleLogBuffer buffer = new TestExhaustibleLogBuffer();
+        EventLogObject el = d1.addObject(new EventLogObject(
+                d1, 0, "el", buffer, false, DateTime.UNSPECIFIED, DateTime.UNSPECIFIED, true, 10));
+        el.writeProperty(null,
+                new PropertyValue(PropertyIdentifier.bufferSize, new Unsigned32(BUFFER_SIZE_UNKNOWN)));
+        buffer.spaceExhausted = true;
+
+        assertBACnetServiceException(
+                () -> el.writeProperty(null, new PropertyValue(PropertyIdentifier.enable, Boolean.TRUE)),
+                ErrorClass.object, ErrorCode.logBufferFull);
+    }
+
+    @Test
+    public void bi3_bufferSizeUnknown_enableWhileHasSpaceSucceeds() throws Exception {
+        TestExhaustibleLogBuffer buffer = new TestExhaustibleLogBuffer();
+        EventLogObject el = d1.addObject(new EventLogObject(
+                d1, 0, "el", buffer, false, DateTime.UNSPECIFIED, DateTime.UNSPECIFIED, true, 10));
+        el.writeProperty(null,
+                new PropertyValue(PropertyIdentifier.bufferSize, new Unsigned32(BUFFER_SIZE_UNKNOWN)));
+        buffer.spaceExhausted = false;
+
+        el.writeProperty(null, new PropertyValue(PropertyIdentifier.enable, Boolean.TRUE));
+        assertEquals(Boolean.TRUE, el.get(PropertyIdentifier.enable));
     }
 }

--- a/src/test/java/com/serotonin/bacnet4j/obj/TrendLogMultipleObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/TrendLogMultipleObjectTest.java
@@ -717,4 +717,42 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
         assertEquals(logData2, tl.getRecord(1).getLogData().getData());
         assertEquals(logData2, tl.getRecord(2).getLogData().getData());
     }
+
+    // ---------- bi-3: extremely large logs — Buffer_Size = 0xFFFFFFFF sentinel ----------
+
+    private static class TestExhaustibleLogBuffer extends LinkedListLogBuffer<LogMultipleRecord> {
+        boolean spaceExhausted;
+
+        @Override
+        public boolean hasSpaceForAnotherRecord() {
+            return !spaceExhausted;
+        }
+    }
+
+    @Test
+    public void bi3_bufferSizeUnknown_enableWhileFullYieldsLogBufferFull() throws Exception {
+        TestExhaustibleLogBuffer buffer = new TestExhaustibleLogBuffer();
+        TrendLogMultipleObject tl = d1.addObject(new TrendLogMultipleObject(
+                d1, 0, "tlm", buffer, false, DateTime.UNSPECIFIED, DateTime.UNSPECIFIED, props, 0, true, 10));
+        tl.writeProperty(null,
+                new PropertyValue(PropertyIdentifier.bufferSize, new Unsigned32(TrendLogBase.BUFFER_SIZE_UNKNOWN)));
+        buffer.spaceExhausted = true;
+
+        assertBACnetServiceException(
+                () -> tl.writeProperty(null, new PropertyValue(PropertyIdentifier.enable, Boolean.TRUE)),
+                ErrorClass.object, ErrorCode.logBufferFull);
+    }
+
+    @Test
+    public void bi3_bufferSizeUnknown_enableWhileHasSpaceSucceeds() throws Exception {
+        TestExhaustibleLogBuffer buffer = new TestExhaustibleLogBuffer();
+        TrendLogMultipleObject tl = d1.addObject(new TrendLogMultipleObject(
+                d1, 0, "tlm", buffer, false, DateTime.UNSPECIFIED, DateTime.UNSPECIFIED, props, 0, true, 10));
+        tl.writeProperty(null,
+                new PropertyValue(PropertyIdentifier.bufferSize, new Unsigned32(TrendLogBase.BUFFER_SIZE_UNKNOWN)));
+        buffer.spaceExhausted = false;
+
+        tl.writeProperty(null, new PropertyValue(PropertyIdentifier.enable, Boolean.TRUE));
+        assertEquals(Boolean.TRUE, tl.get(PropertyIdentifier.enable));
+    }
 }

--- a/src/test/java/com/serotonin/bacnet4j/obj/TrendLogMultipleObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/TrendLogMultipleObjectTest.java
@@ -720,6 +720,7 @@ public class TrendLogMultipleObjectTest extends AbstractTest {
 
     // ---------- bi-3: extremely large logs — Buffer_Size = 0xFFFFFFFF sentinel ----------
 
+
     private static class TestExhaustibleLogBuffer extends LinkedListLogBuffer<LogMultipleRecord> {
         boolean spaceExhausted;
 

--- a/src/test/java/com/serotonin/bacnet4j/obj/TrendLogObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/TrendLogObjectTest.java
@@ -858,6 +858,7 @@ public class TrendLogObjectTest extends AbstractTest {
 
     // ---------- bi-3: extremely large logs — Buffer_Size = 0xFFFFFFFF sentinel ----------
 
+
     /**
      * A test log buffer whose "has space" state is toggled programmatically. Used to drive the bi-3 unknown-size
      * behavior deterministically without allocating billions of records.

--- a/src/test/java/com/serotonin/bacnet4j/obj/TrendLogObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/TrendLogObjectTest.java
@@ -855,4 +855,75 @@ public class TrendLogObjectTest extends AbstractTest {
                 new ChangeOfReliabilityNotif(Reliability.configurationError, new StatusFlags(true, true, false, false),
                         new SequenceOf<>())), notif.eventValues());
     }
+
+    // ---------- bi-3: extremely large logs — Buffer_Size = 0xFFFFFFFF sentinel ----------
+
+    /**
+     * A test log buffer whose "has space" state is toggled programmatically. Used to drive the bi-3 unknown-size
+     * behavior deterministically without allocating billions of records.
+     */
+    private static class TestExhaustibleLogBuffer extends LinkedListLogBuffer<LogRecord> {
+        boolean spaceExhausted;
+
+        @Override
+        public boolean hasSpaceForAnotherRecord() {
+            return !spaceExhausted;
+        }
+    }
+
+    @Test
+    public void bi3_bufferSizeUnknown_enableWhileFullYieldsLogBufferFull() throws Exception {
+        // Buffer_Size = 0xFFFFFFFF, Stop_When_Full = TRUE, no space available → Enable=TRUE must yield LOG_BUFFER_FULL.
+        TestExhaustibleLogBuffer buffer = new TestExhaustibleLogBuffer();
+        TrendLogObject tl = d1.addObject(new TrendLogObject(
+                d1, 0, "tl", buffer, false, DateTime.UNSPECIFIED, DateTime.UNSPECIFIED,
+                new DeviceObjectPropertyReference(1, ao.getId(), PropertyIdentifier.presentValue), 0, true, 10));
+        tl.writeProperty(null,
+                new PropertyValue(PropertyIdentifier.bufferSize, new Unsigned32(TrendLogBase.BUFFER_SIZE_UNKNOWN)));
+        buffer.spaceExhausted = true;
+
+        assertBACnetServiceException(
+                () -> tl.writeProperty(null, new PropertyValue(PropertyIdentifier.enable, Boolean.TRUE)),
+                ErrorClass.object, ErrorCode.logBufferFull);
+    }
+
+    @Test
+    public void bi3_bufferSizeUnknown_enableWhileHasSpaceSucceeds() throws Exception {
+        // Buffer_Size = 0xFFFFFFFF and space available → Enable can be written to TRUE normally.
+        TestExhaustibleLogBuffer buffer = new TestExhaustibleLogBuffer();
+        TrendLogObject tl = d1.addObject(new TrendLogObject(
+                d1, 0, "tl", buffer, false, DateTime.UNSPECIFIED, DateTime.UNSPECIFIED,
+                new DeviceObjectPropertyReference(1, ao.getId(), PropertyIdentifier.presentValue), 0, true, 10));
+        tl.writeProperty(null,
+                new PropertyValue(PropertyIdentifier.bufferSize, new Unsigned32(TrendLogBase.BUFFER_SIZE_UNKNOWN)));
+        buffer.spaceExhausted = false;
+
+        tl.writeProperty(null, new PropertyValue(PropertyIdentifier.enable, Boolean.TRUE));
+        assertEquals(Boolean.TRUE, tl.get(PropertyIdentifier.enable));
+    }
+
+    @Test
+    public void bi3_bufferSizeUnknown_writeStopWhenFullWhileExhaustedDisablesLogging() throws Exception {
+        // With Buffer_Size = 0xFFFFFFFF, Enable = TRUE, and no space, writing Stop_When_Full=TRUE must
+        // discard the oldest record and set Enable to FALSE.
+        TestExhaustibleLogBuffer buffer = new TestExhaustibleLogBuffer();
+        TrendLogObject tl = d1.addObject(new TrendLogObject(
+                d1, 0, "tl", buffer, false, DateTime.UNSPECIFIED, DateTime.UNSPECIFIED,
+                new DeviceObjectPropertyReference(1, ao.getId(), PropertyIdentifier.presentValue), 0, false, 10));
+        // Seed the buffer with a few records so we can observe an eviction.
+        tl.writeProperty(null,
+                new PropertyValue(PropertyIdentifier.bufferSize, new Unsigned32(TrendLogBase.BUFFER_SIZE_UNKNOWN)));
+        tl.writeProperty(null, new PropertyValue(PropertyIdentifier.enable, Boolean.TRUE));
+        doTriggers(tl, 3);
+        int initialSize = tl.getRecordCount();
+        assertTrue("buffer should have records before eviction test", initialSize >= 1);
+
+        // Signal exhaustion and turn StopWhenFull on.
+        buffer.spaceExhausted = true;
+        tl.writeProperty(null, new PropertyValue(PropertyIdentifier.stopWhenFull, Boolean.TRUE));
+
+        // Enable must have been set to FALSE and at least the oldest record evicted.
+        assertEquals(Boolean.FALSE, tl.get(PropertyIdentifier.enable));
+        assertTrue("oldest record should have been evicted", tl.getRecordCount() < initialSize);
+    }
 }

--- a/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadRangeRequestTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadRangeRequestTest.java
@@ -75,6 +75,7 @@ import com.serotonin.bacnet4j.type.primitive.Date;
 import com.serotonin.bacnet4j.type.primitive.Null;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
 import com.serotonin.bacnet4j.type.primitive.Real;
+import com.serotonin.bacnet4j.type.primitive.SignedInteger;
 import com.serotonin.bacnet4j.type.primitive.Time;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
@@ -93,7 +94,7 @@ public class ReadRangeRequestTest {
     }
 
     @After
-    public void after() throws Exception {
+    public void after() {
         d1.terminate();
     }
 
@@ -102,7 +103,7 @@ public class ReadRangeRequestTest {
      */
     @Test
     public void networkRead() throws Exception {
-        final SequenceOf<Recipient> recipients =
+        SequenceOf<Recipient> recipients =
                 new SequenceOf<>(new Recipient(new ObjectIdentifier(ObjectType.device, 1)),
                         new Recipient(new ObjectIdentifier(ObjectType.device, 2)),
                         new Recipient(new ObjectIdentifier(ObjectType.device, 3)),
@@ -111,10 +112,10 @@ public class ReadRangeRequestTest {
                         new Recipient(new ObjectIdentifier(ObjectType.device, 6)));
         d1.getObject(d1.getId()).writePropertyInternal(PropertyIdentifier.restartNotificationRecipients, recipients);
 
-        final LocalDevice d2 = new LocalDevice(2, new DefaultTransport(new TestNetwork(map, 2, 0))).initialize();
+        LocalDevice d2 = new LocalDevice(2, new DefaultTransport(new TestNetwork(map, 2, 0))).initialize();
 
-        final RemoteDevice rd1 = d2.getRemoteDeviceBlocking(1);
-        final ReadRangeAck ack =
+        RemoteDevice rd1 = d2.getRemoteDeviceBlocking(1);
+        ReadRangeAck ack =
                 d2.send(rd1, new ReadRangeRequest(d1.getId(), PropertyIdentifier.restartNotificationRecipients, null))
                         .get();
 
@@ -134,29 +135,29 @@ public class ReadRangeRequestTest {
      */
     @Test
     public void trendLogMultiple() throws Exception {
-        final WarpClock clock = new WarpClock();
+        WarpClock clock = new WarpClock();
 
-        final LocalDevice d11 =
+        LocalDevice d11 =
                 new LocalDevice(11, new DefaultTransport(new TestNetwork(map, 11, 0))).withClock(clock).initialize();
-        final AnalogInputObject ai = d11.addObject(new AnalogInputObject(
+        AnalogInputObject ai = d11.addObject(new AnalogInputObject(
                 d11, 0, "ai", 12, EngineeringUnits.noUnits, false));
 
-        final LocalDevice d12 =
+        LocalDevice d12 =
                 new LocalDevice(12, new DefaultTransport(new TestNetwork(map, 12, 0))).withClock(clock).initialize();
-        final TrendLogMultipleObject tl =
+        TrendLogMultipleObject tl =
                 d12.addObject(new TrendLogMultipleObject(d12, 0, "tlm", new LinkedListLogBuffer<>(), true,
                         DateTime.UNSPECIFIED, DateTime.UNSPECIFIED, new BACnetArray<>(
                         new DeviceObjectPropertyReference(11, ai.getId(), PropertyIdentifier.presentValue)), 0, false,
                         100));
 
-        final RemoteDevice rd12 = d11.getRemoteDeviceBlocking(12);
-        final DateTime now = new DateTime(clock.millis());
+        RemoteDevice rd12 = d11.getRemoteDeviceBlocking(12);
+        DateTime now = new DateTime(clock.millis());
 
         // Trigger the trend log a few times.
         doTriggers(tl, 11);
 
         // Read the buffer.
-        final ReadRangeAck ack =
+        ReadRangeAck ack =
                 d11.send(rd12, new ReadRangeRequest(tl.getId(), PropertyIdentifier.logBuffer, null)).get();
 
         assertEquals(tl.getId(), ack.getObjectIdentifier());
@@ -180,7 +181,7 @@ public class ReadRangeRequestTest {
         assertNull(ack.getFirstSequenceNumber());
     }
 
-    private static void doTriggers(final TrendLogMultipleObject tl, final int count) throws Exception {
+    private static void doTriggers(TrendLogMultipleObject tl, int count) throws Exception {
         int remaining = count;
         while (remaining > 0) {
             await(tl::trigger);
@@ -191,8 +192,6 @@ public class ReadRangeRequestTest {
 
     /**
      * 15.8.1.1.4.1.3
-     *
-     * @throws BACnetException
      */
     @Test
     public void positionPositiveCount() throws BACnetException {
@@ -201,7 +200,7 @@ public class ReadRangeRequestTest {
             data.add(new UnsignedInteger(i + 1));
         d1.getObject(d1.getId()).writePropertyInternal(pid, data);
 
-        final ReadRangeAck ack =
+        ReadRangeAck ack =
                 (ReadRangeAck) new ReadRangeRequest(d1.getId(), pid, null, new ByPosition(800, 300)).handle(d1, null);
 
         data = new SequenceOf<>(200);
@@ -219,8 +218,6 @@ public class ReadRangeRequestTest {
 
     /**
      * 15.8.1.1.4.1.4
-     *
-     * @throws BACnetException
      */
     @Test
     public void positionNegativeCount() throws BACnetException {
@@ -229,7 +226,7 @@ public class ReadRangeRequestTest {
             data.add(new UnsignedInteger(i + 1));
         d1.getObject(d1.getId()).writePropertyInternal(pid, data);
 
-        final ReadRangeAck ack =
+        ReadRangeAck ack =
                 (ReadRangeAck) new ReadRangeRequest(d1.getId(), pid, null, new ByPosition(1000, -1000)).handle(d1,
                         null);
 
@@ -248,8 +245,6 @@ public class ReadRangeRequestTest {
 
     /**
      * 15.8.1.1.4.2.3
-     *
-     * @throws BACnetException
      */
     @Test
     public void sequencePositiveCount() throws BACnetException {
@@ -258,7 +253,7 @@ public class ReadRangeRequestTest {
             data.add(createLogRecord(now, 2001 + i));
         d1.getObject(d1.getId()).writePropertyInternal(pid, data);
 
-        final ReadRangeAck ack =
+        ReadRangeAck ack =
                 (ReadRangeAck) new ReadRangeRequest(d1.getId(), pid, null, new BySequenceNumber(2800, 300)).handle(d1,
                         null);
 
@@ -277,8 +272,6 @@ public class ReadRangeRequestTest {
 
     /**
      * 15.8.1.1.4.2.4
-     *
-     * @throws BACnetException
      */
     @Test
     public void sequenceNegativeCount() throws BACnetException {
@@ -287,7 +280,7 @@ public class ReadRangeRequestTest {
             data.add(createLogRecord(now, 2001 + i));
         d1.getObject(d1.getId()).writePropertyInternal(pid, data);
 
-        final ReadRangeAck ack =
+        ReadRangeAck ack =
                 (ReadRangeAck) new ReadRangeRequest(d1.getId(), pid, null, new BySequenceNumber(3000, -1000)).handle(d1,
                         null);
 
@@ -306,20 +299,18 @@ public class ReadRangeRequestTest {
 
     /**
      * 15.8.1.1.4.3.3
-     *
-     * @throws BACnetException
      */
     @Test
     public void timePositiveCount() throws BACnetException {
         SequenceOf<LogRecord> data = new SequenceOf<>(1000);
-        final GregorianCalendar gc = new GregorianCalendar(2013, Calendar.MARCH, 18, 1, 1);
+        GregorianCalendar gc = new GregorianCalendar(2013, Calendar.MARCH, 18, 1, 1);
         for (int i = 0; i < 1000; i++) {
             data.add(createLogRecord(new DateTime(gc), i + 2001));
             gc.add(Calendar.MINUTE, 1);
         }
         d1.getObject(d1.getId()).writePropertyInternal(pid, data);
 
-        final ReadRangeAck ack = (ReadRangeAck) new ReadRangeRequest(d1.getId(), pid, null,
+        ReadRangeAck ack = (ReadRangeAck) new ReadRangeRequest(d1.getId(), pid, null,
                 new ByTime(new DateTime(new Date(2013, Month.MARCH, 18, null), new Time(13, 59, 0, 0)), 300)).handle(d1,
                 null);
 
@@ -341,20 +332,18 @@ public class ReadRangeRequestTest {
 
     /**
      * 15.8.1.1.4.3.4
-     *
-     * @throws BACnetException
      */
     @Test
     public void timePositiveOutdatedCount() throws BACnetException {
         SequenceOf<LogRecord> data = new SequenceOf<>(1000);
-        final GregorianCalendar gc = new GregorianCalendar(2013, Calendar.MARCH, 18, 1, 1);
+        GregorianCalendar gc = new GregorianCalendar(2013, Calendar.MARCH, 18, 1, 1);
         for (int i = 0; i < 1000; i++) {
             data.add(createLogRecord(new DateTime(gc), i + 2001));
             gc.add(Calendar.MINUTE, 1);
         }
         d1.getObject(d1.getId()).writePropertyInternal(pid, data);
 
-        final ReadRangeAck ack = (ReadRangeAck) new ReadRangeRequest(d1.getId(), pid, null,
+        ReadRangeAck ack = (ReadRangeAck) new ReadRangeRequest(d1.getId(), pid, null,
                 new ByTime(new DateTime(new Date(1991, Month.NOVEMBER, 17, null), new Time(19, 20, 0, 0)), 300)).handle(
                 d1, null);
 
@@ -376,20 +365,18 @@ public class ReadRangeRequestTest {
 
     /**
      * 15.8.1.1.4.3.5
-     *
-     * @throws BACnetException
      */
     @Test
     public void timeNegativeCount() throws BACnetException {
         SequenceOf<LogRecord> data = new SequenceOf<>(1000);
-        final GregorianCalendar gc = new GregorianCalendar(2013, Calendar.MARCH, 18, 1, 1);
+        GregorianCalendar gc = new GregorianCalendar(2013, Calendar.MARCH, 18, 1, 1);
         for (int i = 0; i < 1000; i++) {
             data.add(createLogRecord(new DateTime(gc), i + 2001));
             gc.add(Calendar.MINUTE, 1);
         }
         d1.getObject(d1.getId()).writePropertyInternal(pid, data);
 
-        final ReadRangeAck ack = (ReadRangeAck) new ReadRangeRequest(d1.getId(), pid, null,
+        ReadRangeAck ack = (ReadRangeAck) new ReadRangeRequest(d1.getId(), pid, null,
                 new ByTime(new DateTime(new Date(2013, Month.MARCH, 18, null), new Time(17, 40, 0, 0)), -1000)).handle(
                 d1, null);
 
@@ -486,12 +473,12 @@ public class ReadRangeRequestTest {
         }
 
         @Override
-        public void write(final ByteQueue queue) {
+        public void write(ByteQueue queue) {
             throw new RuntimeException("not implemented");
         }
 
         @Override
-        public void write(final ByteQueue queue, final int contextId) {
+        public void write(ByteQueue queue, int contextId) {
             throw new RuntimeException("not implemented");
         }
 
@@ -505,7 +492,7 @@ public class ReadRangeRequestTest {
     public void noData() throws Exception {
         d1.getObject(d1.getId()).writePropertyInternal(pid, new SequenceOf<>());
 
-        final ReadRangeAck ack = (ReadRangeAck) new ReadRangeRequest(d1.getId(), pid, null).handle(d1, null);
+        ReadRangeAck ack = (ReadRangeAck) new ReadRangeRequest(d1.getId(), pid, null).handle(d1, null);
 
         assertEquals(d1.getId(), ack.getObjectIdentifier());
         assertEquals(pid, ack.getPropertyIdentifier());
@@ -523,7 +510,7 @@ public class ReadRangeRequestTest {
             data.add(new UnsignedInteger(i + 1));
         d1.getObject(d1.getId()).writePropertyInternal(pid, data);
 
-        final ReadRangeAck ack =
+        ReadRangeAck ack =
                 (ReadRangeAck) new ReadRangeRequest(d1.getId(), pid, null, new ByPosition(800, 150)).handle(d1, null);
 
         data = new SequenceOf<>(150);
@@ -541,12 +528,12 @@ public class ReadRangeRequestTest {
 
     @Test
     public void positionTooLow() throws BACnetException {
-        final SequenceOf<UnsignedInteger> data = new SequenceOf<>(1000);
+        SequenceOf<UnsignedInteger> data = new SequenceOf<>(1000);
         for (int i = 0; i < 1000; i++)
             data.add(new UnsignedInteger(i + 1));
         d1.getObject(d1.getId()).writePropertyInternal(pid, data);
 
-        final ReadRangeAck ack =
+        ReadRangeAck ack =
                 (ReadRangeAck) new ReadRangeRequest(d1.getId(), pid, null, new ByPosition(0, 150)).handle(d1, null);
 
         assertEquals(d1.getId(), ack.getObjectIdentifier());
@@ -560,12 +547,12 @@ public class ReadRangeRequestTest {
 
     @Test
     public void positionTooHigh() throws BACnetException {
-        final SequenceOf<UnsignedInteger> data = new SequenceOf<>(1000);
+        SequenceOf<UnsignedInteger> data = new SequenceOf<>(1000);
         for (int i = 0; i < 1000; i++)
             data.add(new UnsignedInteger(i + 1));
         d1.getObject(d1.getId()).writePropertyInternal(pid, data);
 
-        final ReadRangeAck ack =
+        ReadRangeAck ack =
                 (ReadRangeAck) new ReadRangeRequest(d1.getId(), pid, null, new ByPosition(1001, 150)).handle(d1, null);
 
         assertEquals(d1.getId(), ack.getObjectIdentifier());
@@ -584,7 +571,7 @@ public class ReadRangeRequestTest {
             data.add(new UnsignedInteger(i + 1));
         d1.getObject(d1.getId()).writePropertyInternal(pid, data);
 
-        final ReadRangeAck ack = (ReadRangeAck) new ReadRangeRequest(d1.getId(), pid, null).handle(d1, null);
+        ReadRangeAck ack = (ReadRangeAck) new ReadRangeRequest(d1.getId(), pid, null).handle(d1, null);
 
         data = new SequenceOf<>(200);
         for (int i = 0; i < 200; i++)
@@ -601,7 +588,7 @@ public class ReadRangeRequestTest {
 
     @Test
     public void sequenceOutOfRange() throws BACnetException {
-        final SequenceOf<LogRecord> data = new SequenceOf<>(1000);
+        SequenceOf<LogRecord> data = new SequenceOf<>(1000);
         for (int i = 0; i < 1000; i++)
             data.add(createLogRecord(now, 2001 + i));
         d1.getObject(d1.getId()).writePropertyInternal(pid, data);
@@ -635,14 +622,14 @@ public class ReadRangeRequestTest {
     @Test
     public void timeNegativeCountSearchMiss() throws BACnetException {
         SequenceOf<LogRecord> data = new SequenceOf<>(1000);
-        final GregorianCalendar gc = new GregorianCalendar(2013, Calendar.MARCH, 18, 1, 1);
+        GregorianCalendar gc = new GregorianCalendar(2013, Calendar.MARCH, 18, 1, 1);
         for (int i = 0; i < 20; i++) {
             data.add(createLogRecord(new DateTime(gc), i + 2001));
             gc.add(Calendar.MINUTE, 1);
         }
         d1.getObject(d1.getId()).writePropertyInternal(pid, data);
 
-        final ReadRangeAck ack = (ReadRangeAck) new ReadRangeRequest(d1.getId(), pid, null,
+        ReadRangeAck ack = (ReadRangeAck) new ReadRangeRequest(d1.getId(), pid, null,
                 new ByTime(new DateTime(new Date(2013, Month.MARCH, 18, null), new Time(1, 15, 30, 0)), -10)).handle(d1,
                 null);
 
@@ -664,8 +651,8 @@ public class ReadRangeRequestTest {
 
     @Test
     public void timeOutOfRange() throws BACnetException {
-        final SequenceOf<LogRecord> data = new SequenceOf<>(1000);
-        final GregorianCalendar gc = new GregorianCalendar(2013, Calendar.MARCH, 18, 1, 1);
+        SequenceOf<LogRecord> data = new SequenceOf<>(1000);
+        GregorianCalendar gc = new GregorianCalendar(2013, Calendar.MARCH, 18, 1, 1);
         for (int i = 0; i < 20; i++) {
             data.add(createLogRecord(new DateTime(gc), i + 2001));
             gc.add(Calendar.MINUTE, 1);
@@ -706,7 +693,7 @@ public class ReadRangeRequestTest {
             data.add(new UnsignedInteger(i + 1));
         d1.getObject(d1.getId()).writePropertyInternal(pid, data);
 
-        final ReadRangeAck ack =
+        ReadRangeAck ack =
                 (ReadRangeAck) new ReadRangeRequest(d1.getId(), pid, null, new ByPosition(951, 100)).handle(d1, null);
 
         data = new SequenceOf<>(50);
@@ -729,7 +716,7 @@ public class ReadRangeRequestTest {
             data.add(new UnsignedInteger(i + 1));
         d1.getObject(d1.getId()).writePropertyInternal(pid, data);
 
-        final ReadRangeAck ack =
+        ReadRangeAck ack =
                 (ReadRangeAck) new ReadRangeRequest(d1.getId(), pid, null, new ByPosition(50, -100)).handle(d1, null);
 
         data = new SequenceOf<>(50);
@@ -745,9 +732,63 @@ public class ReadRangeRequestTest {
         assertNull(ack.getFirstSequenceNumber());
     }
 
-    private static LogRecord createLogRecord(final DateTime timestamp, final long sequenceNumber) {
-        final LogRecord record = new LogRecord(timestamp, Null.instance, null);
-        record.setSequenceNumber(sequenceNumber);
-        return record;
+    private static LogRecord createLogRecord(DateTime timestamp, long sequenceNumber) {
+        LogRecord rec = new LogRecord(timestamp, Null.instance, null);
+        rec.setSequenceNumber(sequenceNumber);
+        return rec;
+    }
+
+    // ---------- bi-3: extremely large logs — ReadRange fields accept Unsigned64 widths ----------
+
+    /**
+     * Per bi-3, Reference Index in ByPosition must accept values > 2^32-1 for devices that carry Unsigned64
+     * Total_Record_Count-style properties. UnsignedInteger is variable-length ASN.1, so the wire encoding already
+     * handles arbitrary widths. This test round-trips a value above the Unsigned32 boundary.
+     */
+    @Test
+    public void bi3_byPosition_referenceIndexOverUnsigned32_roundTrip() throws Exception {
+        UnsignedInteger big = new UnsignedInteger(0x100000000L);
+        ReadRangeRequest req = new ReadRangeRequest(
+                d1.getId(), pid, null, new ByPosition(big, new SignedInteger(1)));
+
+        ByteQueue queue = new ByteQueue();
+        req.write(queue);
+        ReadRangeRequest decoded = new ReadRangeRequest(queue);
+
+        assertEquals(req, decoded);
+    }
+
+    /**
+     * Same test for BySequenceNumber's Reference Sequence Number field.
+     */
+    @Test
+    public void bi3_bySequenceNumber_referenceIndexOverUnsigned32_roundTrip() throws Exception {
+        UnsignedInteger big = new UnsignedInteger(0x123456789L);
+        ReadRangeRequest req = new ReadRangeRequest(
+                d1.getId(), pid, null, new BySequenceNumber(big, new SignedInteger(-5)));
+
+        ByteQueue queue = new ByteQueue();
+        req.write(queue);
+        ReadRangeRequest decoded = new ReadRangeRequest(queue);
+
+        assertEquals(req, decoded);
+    }
+
+    /**
+     * First Sequence Number in the response must also accept > 2^32-1 values.
+     */
+    @Test
+    public void bi3_readRangeAck_firstSequenceNumberOverUnsigned32_roundTrip() throws Exception {
+        UnsignedInteger big = new UnsignedInteger(0xFFFFFFFF00L);
+        ReadRangeAck ack = new ReadRangeAck(d1.getId(), pid, null,
+                new ResultFlags(true, false, false), UnsignedInteger.ZERO, new SequenceOf<>(), big);
+
+        ByteQueue queue = new ByteQueue();
+        ack.write(queue);
+        ReadRangeAck decoded = (ReadRangeAck)
+                com.serotonin.bacnet4j.service.acknowledgement.AcknowledgementService.createAcknowledgementService(
+                        ReadRangeAck.TYPE_ID, queue);
+
+        assertEquals(big, decoded.getFirstSequenceNumber());
     }
 }

--- a/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadRangeRequestTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadRangeRequestTest.java
@@ -86,7 +86,7 @@ public class ReadRangeRequestTest {
     private final TestNetworkMap map = new TestNetworkMap();
     final PropertyIdentifier pid = PropertyIdentifier.forId(9999);
     private final LocalDevice d1 = new LocalDevice(1, new DefaultTransport(new TestNetwork(map, 1, 0)));
-    final DateTime now = new DateTime(d1);
+    final DateTime localNow = new DateTime(d1);
 
     @Before
     public void before() throws Exception {
@@ -250,7 +250,7 @@ public class ReadRangeRequestTest {
     public void sequencePositiveCount() throws BACnetException {
         SequenceOf<LogRecord> data = new SequenceOf<>(1000);
         for (int i = 0; i < 1000; i++)
-            data.add(createLogRecord(now, 2001 + i));
+            data.add(createLogRecord(localNow, 2001 + i));
         d1.getObject(d1.getId()).writePropertyInternal(pid, data);
 
         ReadRangeAck ack =
@@ -259,7 +259,7 @@ public class ReadRangeRequestTest {
 
         data = new SequenceOf<>(200);
         for (int i = 0; i < 200; i++)
-            data.add(createLogRecord(now, i + 2800));
+            data.add(createLogRecord(localNow, i + 2800));
 
         assertEquals(d1.getId(), ack.getObjectIdentifier());
         assertEquals(pid, ack.getPropertyIdentifier());
@@ -277,7 +277,7 @@ public class ReadRangeRequestTest {
     public void sequenceNegativeCount() throws BACnetException {
         SequenceOf<LogRecord> data = new SequenceOf<>(1000);
         for (int i = 0; i < 1000; i++)
-            data.add(createLogRecord(now, 2001 + i));
+            data.add(createLogRecord(localNow, 2001 + i));
         d1.getObject(d1.getId()).writePropertyInternal(pid, data);
 
         ReadRangeAck ack =
@@ -286,7 +286,7 @@ public class ReadRangeRequestTest {
 
         data = new SequenceOf<>(200);
         for (int i = 0; i < 200; i++)
-            data.add(createLogRecord(now, i + 2801));
+            data.add(createLogRecord(localNow, i + 2801));
 
         assertEquals(d1.getId(), ack.getObjectIdentifier());
         assertEquals(pid, ack.getPropertyIdentifier());
@@ -590,7 +590,7 @@ public class ReadRangeRequestTest {
     public void sequenceOutOfRange() throws BACnetException {
         SequenceOf<LogRecord> data = new SequenceOf<>(1000);
         for (int i = 0; i < 1000; i++)
-            data.add(createLogRecord(now, 2001 + i));
+            data.add(createLogRecord(localNow, 2001 + i));
         d1.getObject(d1.getId()).writePropertyInternal(pid, data);
 
         // Too low


### PR DESCRIPTION
https://radixiot.atlassian.net/browse/MANGO-2996

- Implements the Buffer_Size = 2³²−1 sentinel semantics from addendum 135-2016bi-3 for TrendLog, TrendLogMultiple, and EventLog objects. When Buffer_Size holds this reserved value, the object treats the buffer as "size unknown, constrained only by available resources"; the Enable, Stop_When_Full, and record-add paths defer to the buffer's own exhaustion signal instead of comparing Record_Count to a fixed cap.
- Adds a hasSpaceForAnotherRecord() extension point on LogBuffer (default true). Storage-backed buffers embedded by downstream products override this to signal exhaustion, which is what drives the LOG_BUFFER_FULL response and the discard-oldest / disable / record-event behavior in sentinel mode.
- Fixes a latent width mismatch in the buffer-full comparisons: the previous code compared Unsigned32.intValue() (which returns -1 for 0xFFFFFFFF due to Java signed-int overflow) against the actual buffer occupancy, so the LOG_BUFFER_FULL branch could never fire for the sentinel value. New helpers isBufferFull / isBufferFullAfterNext use longValue() and route through the sentinel branch when applicable.
- No wire-format change. UnsignedInteger is already variable-length ASN.1, so ReadRange Reference Index, Reference Sequence Number, and First Sequence Number fields already accept Unsigned64 values on the wire. Round-trip tests confirm.

Some cleanup of "final" flotsam and SQ notes.