### PR TITLE
MANGO-2956 Accept writes of null to non-commandable properties for rev 21 compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ trendLogMult.writeProperty(PropertyIdentifier.recordCount, new UnsignedInteger(1
 - Protocol revision increased to 20
 - Many renamings on multiple levels (class, method, field, enum, etc.) to make BACnet4J compliant with MS/TP
   nomenclature changes
+- Names of engineering units have been changed to align with the spec
+- CharacterStringObject was renamed to CharacterStringValueObject
 
 *Version 6.2.0*
 

--- a/src/main/java/com/serotonin/bacnet4j/obj/BACnetObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/BACnetObject.java
@@ -69,6 +69,7 @@ import com.serotonin.bacnet4j.type.enumerated.ObjectType;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
 import com.serotonin.bacnet4j.type.primitive.Boolean;
 import com.serotonin.bacnet4j.type.primitive.CharacterString;
+import com.serotonin.bacnet4j.type.primitive.Null;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
 import com.serotonin.bacnet4j.type.primitive.Real;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
@@ -94,20 +95,19 @@ public class BACnetObject {
     // Configuration
     private boolean deletable;
 
-    public BACnetObject(final LocalDevice localDevice, final ObjectType type, final int instanceNumber) {
+    public BACnetObject(LocalDevice localDevice, ObjectType type, int instanceNumber) {
         this(localDevice, type, instanceNumber, null);
     }
 
-    public BACnetObject(final LocalDevice localDevice, final ObjectType type, final int instanceNumber,
-            final String name) {
+    public BACnetObject(LocalDevice localDevice, ObjectType type, int instanceNumber, String name) {
         this(localDevice, new ObjectIdentifier(type, instanceNumber), name);
     }
 
-    public BACnetObject(final LocalDevice localDevice, final ObjectIdentifier id) {
+    public BACnetObject(LocalDevice localDevice, ObjectIdentifier id) {
         this(localDevice, id, null);
     }
 
-    public BACnetObject(final LocalDevice localDevice, final ObjectIdentifier id, final String name) {
+    public BACnetObject(LocalDevice localDevice, ObjectIdentifier id, String name) {
         Objects.requireNonNull(localDevice);
         Objects.requireNonNull(id);
 
@@ -136,7 +136,7 @@ public class BACnetObject {
     }
 
     public String getObjectName() {
-        final CharacterString name = get(PropertyIdentifier.objectName);
+        CharacterString name = get(PropertyIdentifier.objectName);
         if (name == null)
             return null;
         return name.getValue();
@@ -150,7 +150,7 @@ public class BACnetObject {
         return deletable;
     }
 
-    public void setDeletable(final boolean deletable) {
+    public void setDeletable(boolean deletable) {
         this.deletable = deletable;
     }
 
@@ -160,7 +160,7 @@ public class BACnetObject {
     //
     public final void initialize() {
         // Notify the mixins
-        for (final AbstractMixin mixin : mixins) {
+        for (AbstractMixin mixin : mixins) {
             mixin.initialize();
         }
         initializeImpl();
@@ -175,7 +175,7 @@ public class BACnetObject {
      */
     public final void terminate() {
         // Notify the mixins
-        for (final AbstractMixin mixin : mixins) {
+        for (AbstractMixin mixin : mixins) {
             mixin.terminate();
         }
         terminateImpl();
@@ -189,11 +189,11 @@ public class BACnetObject {
     //
     // Listeners
     //
-    public void addListener(final BACnetObjectListener l) {
+    public void addListener(BACnetObjectListener l) {
         listeners.add(l);
     }
 
-    public void removeListener(final BACnetObjectListener l) {
+    public void removeListener(BACnetObjectListener l) {
         listeners.remove(l);
     }
 
@@ -201,11 +201,11 @@ public class BACnetObject {
     //
     // Mixins
     //
-    protected final void addMixin(final AbstractMixin mixin) {
+    protected final void addMixin(AbstractMixin mixin) {
         addMixin(mixins.size(), mixin);
     }
 
-    protected final void addMixin(int index, final AbstractMixin mixin) {
+    protected final void addMixin(int index, AbstractMixin mixin) {
         mixins.add(index, mixin);
 
         if (mixin instanceof HasStatusFlagsMixin m)
@@ -218,7 +218,7 @@ public class BACnetObject {
             changeOfValueMixin = m;
     }
 
-    public void setOverridden(final boolean b) {
+    public void setOverridden(boolean b) {
         if (hasStatusFlagsMixin != null)
             hasStatusFlagsMixin.setOverridden(b);
         if (commandableMixin != null)
@@ -235,7 +235,7 @@ public class BACnetObject {
 
     //
     // Commandable
-    protected void _supportCommandable(final Encodable relinquishDefault) {
+    protected void _supportCommandable(Encodable relinquishDefault) {
         if (commandableMixin != null)
             commandableMixin.supportCommandable(relinquishDefault);
     }
@@ -270,9 +270,8 @@ public class BACnetObject {
 
     //
     // Intrinsic reporting
-    public void acknowledgeAlarm(final UnsignedInteger acknowledgingProcessIdentifier,
-            final EventState eventStateAcknowledged, final TimeStamp timeStamp,
-            final CharacterString acknowledgmentSource, final TimeStamp timeOfAcknowledgment)
+    public void acknowledgeAlarm(UnsignedInteger acknowledgingProcessIdentifier, EventState eventStateAcknowledged,
+            TimeStamp timeStamp, CharacterString acknowledgmentSource, TimeStamp timeOfAcknowledgment)
             throws BACnetServiceException {
         if (eventReportingMixin == null)
             throw new BACnetServiceException(ErrorClass.object, ErrorCode.noAlarmConfigured);
@@ -282,7 +281,7 @@ public class BACnetObject {
 
     //
     // COVs
-    protected void _supportCovReporting(final Real covIncrement, final UnsignedInteger covPeriod) {
+    protected void _supportCovReporting(Real covIncrement, UnsignedInteger covPeriod) {
         addMixin(new CovReportingMixin(this, covIncrement, covPeriod));
     }
 
@@ -298,10 +297,9 @@ public class BACnetObject {
         return null;
     }
 
-    public EnrollmentSummary getEnrollmentSummary(final AcknowledgmentFilter acknowledgmentFilter,
-            final RecipientProcess enrollmentFilter, final EventStateFilter eventStateFilter,
-            final EventType eventTypeFilter, final PriorityFilter priorityFilter,
-            final UnsignedInteger notificationClassFilter) {
+    public EnrollmentSummary getEnrollmentSummary(AcknowledgmentFilter acknowledgmentFilter,
+            RecipientProcess enrollmentFilter, EventStateFilter eventStateFilter, EventType eventTypeFilter,
+            PriorityFilter priorityFilter, UnsignedInteger notificationClassFilter) {
         if (eventReportingMixin != null)
             return eventReportingMixin.getEnrollmentSummary(acknowledgmentFilter, enrollmentFilter,
                     eventStateFilter, eventTypeFilter, priorityFilter, notificationClassFilter);
@@ -310,25 +308,24 @@ public class BACnetObject {
 
     //
     // COV
-    public void addCovSubscription(final Address from, final UnsignedInteger subscriberProcessIdentifier,
-            final Boolean issueConfirmedNotifications, final UnsignedInteger lifetime,
-            final PropertyReference monitoredPropertyIdentifier, final Real covIncrement)
-            throws BACnetServiceException {
+    public void addCovSubscription(Address from, UnsignedInteger subscriberProcessIdentifier,
+            Boolean issueConfirmedNotifications, UnsignedInteger lifetime,
+            PropertyReference monitoredPropertyIdentifier, Real covIncrement) throws BACnetServiceException {
         if (changeOfValueMixin == null)
             throw new BACnetServiceException(ErrorClass.object, ErrorCode.optionalFunctionalityNotSupported);
         changeOfValueMixin.addCovSubscription(from, subscriberProcessIdentifier, issueConfirmedNotifications, lifetime,
                 monitoredPropertyIdentifier, covIncrement);
     }
 
-    public void removeCovSubscription(final Address from, final UnsignedInteger subscriberProcessIdentifier,
-            final PropertyReference monitoredPropertyIdentifier) {
+    public void removeCovSubscription(Address from, UnsignedInteger subscriberProcessIdentifier,
+            PropertyReference monitoredPropertyIdentifier) {
         if (changeOfValueMixin != null)
             changeOfValueMixin.removeCovSubscription(from, subscriberProcessIdentifier, monitoredPropertyIdentifier);
     }
 
     //
     // Persistence
-    public String getPersistenceKey(final PropertyIdentifier pid) {
+    public String getPersistenceKey(PropertyIdentifier pid) {
         return objectType.toString() + "." + getInstanceId() + "." + pid;
     }
 
@@ -342,7 +339,7 @@ public class BACnetObject {
      * all mixins and retrieves the property directly from the internal map.
      */
     @SuppressWarnings("unchecked")
-    public <T extends Encodable> T get(final PropertyIdentifier pid) {
+    public <T extends Encodable> T get(PropertyIdentifier pid) {
         return (T) properties.get(pid);
     }
 
@@ -353,9 +350,9 @@ public class BACnetObject {
      * @throws BACnetServiceException if the object objected to the read
      */
     @SuppressWarnings("unchecked")
-    public final <T extends Encodable> T readProperty(final PropertyIdentifier pid) throws BACnetServiceException {
+    public final <T extends Encodable> T readProperty(PropertyIdentifier pid) throws BACnetServiceException {
         // Give the mixins notice that the property is being read.
-        for (final AbstractMixin mixin : mixins)
+        for (AbstractMixin mixin : mixins)
             mixin.beforeReadProperty(pid);
         beforeReadProperty(pid);
 
@@ -368,8 +365,8 @@ public class BACnetObject {
      *
      * @throws BACnetServiceException if the object objected to the read, or if the property was not found (was null).
      */
-    public final Encodable readPropertyRequired(final PropertyIdentifier pid) throws BACnetServiceException {
-        final Encodable p = readProperty(pid);
+    public final Encodable readPropertyRequired(PropertyIdentifier pid) throws BACnetServiceException {
+        Encodable p = readProperty(pid);
         if (p == null)
             throw new BACnetServiceException(ErrorClass.property, ErrorCode.unknownProperty);
         return p;
@@ -381,16 +378,16 @@ public class BACnetObject {
      *
      * @throws BACnetServiceException if the object objected to the read
      */
-    public final Encodable readProperty(final PropertyIdentifier pid, final UnsignedInteger propertyArrayIndex)
+    public final Encodable readProperty(PropertyIdentifier pid, UnsignedInteger propertyArrayIndex)
             throws BACnetServiceException {
-        final Encodable result = readProperty(pid);
+        Encodable result = readProperty(pid);
         if (propertyArrayIndex == null)
             return result;
 
         if (!(result instanceof BACnetArray<?> array))
             throw new BACnetServiceException(ErrorClass.property, ErrorCode.propertyIsNotAnArray);
 
-        final int index = propertyArrayIndex.intValue();
+        int index = propertyArrayIndex.intValue();
         if (index == 0)
             return new UnsignedInteger(array.getCount());
 
@@ -410,9 +407,9 @@ public class BACnetObject {
      *
      * @throws BACnetServiceException if the object objected to the read, or if the property was not found (was null).
      */
-    public final Encodable readPropertyRequired(final PropertyIdentifier pid, final UnsignedInteger propertyArrayIndex)
+    public final Encodable readPropertyRequired(PropertyIdentifier pid, UnsignedInteger propertyArrayIndex)
             throws BACnetServiceException {
-        final Encodable p = readProperty(pid, propertyArrayIndex);
+        Encodable p = readProperty(pid, propertyArrayIndex);
         if (p == null)
             throw new BACnetServiceException(ErrorClass.property, ErrorCode.unknownProperty);
         return p;
@@ -427,23 +424,23 @@ public class BACnetObject {
      * Write a property with no notifications. Circumvents the object and all mixins for validations, handling, and
      * post-write notifications.
      */
-    protected void set(final PropertyIdentifier pid, final Encodable value) {
+    protected void set(PropertyIdentifier pid, Encodable value) {
         properties.put(pid, value);
     }
 
     /**
      * Convenience method for writing a property with full validation, handling, and post-write notifications.
      */
-    public BACnetObject writeProperty(final ValueSource valueSource, final PropertyIdentifier pid,
-            final Encodable value) throws BACnetServiceException {
+    public BACnetObject writeProperty(ValueSource valueSource, PropertyIdentifier pid, Encodable value)
+            throws BACnetServiceException {
         return writeProperty(valueSource, new PropertyValue(pid, value));
     }
 
     /**
      * Convenience method for writing a property with full validation, handling, and post-write notifications.
      */
-    public BACnetObject writeProperty(final ValueSource valueSource, final PropertyIdentifier pid, final int indexBase1,
-            final Encodable value) throws BACnetServiceException {
+    public BACnetObject writeProperty(ValueSource valueSource, PropertyIdentifier pid, int indexBase1, Encodable value)
+            throws BACnetServiceException {
         return writeProperty(valueSource, new PropertyValue(pid, new UnsignedInteger(indexBase1), value, null));
     }
 
@@ -452,10 +449,9 @@ public class BACnetObject {
      * notifications via the object itself and mixins.
      */
     @SuppressWarnings("unchecked")
-    public BACnetObject writeProperty(final ValueSource valueSource, final PropertyValue value)
-            throws BACnetServiceException {
-        final PropertyIdentifier pid = value.getPropertyIdentifier();
-        final UnsignedInteger pin = value.getPropertyArrayIndex();
+    public BACnetObject writeProperty(ValueSource valueSource, PropertyValue value) throws BACnetServiceException {
+        PropertyIdentifier pid = value.getPropertyIdentifier();
+        UnsignedInteger pin = value.getPropertyArrayIndex();
         Encodable valueToWrite = value.getValue();
 
         if (PropertyIdentifier.objectType.equals(pid))
@@ -463,9 +459,23 @@ public class BACnetObject {
         if (PropertyIdentifier.priorityArray.equals(pid))
             throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
 
+        ObjectPropertyTypeDefinition def = ObjectProperties.getObjectPropertyTypeDefinition(objectType, pid);
+
+        // Per addendum 135-2016br-2: a relinquish (NULL value with a priority) targeting a non-commandable property
+        // whose declared datatype does not include NULL shall not fail. The property is not changed and the write
+        // is reported successful. Applied before any mixin validation because mixins routinely cast the incoming
+        // value to the declared type without checking, which would otherwise throw before this rule can be
+        // evaluated. Commandable properties are excluded — for those, NULL-with-priority is a real relinquish
+        // handled by CommandableMixin.
+        if (value.getValue() instanceof Null && value.getPriority() != null && def != null
+                && !(ObjectProperties.isCommandable(objectType, pid) && supportsCommandable())
+                && !def.getPropertyTypeDefinition().getClazz().isAssignableFrom(value.getValue().getClass())) {
+            return this;
+        }
+
         // Validation - run through the mixins
         boolean handled = false;
-        for (final AbstractMixin mixin : mixins) {
+        for (AbstractMixin mixin : mixins) {
             handled = mixin.validateProperty(valueSource, value);
             if (handled)
                 break;
@@ -474,9 +484,7 @@ public class BACnetObject {
             handled = validateProperty(valueSource, value);
 
         if (!handled) {
-            // Validate the value to be written. First get the definition for the property.
-            final ObjectPropertyTypeDefinition def = ObjectProperties.getObjectPropertyTypeDefinition(objectType, pid);
-
+            // Validate the value to be written.
             if (pin == null) {
                 // Not writing to an array index.
                 if (def == null) {
@@ -490,7 +498,7 @@ public class BACnetObject {
                         throw new BACnetServiceException(ErrorClass.property, ErrorCode.datatypeNotSupported);
                     }
                 } else {
-                    final PropertyTypeDefinition pdef = def.getPropertyTypeDefinition();
+                    PropertyTypeDefinition pdef = def.getPropertyTypeDefinition();
 
                     // Validate against the property definition.
                     if (pdef.isArray()) {
@@ -498,7 +506,7 @@ public class BACnetObject {
                         if (!(valueToWrite instanceof SequenceOf))
                             throw new BACnetServiceException(ErrorClass.property, ErrorCode.invalidDataType);
 
-                        final SequenceOf<Encodable> seq = (SequenceOf<Encodable>) valueToWrite;
+                        SequenceOf<Encodable> seq = (SequenceOf<Encodable>) valueToWrite;
 
                         if (pdef.getArrayLength() > 0) {
                             // And the length needs to match the definition if not n
@@ -507,7 +515,7 @@ public class BACnetObject {
                         }
 
                         // And the types of the elements need to match the definition.
-                        for (final Encodable e : seq) {
+                        for (Encodable e : seq) {
                             if (!pdef.getClazz().isAssignableFrom(e.getClass()))
                                 throw new BACnetServiceException(ErrorClass.property, ErrorCode.invalidDataType);
                         }
@@ -519,10 +527,10 @@ public class BACnetObject {
                         if (!(valueToWrite instanceof SequenceOf))
                             throw new BACnetServiceException(ErrorClass.property, ErrorCode.invalidDataType);
 
-                        final SequenceOf<Encodable> seq = (SequenceOf<Encodable>) valueToWrite;
+                        SequenceOf<Encodable> seq = (SequenceOf<Encodable>) valueToWrite;
 
                         // And the types of the elements need to match the definition.
-                        for (final Encodable e : seq) {
+                        for (Encodable e : seq) {
                             if (!pdef.getClazz().isAssignableFrom(e.getClass()))
                                 throw new BACnetServiceException(ErrorClass.property, ErrorCode.invalidDataType);
                         }
@@ -534,7 +542,7 @@ public class BACnetObject {
                 }
             } else {
                 // Writing to an array index.
-                final Encodable prop = properties.get(pid);
+                Encodable prop = properties.get(pid);
                 if (prop == null) {
                     throw new BACnetServiceException(ErrorClass.property, ErrorCode.unknownProperty);
                 }
@@ -577,7 +585,7 @@ public class BACnetObject {
 
         // Writing
         handled = false;
-        for (final AbstractMixin mixin : mixins) {
+        for (AbstractMixin mixin : mixins) {
             handled = mixin.writeProperty(valueSource, value);
             if (handled)
                 break;
@@ -589,7 +597,7 @@ public class BACnetObject {
                 writePropertyInternal(pid, valueToWrite);
             } else {
                 // Set the value in an array.
-                final BACnetArray<Encodable> arr = (BACnetArray<Encodable>) properties.get(pid);
+                BACnetArray<Encodable> arr = (BACnetArray<Encodable>) properties.get(pid);
                 arr.setBase1(pin.intValue(), valueToWrite);
                 writePropertyInternal(pid, arr);
             }
@@ -603,12 +611,12 @@ public class BACnetObject {
      * object configuration and property writes from mixins themselves, but can also be used by client code to set
      * object properties. Calls mixin "after write" methods and fires COV subscriptions.
      */
-    public BACnetObject writePropertyInternal(final PropertyIdentifier pid, final Encodable value) {
-        final Encodable oldValue = properties.get(pid);
+    public BACnetObject writePropertyInternal(PropertyIdentifier pid, Encodable value) {
+        Encodable oldValue = properties.get(pid);
         set(pid, value);
 
         // After writing.
-        for (final AbstractMixin mixin : mixins)
+        for (AbstractMixin mixin : mixins)
             mixin.afterWriteProperty(pid, oldValue, value);
         afterWriteProperty(pid, oldValue, value);
 
@@ -628,8 +636,7 @@ public class BACnetObject {
      * @return true if no more validation should occur, including the generic data type validation.
      * @throws BACnetServiceException to abort the write.
      */
-    protected boolean validateProperty(final ValueSource valueSource, final PropertyValue value)
-            throws BACnetServiceException {
+    protected boolean validateProperty(ValueSource valueSource, PropertyValue value) throws BACnetServiceException {
         return false;
     }
 
@@ -640,8 +647,7 @@ public class BACnetObject {
      * @param oldValue the old value
      * @param newValue the new value
      */
-    protected void afterWriteProperty(final PropertyIdentifier pid, final Encodable oldValue,
-            final Encodable newValue) {
+    protected void afterWriteProperty(PropertyIdentifier pid, Encodable oldValue, Encodable newValue) {
         // no op
     }
 
@@ -650,7 +656,7 @@ public class BACnetObject {
      *
      * @param pid the property identifier
      */
-    protected void beforeReadProperty(final PropertyIdentifier pid) throws BACnetServiceException {
+    protected void beforeReadProperty(PropertyIdentifier pid) throws BACnetServiceException {
         // no op
     }
 
@@ -661,23 +667,23 @@ public class BACnetObject {
 
     @Override
     public int hashCode() {
-        final ObjectIdentifier id = getId();
-        final int PRIME = 31;
+        ObjectIdentifier id = getId();
+        int PRIME = 31;
         int result = 1;
         result = PRIME * result + (id == null ? 0 : id.hashCode());
         return result;
     }
 
     @Override
-    public boolean equals(final Object obj) {
-        final ObjectIdentifier id = getId();
+    public boolean equals(Object obj) {
+        ObjectIdentifier id = getId();
         if (this == obj)
             return true;
         if (obj == null)
             return false;
         if (getClass() != obj.getClass())
             return false;
-        final BACnetObject other = (BACnetObject) obj;
+        BACnetObject other = (BACnetObject) obj;
         if (id == null) {
             if (other.getId() != null)
                 return false;

--- a/src/main/java/com/serotonin/bacnet4j/obj/CharacterStringValueObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/CharacterStringValueObject.java
@@ -45,11 +45,10 @@ import com.serotonin.bacnet4j.type.primitive.CharacterString;
 /**
  * @author Phillip Dunlap, based on BinaryValueObject
  */
-public class CharacterStringObject extends BACnetObject {
-    public CharacterStringObject(LocalDevice localDevice, int instanceNumber,
-            String name, final CharacterString presentValue, final boolean outOfService) {
+public class CharacterStringValueObject extends BACnetObject {
+    public CharacterStringValueObject(LocalDevice localDevice, int instanceNumber, String name,
+            CharacterString presentValue, boolean outOfService) {
         super(localDevice, ObjectType.characterstringValue, instanceNumber, name);
-
 
         writePropertyInternal(PropertyIdentifier.eventState, EventState.normal);
         writePropertyInternal(PropertyIdentifier.outOfService, Boolean.valueOf(outOfService));
@@ -66,13 +65,13 @@ public class CharacterStringObject extends BACnetObject {
         writePropertyInternal(PropertyIdentifier.presentValue, presentValue);
     }
 
-    public CharacterStringObject supportCommandable(final CharacterString relinquishDefault) {
+    public CharacterStringValueObject supportCommandable(CharacterString relinquishDefault) {
         Objects.requireNonNull(relinquishDefault);
         super._supportCommandable(relinquishDefault);
         return this;
     }
 
-    public CharacterStringObject supportCovReporting() {
+    public CharacterStringValueObject supportCovReporting() {
         _supportCovReporting(null, null);
         return this;
     }

--- a/src/main/java/com/serotonin/bacnet4j/obj/ObjectProperties.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/ObjectProperties.java
@@ -233,13 +233,11 @@ public class ObjectProperties {
         return getObjectPropertyTypeDefinitions(objectType, 0);
     }
 
-    public static List<ObjectPropertyTypeDefinition> getRequiredObjectPropertyTypeDefinitions(
-            ObjectType objectType) {
+    public static List<ObjectPropertyTypeDefinition> getRequiredObjectPropertyTypeDefinitions(ObjectType objectType) {
         return getObjectPropertyTypeDefinitions(objectType, 1);
     }
 
-    public static List<ObjectPropertyTypeDefinition> getOptionalObjectPropertyTypeDefinitions(
-            ObjectType objectType) {
+    public static List<ObjectPropertyTypeDefinition> getOptionalObjectPropertyTypeDefinitions(ObjectType objectType) {
         return getObjectPropertyTypeDefinitions(objectType, 2);
     }
 
@@ -303,16 +301,16 @@ public class ObjectProperties {
     /**
      * Add a list property
      */
-    private static void add(ObjectType type, PropertyIdentifier pid, Class<? extends Encodable> clazz,
-            boolean required, boolean isList) {
+    private static void add(ObjectType type, PropertyIdentifier pid, Class<? extends Encodable> clazz, boolean required,
+            boolean isList) {
         add(type, required, new PropertyTypeDefinition(pid, clazz, isList));
     }
 
     /**
      * Add an array property. If the array length is n, use 0.
      */
-    private static void add(ObjectType type, PropertyIdentifier pid, Class<? extends Encodable> clazz,
-            boolean required, int arrayLength) {
+    private static void add(ObjectType type, PropertyIdentifier pid, Class<? extends Encodable> clazz, boolean required,
+            int arrayLength) {
         add(type, required, new PropertyTypeDefinition(pid, clazz, arrayLength));
     }
 

--- a/src/main/java/com/serotonin/bacnet4j/type/Encodable.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/Encodable.java
@@ -45,6 +45,7 @@ import com.serotonin.bacnet4j.obj.PropertyTypeDefinition;
 import com.serotonin.bacnet4j.type.constructed.BACnetArray;
 import com.serotonin.bacnet4j.type.constructed.Choice;
 import com.serotonin.bacnet4j.type.constructed.ChoiceOptions;
+import com.serotonin.bacnet4j.type.constructed.OptionalBase;
 import com.serotonin.bacnet4j.type.constructed.PriorityArray;
 import com.serotonin.bacnet4j.type.constructed.PriorityValue;
 import com.serotonin.bacnet4j.type.constructed.SequenceOf;
@@ -74,14 +75,14 @@ public abstract class Encodable {
         return "Encodable(" + getClass().getName() + ")";
     }
 
-    protected static void popTagData(final ByteQueue queue, final TagData tagData) {
+    protected static void popTagData(ByteQueue queue, TagData tagData) {
         peekTagData(queue, tagData);
         queue.pop(tagData.tagLength);
     }
 
-    protected static void peekTagData(final ByteQueue queue, final TagData tagData) {
+    protected static void peekTagData(ByteQueue queue, TagData tagData) {
         int peekIndex = 0;
-        final byte b = queue.peek(peekIndex++);
+        byte b = queue.peek(peekIndex++);
         tagData.tagNumber = (b & 0xff) >> 4;
         tagData.contextSpecific = (b & 8) == 8;
         tagData.length = b & 7;
@@ -102,13 +103,13 @@ public abstract class Encodable {
         tagData.tagLength = peekIndex;
     }
 
-    protected static boolean isContextTag(final ByteQueue queue) {
+    protected static boolean isContextTag(ByteQueue queue) {
         if (queue.size() == 0)
             return false;
         return (queue.peek(0) & 8) == 8;
     }
 
-    protected static int peekTagNumber(final ByteQueue queue) {
+    protected static int peekTagNumber(ByteQueue queue) {
         if (queue.size() == 0)
             return -1;
 
@@ -119,12 +120,12 @@ public abstract class Encodable {
         return tagNumber;
     }
 
-    protected static int getTagLength(final ByteQueue queue) {
+    protected static int getTagLength(ByteQueue queue) {
         if (queue.size() == 0)
             return -1;
 
         // Take a peek at the tag number.
-        final int tagNumber = toInt(queue.peek(0)) >> 4;
+        int tagNumber = toInt(queue.peek(0)) >> 4;
         if (tagNumber == 15)
             return 2;
         return 1;
@@ -132,7 +133,7 @@ public abstract class Encodable {
 
     //
     // Write context tags for base types.
-    protected void writeContextTag(final ByteQueue queue, final int contextId, final boolean start) {
+    protected void writeContextTag(ByteQueue queue, int contextId, boolean start) {
         if (contextId < 0 || contextId > 254)
             throw new RuntimeException("Invalid context id: " + contextId);
 
@@ -146,11 +147,11 @@ public abstract class Encodable {
 
     //
     // Read start tags.
-    protected static int readStart(final ByteQueue queue) {
+    protected static int readStart(ByteQueue queue) {
         if (queue.size() == 0)
             return -1;
 
-        final int b = toInt(queue.peek(0));
+        int b = toInt(queue.peek(0));
         if ((b & 0xf) != 0xe)
             return -1;
         if ((b & 0xf0) == 0xf0)
@@ -158,8 +159,8 @@ public abstract class Encodable {
         return b >> 4;
     }
 
-    protected static int popStart(final ByteQueue queue) {
-        final int contextId = readStart(queue);
+    protected static int popStart(ByteQueue queue) {
+        int contextId = readStart(queue);
         if (contextId != -1) {
             queue.pop();
             if (contextId > 14)
@@ -168,17 +169,17 @@ public abstract class Encodable {
         return contextId;
     }
 
-    protected static void popStart(final ByteQueue queue, final int contextId) throws BACnetErrorException {
+    protected static void popStart(ByteQueue queue, int contextId) throws BACnetErrorException {
         if (popStart(queue) != contextId)
             throw new BACnetErrorException(ErrorClass.property, ErrorCode.missingRequiredParameter);
     }
 
     //
     // Read end tags.
-    protected static int readEnd(final ByteQueue queue) {
+    protected static int readEnd(ByteQueue queue) {
         if (queue.size() == 0)
             return -1;
-        final int b = toInt(queue.peek(0));
+        int b = toInt(queue.peek(0));
         if ((b & 0xf) != 0xf)
             return -1;
         if ((b & 0xf0) == 0xf0)
@@ -186,7 +187,7 @@ public abstract class Encodable {
         return b >> 4;
     }
 
-    protected static void popEnd(final ByteQueue queue, final int contextId) throws BACnetErrorException {
+    protected static void popEnd(ByteQueue queue, int contextId) throws BACnetErrorException {
         if (readEnd(queue) != contextId)
             throw new BACnetErrorException(ErrorClass.property, ErrorCode.missingRequiredParameter);
         queue.pop();
@@ -197,28 +198,28 @@ public abstract class Encodable {
     /**
      * Check if the tag number at the beginning of the queue matches the given context id.
      */
-    private static boolean matchContextId(final ByteQueue queue, final int contextId) {
+    private static boolean matchContextId(ByteQueue queue, int contextId) {
         return peekTagNumber(queue) == contextId;
     }
 
     /**
      * Check if the tag at the beginning of the queue is a start tag that matches given context id.
      */
-    protected static boolean matchStartTag(final ByteQueue queue, final int contextId) {
+    protected static boolean matchStartTag(ByteQueue queue, int contextId) {
         return matchContextId(queue, contextId) && (queue.peek(0) & 0xf) == 0xe;
     }
 
     /**
      * Check if the tag at the beginning of the queue is an end tag that matches given context id.
      */
-    protected static boolean matchEndTag(final ByteQueue queue, final int contextId) {
+    protected static boolean matchEndTag(ByteQueue queue, int contextId) {
         return matchContextId(queue, contextId) && (queue.peek(0) & 0xf) == 0xf;
     }
 
     /**
      * Check if the tag at the beginning of the queue is NOT an end tag, but that it matches given context id.
      */
-    protected static boolean matchNonEndTag(final ByteQueue queue, final int contextId) {
+    protected static boolean matchNonEndTag(ByteQueue queue, int contextId) {
         return matchContextId(queue, contextId) && (queue.peek(0) & 0xf) != 0xf;
     }
 
@@ -227,26 +228,25 @@ public abstract class Encodable {
     //
 
     @SuppressWarnings("unchecked")
-    public static <T extends Encodable> T read(final ByteQueue queue, final Class<T> clazz) throws BACnetException {
+    public static <T extends Encodable> T read(ByteQueue queue, Class<T> clazz) throws BACnetException {
         if (clazz == Primitive.class)
             return (T) Primitive.createPrimitive(queue);
 
         try {
             return clazz.getConstructor(ByteQueue.class).newInstance(queue);
-        } catch (final InvocationTargetException e) {
+        } catch (InvocationTargetException e) {
             // Check if there is a wrapped BACnet exception
             if (e.getCause() instanceof BACnetException be)
                 throw be;
             throw new ReflectionException(e);
-        } catch (final Exception e) {
+        } catch (Exception e) {
             throw new BACnetException(e);
         }
     }
 
     //
     // Read and write with context id.
-    public static <T extends Encodable> T read(final ByteQueue queue, final Class<T> clazz, final int contextId)
-            throws BACnetException {
+    public static <T extends Encodable> T read(ByteQueue queue, Class<T> clazz, int contextId) throws BACnetException {
         if (!matchNonEndTag(queue, contextId))
             throw new BACnetErrorException(ErrorClass.property, ErrorCode.missingRequiredParameter);
 
@@ -256,8 +256,8 @@ public abstract class Encodable {
         return readWrapped(queue, clazz, contextId);
     }
 
-    protected static <T extends Encodable> T readOptional(final ByteQueue queue, final Class<T> clazz,
-            final int contextId) throws BACnetException {
+    protected static <T extends Encodable> T readOptional(ByteQueue queue, Class<T> clazz, int contextId)
+            throws BACnetException {
         if (!matchNonEndTag(queue, contextId))
             return null;
         return read(queue, clazz, contextId);
@@ -265,12 +265,11 @@ public abstract class Encodable {
 
     //
     // Read choices
-    protected static Choice readChoice(final ByteQueue queue, final ChoiceOptions choiceOptions)
-            throws BACnetException {
+    protected static Choice readChoice(ByteQueue queue, ChoiceOptions choiceOptions) throws BACnetException {
         return new Choice(queue, choiceOptions);
     }
 
-    protected static Choice readChoice(final ByteQueue queue, final ChoiceOptions choiceOptions, final int contextId)
+    protected static Choice readChoice(ByteQueue queue, ChoiceOptions choiceOptions, int contextId)
             throws BACnetException {
         popStart(queue, contextId);
         try {
@@ -280,15 +279,14 @@ public abstract class Encodable {
         }
     }
 
-    protected static Choice readOptionalChoice(final ByteQueue queue, final ChoiceOptions choiceOptions)
-            throws BACnetException {
+    protected static Choice readOptionalChoice(ByteQueue queue, ChoiceOptions choiceOptions) throws BACnetException {
         if (peekTagNumber(queue) == -1)
             return null;
         return readChoice(queue, choiceOptions);
     }
 
-    protected static Choice readOptionalChoice(final ByteQueue queue, final ChoiceOptions choiceOptions,
-            final int contextId) throws BACnetException {
+    protected static Choice readOptionalChoice(ByteQueue queue, ChoiceOptions choiceOptions, int contextId)
+            throws BACnetException {
         if (!matchNonEndTag(queue, contextId))
             return null;
         return readChoice(queue, choiceOptions, contextId);
@@ -296,65 +294,64 @@ public abstract class Encodable {
 
     //
     // Read lists
-    public static <T extends Encodable> SequenceOf<T> readSequenceOf(final ByteQueue queue, final Class<T> clazz)
+    public static <T extends Encodable> SequenceOf<T> readSequenceOf(ByteQueue queue, Class<T> clazz)
             throws BACnetException {
         return new SequenceOf<>(queue, clazz);
     }
 
-    protected static <T extends Encodable> SequenceOf<T> readSequenceOf(final ByteQueue queue, final int count,
-            final Class<T> clazz) throws BACnetException {
+    protected static <T extends Encodable> SequenceOf<T> readSequenceOf(ByteQueue queue, int count, Class<T> clazz)
+            throws BACnetException {
         return new SequenceOf<>(queue, count, clazz);
     }
 
-    protected static <T extends Encodable> SequenceOf<T> readSequenceOf(final ByteQueue queue, final Class<T> clazz,
-            final int contextId) throws BACnetException {
+    protected static <T extends Encodable> SequenceOf<T> readSequenceOf(ByteQueue queue, Class<T> clazz, int contextId)
+            throws BACnetException {
         popStart(queue, contextId);
-        final SequenceOf<T> result = new SequenceOf<>(queue, clazz, contextId);
+        SequenceOf<T> result = new SequenceOf<>(queue, clazz, contextId);
         popEnd(queue, contextId);
         return result;
     }
 
-    protected static <T extends Encodable> T readSequenceType(final ByteQueue queue, final Class<T> clazz,
-            final int contextId) throws BACnetException {
+    protected static <T extends Encodable> T readSequenceType(ByteQueue queue, Class<T> clazz, int contextId)
+            throws BACnetException {
         popStart(queue, contextId);
         T result;
         try {
             result = clazz.getConstructor(ByteQueue.class, Integer.TYPE).newInstance(queue, contextId);
-        } catch (final Exception e) {
+        } catch (Exception e) {
             throw new BACnetException(e);
         }
         popEnd(queue, contextId);
         return result;
     }
 
-    protected static SequenceOf<Choice> readSequenceOfChoice(final ByteQueue queue, final ChoiceOptions choiceOptions,
-            final int contextId) throws BACnetException {
+    protected static SequenceOf<Choice> readSequenceOfChoice(ByteQueue queue, ChoiceOptions choiceOptions,
+            int contextId) throws BACnetException {
         popStart(queue, contextId);
-        final SequenceOf<Choice> result = new SequenceOf<>();
+        SequenceOf<Choice> result = new SequenceOf<>();
         while (readEnd(queue) != contextId)
             result.add(new Choice(queue, choiceOptions));
         popEnd(queue, contextId);
         return result;
     }
 
-    protected static <T extends Encodable> SequenceOf<T> readOptionalSequenceOf(final ByteQueue queue,
-            final Class<T> clazz, final int contextId) throws BACnetException {
+    protected static <T extends Encodable> SequenceOf<T> readOptionalSequenceOf(ByteQueue queue, Class<T> clazz,
+            int contextId) throws BACnetException {
         if (readStart(queue) != contextId)
             return null;
         return readSequenceOf(queue, clazz, contextId);
     }
 
-    protected static <T extends Encodable> BACnetArray<T> readArray(final ByteQueue queue, final Class<T> clazz,
-            final int contextId) throws BACnetException {
+    protected static <T extends Encodable> BACnetArray<T> readArray(ByteQueue queue, Class<T> clazz, int contextId)
+            throws BACnetException {
         popStart(queue, contextId);
-        final BACnetArray<T> result = new BACnetArray<>(queue, clazz, contextId);
+        BACnetArray<T> result = new BACnetArray<>(queue, clazz, contextId);
         popEnd(queue, contextId);
         return result;
     }
 
-    private static Encodable readUnknown(final ByteQueue queue, final int contextId)
-            throws BACnetException {
-        final TagData tagData = new TagData();
+    private static Encodable readUnknown(ByteQueue queue, int contextId) throws BACnetException {
+        TagData tagData = new TagData();
         peekTagData(queue, tagData);
 
         // Check if the tag number matches the context id. If they match, then create the context-specific parameter,
@@ -404,9 +401,8 @@ public abstract class Encodable {
         }
     }
 
-    protected static Encodable readANY(final ByteQueue queue, final ObjectType objectType,
-            final PropertyIdentifier propertyIdentifier, final UnsignedInteger propertyArrayIndex, final int contextId)
-            throws BACnetException {
+    protected static Encodable readANY(ByteQueue queue, ObjectType objectType, PropertyIdentifier propertyIdentifier,
+            UnsignedInteger propertyArrayIndex, int contextId) throws BACnetException {
         // A property array index of 0 indicates a request for the length of an array.
         if (propertyArrayIndex != null && propertyArrayIndex.intValue() == 0)
             return readWrapped(queue, UnsignedInteger.class, contextId);
@@ -415,7 +411,7 @@ public abstract class Encodable {
             throw new BACnetErrorException(ErrorClass.property, ErrorCode.invalidDataType);
 
         // Get the definition for the property, if there is one.
-        final PropertyTypeDefinition def = getPropertyTypeDefinition(objectType, propertyIdentifier);
+        PropertyTypeDefinition def = getPropertyTypeDefinition(objectType, propertyIdentifier);
 
         if (def == null) {
             // We don't know what this is.
@@ -424,7 +420,7 @@ public abstract class Encodable {
 
         if (ObjectProperties.isCommandable(objectType, propertyIdentifier)) {
             // If the object is commandable, it could be set to Null, so we need to treat it as ambiguous.
-            final AmbiguousValue amb = new AmbiguousValue(queue, contextId);
+            AmbiguousValue amb = new AmbiguousValue(queue, contextId);
 
             if (amb.isNull())
                 return Null.instance;
@@ -445,37 +441,69 @@ public abstract class Encodable {
             return readWrapped(queue, PriorityValue.class, contextId);
         }
 
+        if (isNullPrimitiveBody(queue, contextId) && !OptionalBase.class.isAssignableFrom(def.getClazz())) {
+            // Per addendum 135-2016br-2: preserve a wire NULL value as a bare Null primitive so the write
+            // layer can silently succeed a relinquish attempt against a non-commandable property whose
+            // declared datatype does not include NULL. Only applied when the declared class is a leaf
+            // primitive (e.g. CharacterString, Real, Boolean); CHOICE-based wrappers such as
+            // OptionalCharacterString or ChannelValue accept NULL as a legitimate alternative and are
+            // decoded normally via readWrapped.
+            //
+            // Note that we do not include subsclasses of OptionalBase here because we need those to be instantiated
+            // normally. It's just that when they are null they look like primitive nulls.
+            popStart(queue, contextId);
+            Null n = new Null(queue);
+            popEnd(queue, contextId);
+            return n;
+        }
         return readWrapped(queue, def.getClazz(), contextId);
     }
 
-    protected static Encodable readOptionalANY(final ByteQueue queue, final ObjectType objectType,
-            final PropertyIdentifier propertyIdentifier, final int contextId) throws BACnetException {
+    /**
+     * Peeks at the byte following the opening context tag and reports whether it is a NULL primitive
+     * (application tag 0, length 0). Used by {@link #readANY} to detect a relinquish-style Null value
+     * that would otherwise be rejected by strict-type decode. Does not consume any bytes.
+     */
+    private static boolean isNullPrimitiveBody(ByteQueue queue, int contextId) {
+        if (readStart(queue) != contextId) {
+            return false;
+        }
+        int startTagLength = contextId > 14 ? 2 : 1;
+        if (queue.size() < startTagLength + 2) {
+            return false;
+        }
+        // The byte after the opening context tag encodes the value tag. NULL is application tag 0, primitive,
+        // length 0 — a single 0x00 byte. The following byte should be the closing context tag.
+        return (queue.peek(startTagLength) & 0xff) == 0x00;
+    }
+
+    protected static Encodable readOptionalANY(ByteQueue queue, ObjectType objectType,
+            PropertyIdentifier propertyIdentifier, int contextId) throws BACnetException {
         if (readStart(queue) != contextId)
             return null;
         return readANY(queue, objectType, propertyIdentifier, null, contextId);
     }
 
-    protected static Encodable readOptionalANY(final ByteQueue queue, final ObjectType objectType,
-            final PropertyIdentifier propertyIdentifier, UnsignedInteger propertyArrayIndex, final int contextId)
+    protected static Encodable readOptionalANY(ByteQueue queue, ObjectType objectType,
+            PropertyIdentifier propertyIdentifier, UnsignedInteger propertyArrayIndex, int contextId)
             throws BACnetException {
         if (readStart(queue) != contextId)
             return null;
         return readANY(queue, objectType, propertyIdentifier, propertyArrayIndex, contextId);
     }
 
-    protected static SequenceOf<? extends Encodable> readSequenceOfANY(final ByteQueue queue,
-            final ObjectType objectType, final PropertyIdentifier propertyIdentifier, final int contextId)
-            throws BACnetException {
-        final PropertyTypeDefinition def = getPropertyTypeDefinition(objectType, propertyIdentifier);
+    protected static SequenceOf<? extends Encodable> readSequenceOfANY(ByteQueue queue, ObjectType objectType,
+            PropertyIdentifier propertyIdentifier, int contextId) throws BACnetException {
+        PropertyTypeDefinition def = getPropertyTypeDefinition(objectType, propertyIdentifier);
         if (def == null)
             return readSequenceOf(queue, AmbiguousValue.class, contextId);
         return readSequenceOf(queue, def.getClazz(), contextId);
     }
 
-    private static PropertyTypeDefinition getPropertyTypeDefinition(final ObjectType objectType,
-            final PropertyIdentifier propertyIdentifier) {
+    private static PropertyTypeDefinition getPropertyTypeDefinition(ObjectType objectType,
+            PropertyIdentifier propertyIdentifier) {
         if (objectType != null && propertyIdentifier != null) {
-            final ObjectPropertyTypeDefinition def = ObjectProperties.getObjectPropertyTypeDefinition(objectType,
+            ObjectPropertyTypeDefinition def = ObjectProperties.getObjectPropertyTypeDefinition(objectType,
                     propertyIdentifier);
             if (def != null) {
                 return def.getPropertyTypeDefinition();
@@ -491,16 +519,16 @@ public abstract class Encodable {
     }
 
     // Read vendor-specific
-    protected static EncodedValue readEncodedValue(final ByteQueue queue, final int contextId) throws BACnetException {
+    protected static EncodedValue readEncodedValue(ByteQueue queue, int contextId) throws BACnetException {
         if (readStart(queue) != contextId)
             return null;
         return new EncodedValue(queue, contextId);
     }
 
-    private static <T extends Encodable> T readWrapped(final ByteQueue queue, final Class<T> clazz, final int contextId)
+    private static <T extends Encodable> T readWrapped(ByteQueue queue, Class<T> clazz, int contextId)
             throws BACnetException {
         popStart(queue, contextId);
-        final T result = read(queue, clazz);
+        T result = read(queue, clazz);
         popEnd(queue, contextId);
         return result;
     }
@@ -509,30 +537,30 @@ public abstract class Encodable {
     // Writing
     //
 
-    public static void write(final ByteQueue queue, final Encodable type) {
+    public static void write(ByteQueue queue, Encodable type) {
         type.write(queue);
     }
 
-    public static void write(final ByteQueue queue, final Encodable type, final int contextId) {
+    public static void write(ByteQueue queue, Encodable type, int contextId) {
         type.write(queue, contextId);
     }
 
     //
     // Optional read and write.
-    protected static void writeOptional(final ByteQueue queue, final Encodable type) {
+    protected static void writeOptional(ByteQueue queue, Encodable type) {
         if (type == null)
             return;
         write(queue, type);
     }
 
-    protected static void writeOptional(final ByteQueue queue, final Encodable type, final int contextId) {
+    protected static void writeOptional(ByteQueue queue, Encodable type, int contextId) {
         if (type == null)
             return;
         write(queue, type, contextId);
     }
 
     // Read and write encodable
-    protected static void writeANY(final ByteQueue queue, final Encodable type, final int contextId) {
+    protected static void writeANY(ByteQueue queue, Encodable type, int contextId) {
         if (Primitive.class.isAssignableFrom(type.getClass()))
             ((Primitive) type).writeWithContextTag(queue, contextId);
         else

--- a/src/main/java/com/serotonin/bacnet4j/type/constructed/OptionalBase.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/constructed/OptionalBase.java
@@ -27,35 +27,71 @@
 
 package com.serotonin.bacnet4j.type.constructed;
 
+import java.util.Objects;
+
 import com.serotonin.bacnet4j.exception.BACnetException;
+import com.serotonin.bacnet4j.type.Encodable;
 import com.serotonin.bacnet4j.type.primitive.Null;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
 
-public class OptionalPriorityFilter extends OptionalBase {
-    private static final ChoiceOptions choiceOptions = new ChoiceOptions();
+/**
+ * Base class for optional-type classes.
+ */
+public abstract class OptionalBase extends BaseType {
+    protected final Choice choice;
 
-    static {
-        choiceOptions.addPrimitive(Null.class);
-        choiceOptions.addPrimitive(PriorityFilter.class);
+    protected OptionalBase(ChoiceOptions choiceOptions) {
+        this.choice = new Choice(Null.instance, choiceOptions);
     }
 
-    public OptionalPriorityFilter() {
-        super(choiceOptions);
+    protected OptionalBase(Encodable e, ChoiceOptions choiceOptions) {
+        this.choice = new Choice(e, choiceOptions);
     }
 
-    public OptionalPriorityFilter(PriorityFilter filter) {
-        super(filter, choiceOptions);
+    public boolean isNull() {
+        return choice.getContextId() == 0;
     }
 
-    public PriorityFilter getFilterValue() {
+    public Null getNullValue() {
         return choice.getDatum();
     }
 
-    public boolean isFilterValue() {
-        return choice.getDatum() instanceof PriorityFilter;
+    public boolean isNullValue() {
+        return choice.getDatum() instanceof Null;
     }
 
-    public OptionalPriorityFilter(ByteQueue queue) throws BACnetException {
-        super(queue, choiceOptions);
+    public Choice getChoice() {
+        return choice;
+    }
+
+    public <T extends Encodable> T getValue() {
+        return choice.getDatum();
+    }
+
+    @Override
+    public final void write(ByteQueue queue) {
+        write(queue, choice);
+    }
+
+    protected OptionalBase(ByteQueue queue, ChoiceOptions choiceOptions) throws BACnetException {
+        choice = readChoice(queue, choiceOptions);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getName() + " [choice=" + choice + "]";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass())
+            return false;
+        OptionalBase that = (OptionalBase) o;
+        return Objects.equals(choice, that.choice);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(choice);
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/type/constructed/OptionalBinaryPV.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/constructed/OptionalBinaryPV.java
@@ -32,30 +32,20 @@ import com.serotonin.bacnet4j.type.enumerated.BinaryPV;
 import com.serotonin.bacnet4j.type.primitive.Null;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
 
-public class OptionalBinaryPV extends BaseType {
-    private static ChoiceOptions choiceOptions = new ChoiceOptions();
+public class OptionalBinaryPV extends OptionalBase {
+    private static final ChoiceOptions choiceOptions = new ChoiceOptions();
 
     static {
         choiceOptions.addPrimitive(Null.class);
         choiceOptions.addPrimitive(BinaryPV.class);
     }
 
-    private final Choice choice;
-
     public OptionalBinaryPV() {
-        this.choice = new Choice(Null.instance, choiceOptions);
+        super(choiceOptions);
     }
 
-    public OptionalBinaryPV(final BinaryPV binaryPV) {
-        this.choice = new Choice(binaryPV, choiceOptions);
-    }
-
-    public boolean isNullValue() {
-        return choice.isa(Null.class);
-    }
-
-    public Null getNullValue() {
-        return choice.getDatum();
+    public OptionalBinaryPV(BinaryPV binaryPV) {
+        super(binaryPV, choiceOptions);
     }
 
     public boolean isBinaryPVValue() {
@@ -66,42 +56,7 @@ public class OptionalBinaryPV extends BaseType {
         return choice.getDatum();
     }
 
-    @Override
-    public void write(final ByteQueue queue) {
-        write(queue, choice);
-    }
-
-    public OptionalBinaryPV(final ByteQueue queue) throws BACnetException {
-        choice = readChoice(queue, choiceOptions);
-    }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + (choice == null ? 0 : choice.hashCode());
-        return result;
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        final OptionalBinaryPV other = (OptionalBinaryPV) obj;
-        if (choice == null) {
-            if (other.choice != null)
-                return false;
-        } else if (!choice.equals(other.choice))
-            return false;
-        return true;
-    }
-
-    @Override
-    public String toString() {
-        return "OptionalBinaryPV [choice=" + choice + ']';
+    public OptionalBinaryPV(ByteQueue queue) throws BACnetException {
+        super(queue, choiceOptions);
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/type/constructed/OptionalCharacterString.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/constructed/OptionalCharacterString.java
@@ -28,35 +28,28 @@
 package com.serotonin.bacnet4j.type.constructed;
 
 import com.serotonin.bacnet4j.exception.BACnetException;
-import com.serotonin.bacnet4j.type.Encodable;
 import com.serotonin.bacnet4j.type.primitive.CharacterString;
 import com.serotonin.bacnet4j.type.primitive.Null;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
 
-public class OptionalCharacterString extends BaseType {
-    private static ChoiceOptions choiceOptions = new ChoiceOptions();
+public class OptionalCharacterString extends OptionalBase {
+    private static final ChoiceOptions choiceOptions = new ChoiceOptions();
 
     static {
         choiceOptions.addPrimitive(Null.class);
         choiceOptions.addPrimitive(CharacterString.class);
     }
 
-    private final Choice choice;
-
     public OptionalCharacterString() {
-        this.choice = new Choice(Null.instance, choiceOptions);
+        super(choiceOptions);
     }
 
-    public OptionalCharacterString(final CharacterString characterString) {
-        this.choice = new Choice(characterString, choiceOptions);
+    public OptionalCharacterString(CharacterString characterString) {
+        super(characterString, choiceOptions);
     }
 
-    public OptionalCharacterString(final String string) {
-        this.choice = new Choice(new CharacterString(string), choiceOptions);
-    }
-
-    public Null getNullValue() {
-        return choice.getDatum();
+    public OptionalCharacterString(String string) {
+        super(new CharacterString(string), choiceOptions);
     }
 
     public CharacterString getCharacterStringValue() {
@@ -67,54 +60,7 @@ public class OptionalCharacterString extends BaseType {
         return choice.getDatum() instanceof CharacterString;
     }
 
-    public boolean isNullValue() {
-        return choice.getDatum() instanceof Null;
-    }
-
-    public Choice getChoice() {
-        return choice;
-    }
-
-    public <T extends Encodable> T getValue() {
-        return choice.getDatum();
-    }
-
-    @Override
-    public void write(final ByteQueue queue) {
-        write(queue, choice);
-    }
-
-    public OptionalCharacterString(final ByteQueue queue) throws BACnetException {
-        choice = readChoice(queue, choiceOptions);
-    }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + (choice == null ? 0 : choice.hashCode());
-        return result;
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        final OptionalCharacterString other = (OptionalCharacterString) obj;
-        if (choice == null) {
-            if (other.choice != null)
-                return false;
-        } else if (!choice.equals(other.choice))
-            return false;
-        return true;
-    }
-
-    @Override
-    public String toString() {
-        return "OptionalCharacterString [choice=" + choice + ']';
+    public OptionalCharacterString(ByteQueue queue) throws BACnetException {
+        super(queue, choiceOptions);
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/type/constructed/OptionalReal.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/constructed/OptionalReal.java
@@ -28,35 +28,28 @@
 package com.serotonin.bacnet4j.type.constructed;
 
 import com.serotonin.bacnet4j.exception.BACnetException;
-import com.serotonin.bacnet4j.type.Encodable;
 import com.serotonin.bacnet4j.type.primitive.Null;
 import com.serotonin.bacnet4j.type.primitive.Real;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
 
-public class OptionalReal extends BaseType {
-    private static ChoiceOptions choiceOptions = new ChoiceOptions();
+public class OptionalReal extends OptionalBase {
+    private static final ChoiceOptions choiceOptions = new ChoiceOptions();
 
     static {
         choiceOptions.addPrimitive(Null.class);
         choiceOptions.addPrimitive(Real.class);
     }
 
-    private final Choice choice;
-
     public OptionalReal() {
-        this.choice = new Choice(Null.instance, choiceOptions);
+        super(choiceOptions);
     }
 
-    public OptionalReal(final Real real) {
-        this.choice = new Choice(real, choiceOptions);
+    public OptionalReal(Real real) {
+        super(real, choiceOptions);
     }
 
-    public OptionalReal(final float real) {
-        this.choice = new Choice(new Real(real), choiceOptions);
-    }
-
-    public Null getNullValue() {
-        return choice.getDatum();
+    public OptionalReal(float real) {
+        super(new Real(real), choiceOptions);
     }
 
     public Real getRealValue() {
@@ -67,54 +60,7 @@ public class OptionalReal extends BaseType {
         return choice.getDatum() instanceof Real;
     }
 
-    public boolean isNullValue() {
-        return choice.getDatum() instanceof Null;
-    }
-
-    public Choice getChoice() {
-        return choice;
-    }
-
-    public <T extends Encodable> T getValue() {
-        return choice.getDatum();
-    }
-
-    @Override
-    public void write(final ByteQueue queue) {
-        write(queue, choice);
-    }
-
-    public OptionalReal(final ByteQueue queue) throws BACnetException {
-        choice = readChoice(queue, choiceOptions);
-    }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + (choice == null ? 0 : choice.hashCode());
-        return result;
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        final OptionalReal other = (OptionalReal) obj;
-        if (choice == null) {
-            if (other.choice != null)
-                return false;
-        } else if (!choice.equals(other.choice))
-            return false;
-        return true;
-    }
-
-    @Override
-    public String toString() {
-        return "OptionalReal [choice=" + choice + ']';
+    public OptionalReal(ByteQueue queue) throws BACnetException {
+        super(queue, choiceOptions);
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/type/constructed/OptionalUnsigned.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/constructed/OptionalUnsigned.java
@@ -28,39 +28,28 @@
 package com.serotonin.bacnet4j.type.constructed;
 
 import com.serotonin.bacnet4j.exception.BACnetException;
-import com.serotonin.bacnet4j.type.Encodable;
 import com.serotonin.bacnet4j.type.primitive.Null;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
 
-public class OptionalUnsigned extends BaseType {
-    private static ChoiceOptions choiceOptions = new ChoiceOptions();
+public class OptionalUnsigned extends OptionalBase {
+    private static final ChoiceOptions choiceOptions = new ChoiceOptions();
 
     static {
         choiceOptions.addPrimitive(Null.class);
         choiceOptions.addPrimitive(UnsignedInteger.class);
     }
 
-    private final Choice choice;
-
     public OptionalUnsigned() {
-        this.choice = new Choice(Null.instance, choiceOptions);
+        super(choiceOptions);
     }
 
-    public OptionalUnsigned(final UnsignedInteger unsigned) {
-        this.choice = new Choice(unsigned, choiceOptions);
+    public OptionalUnsigned(UnsignedInteger unsigned) {
+        super(unsigned, choiceOptions);
     }
 
-    public OptionalUnsigned(final int unsigned) {
-        this.choice = new Choice(new UnsignedInteger(unsigned), choiceOptions);
-    }
-
-    public boolean isNull() {
-        return choice.getContextId() == 0;
-    }
-
-    public Null getNullValue() {
-        return choice.getDatum();
+    public OptionalUnsigned(int unsigned) {
+        super(new UnsignedInteger(unsigned), choiceOptions);
     }
 
     public UnsignedInteger getUnsignedIntegerValue() {
@@ -71,54 +60,7 @@ public class OptionalUnsigned extends BaseType {
         return choice.getDatum() instanceof UnsignedInteger;
     }
 
-    public boolean isNullValue() {
-        return choice.getDatum() instanceof Null;
-    }
-
-    public Choice getChoice() {
-        return choice;
-    }
-
-    public <T extends Encodable> T getValue() {
-        return choice.getDatum();
-    }
-
-    @Override
-    public void write(final ByteQueue queue) {
-        write(queue, choice);
-    }
-
-    public OptionalUnsigned(final ByteQueue queue) throws BACnetException {
-        choice = readChoice(queue, choiceOptions);
-    }
-
-    @Override
-    public String toString() {
-        return "OptionalUnsigned [choice=" + choice + "]";
-    }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + (choice == null ? 0 : choice.hashCode());
-        return result;
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        final OptionalUnsigned other = (OptionalUnsigned) obj;
-        if (choice == null) {
-            if (other.choice != null)
-                return false;
-        } else if (!choice.equals(other.choice))
-            return false;
-        return true;
+    public OptionalUnsigned(ByteQueue queue) throws BACnetException {
+        super(queue, choiceOptions);
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/type/enumerated/EngineeringUnits.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/enumerated/EngineeringUnits.java
@@ -55,6 +55,13 @@ public class EngineeringUnits extends Enumerated {
     public static final EngineeringUnits currency8 = new EngineeringUnits(112);
     public static final EngineeringUnits currency9 = new EngineeringUnits(113);
     public static final EngineeringUnits currency10 = new EngineeringUnits(114);
+    // Efficiency
+    public static final EngineeringUnits btuPerHourPerWatt = new EngineeringUnits(47898);
+    public static final EngineeringUnits btuPerWattHourSeasonal = new EngineeringUnits(47899);
+    public static final EngineeringUnits coefficientOfPerformance = new EngineeringUnits(47900);
+    public static final EngineeringUnits coefficientOfPerformanceSeasonal = new EngineeringUnits(47901);
+    public static final EngineeringUnits kilowattPerTonRefrigeration = new EngineeringUnits(47902);
+    public static final EngineeringUnits lumensPerWatt = new EngineeringUnits(47903);
     // Electrical
     public static final EngineeringUnits milliamperes = new EngineeringUnits(2);
     public static final EngineeringUnits amperes = new EngineeringUnits(3);
@@ -76,6 +83,9 @@ public class EngineeringUnits extends Enumerated {
     public static final EngineeringUnits millisiemens = new EngineeringUnits(202);
     public static final EngineeringUnits siemens = new EngineeringUnits(173); // 1 mho equals 1 siemens
     public static final EngineeringUnits siemensPerMeter = new EngineeringUnits(174);
+    public static final EngineeringUnits microsiemensPerCentimeter = new EngineeringUnits(47909);
+    public static final EngineeringUnits millisiemensPerCentimeter = new EngineeringUnits(47910);
+    public static final EngineeringUnits millisiemensPerMeter = new EngineeringUnits(47911);
     public static final EngineeringUnits teslas = new EngineeringUnits(175);
     public static final EngineeringUnits volts = new EngineeringUnits(5);
     public static final EngineeringUnits millivolts = new EngineeringUnits(124);
@@ -87,7 +97,7 @@ public class EngineeringUnits extends Enumerated {
     public static final EngineeringUnits voltAmperesReactive = new EngineeringUnits(11);
     public static final EngineeringUnits kilovoltAmperesReactive = new EngineeringUnits(12);
     public static final EngineeringUnits megavoltAmperesReactive = new EngineeringUnits(13);
-    public static final EngineeringUnits voltsPerDegreeKelvin = new EngineeringUnits(176);
+    public static final EngineeringUnits voltsPerKelvin = new EngineeringUnits(176);
     public static final EngineeringUnits voltsPerMeter = new EngineeringUnits(177);
     public static final EngineeringUnits degreesPhase = new EngineeringUnits(14);
     public static final EngineeringUnits powerFactor = new EngineeringUnits(15);
@@ -117,6 +127,11 @@ public class EngineeringUnits extends Enumerated {
     public static final EngineeringUnits megaBtus = new EngineeringUnits(148);
     public static final EngineeringUnits therms = new EngineeringUnits(21);
     public static final EngineeringUnits tonHours = new EngineeringUnits(22);
+    public static final EngineeringUnits activeEnergyPulseValue = new EngineeringUnits(47918);
+    public static final EngineeringUnits reactiveEnergyPulseValue = new EngineeringUnits(47919);
+    public static final EngineeringUnits apparentEnergyPulseValue = new EngineeringUnits(47920);
+    public static final EngineeringUnits voltSquaredHourPulseValue = new EngineeringUnits(47921);
+    public static final EngineeringUnits ampereSquaredHourPulseValue = new EngineeringUnits(47922);
     // Enthalpy
     public static final EngineeringUnits joulesPerKilogramDryAir = new EngineeringUnits(23);
     public static final EngineeringUnits kilojoulesPerKilogramDryAir = new EngineeringUnits(149);
@@ -124,10 +139,10 @@ public class EngineeringUnits extends Enumerated {
     public static final EngineeringUnits btusPerPoundDryAir = new EngineeringUnits(24);
     public static final EngineeringUnits btusPerPound = new EngineeringUnits(117);
     // Entropy
-    public static final EngineeringUnits joulesPerDegreeKelvin = new EngineeringUnits(127);
-    public static final EngineeringUnits kilojoulesPerDegreeKelvin = new EngineeringUnits(151);
-    public static final EngineeringUnits megajoulesPerDegreeKelvin = new EngineeringUnits(152);
-    public static final EngineeringUnits joulesPerKilogramDegreeKelvin = new EngineeringUnits(128);
+    public static final EngineeringUnits joulesPerKelvin = new EngineeringUnits(127);
+    public static final EngineeringUnits kilojoulesPerKelvin = new EngineeringUnits(151);
+    public static final EngineeringUnits megajoulesPerKelvin = new EngineeringUnits(152);
+    public static final EngineeringUnits joulesPerKilogramKelvin = new EngineeringUnits(128);
     // Force
     public static final EngineeringUnits newton = new EngineeringUnits(153);
     // Frequency
@@ -136,9 +151,12 @@ public class EngineeringUnits extends Enumerated {
     public static final EngineeringUnits hertz = new EngineeringUnits(27);
     public static final EngineeringUnits kilohertz = new EngineeringUnits(129);
     public static final EngineeringUnits megahertz = new EngineeringUnits(130);
+    public static final EngineeringUnits perDay = new EngineeringUnits(47823);
     public static final EngineeringUnits perHour = new EngineeringUnits(131);
+    public static final EngineeringUnits perMillisecond = new EngineeringUnits(47824);
     // Humidity
     public static final EngineeringUnits gramsOfWaterPerKilogramDryAir = new EngineeringUnits(28);
+    public static final EngineeringUnits grainsOfWaterPerPoundDryAir = new EngineeringUnits(47972);
     public static final EngineeringUnits percentRelativeHumidity = new EngineeringUnits(29);
     // Length
     public static final EngineeringUnits micrometers = new EngineeringUnits(194);
@@ -148,6 +166,9 @@ public class EngineeringUnits extends Enumerated {
     public static final EngineeringUnits meters = new EngineeringUnits(31);
     public static final EngineeringUnits inches = new EngineeringUnits(32);
     public static final EngineeringUnits feet = new EngineeringUnits(33);
+    public static final EngineeringUnits yards = new EngineeringUnits(47825);
+    public static final EngineeringUnits miles = new EngineeringUnits(47826);
+    public static final EngineeringUnits nauticalMiles = new EngineeringUnits(47827);
     // Light
     public static final EngineeringUnits candelas = new EngineeringUnits(179);
     public static final EngineeringUnits candelasPerSquareMeter = new EngineeringUnits(180);
@@ -162,24 +183,64 @@ public class EngineeringUnits extends Enumerated {
     public static final EngineeringUnits kilograms = new EngineeringUnits(39);
     public static final EngineeringUnits poundsMass = new EngineeringUnits(40);
     public static final EngineeringUnits tons = new EngineeringUnits(41);
+    public static final EngineeringUnits metricTonnes = new EngineeringUnits(47830);
+    public static final EngineeringUnits shortTons = new EngineeringUnits(47831);
+    public static final EngineeringUnits longTons = new EngineeringUnits(47832);
     // Mass Flow
     public static final EngineeringUnits gramsPerSecond = new EngineeringUnits(154);
     public static final EngineeringUnits gramsPerMinute = new EngineeringUnits(155);
+    public static final EngineeringUnits gramsPerHour = new EngineeringUnits(47833);
+    public static final EngineeringUnits gramsPerDay = new EngineeringUnits(47834);
     public static final EngineeringUnits kilogramsPerSecond = new EngineeringUnits(42);
     public static final EngineeringUnits kilogramsPerMinute = new EngineeringUnits(43);
     public static final EngineeringUnits kilogramsPerHour = new EngineeringUnits(44);
+    public static final EngineeringUnits kilogramsPerDay = new EngineeringUnits(47835);
     public static final EngineeringUnits poundsMassPerSecond = new EngineeringUnits(119);
     public static final EngineeringUnits poundsMassPerMinute = new EngineeringUnits(45);
     public static final EngineeringUnits poundsMassPerHour = new EngineeringUnits(46);
     public static final EngineeringUnits tonsPerHour = new EngineeringUnits(156);
+    public static final EngineeringUnits shortTonsPerSecond = new EngineeringUnits(47836);
+    public static final EngineeringUnits shortTonsPerMinute = new EngineeringUnits(47837);
+    public static final EngineeringUnits shortTonsPerHour = new EngineeringUnits(47838);
+    public static final EngineeringUnits shortTonsPerDay = new EngineeringUnits(47839);
+    public static final EngineeringUnits metricTonnesPerSecond = new EngineeringUnits(47840);
+    public static final EngineeringUnits metricTonnesPerMinute = new EngineeringUnits(47841);
+    public static final EngineeringUnits metricTonnesPerHour = new EngineeringUnits(47842);
+    public static final EngineeringUnits metricTonnesPerDay = new EngineeringUnits(47843);
+    public static final EngineeringUnits longTonsPerSecond = new EngineeringUnits(47844);
+    public static final EngineeringUnits longTonsPerMinute = new EngineeringUnits(47845);
+    public static final EngineeringUnits longTonsPerHour = new EngineeringUnits(47846);
+    public static final EngineeringUnits longTonsPerDay = new EngineeringUnits(47847);
     // Power
     public static final EngineeringUnits milliwatts = new EngineeringUnits(132);
     public static final EngineeringUnits watts = new EngineeringUnits(47);
     public static final EngineeringUnits kilowatts = new EngineeringUnits(48);
     public static final EngineeringUnits megawatts = new EngineeringUnits(49);
+    public static final EngineeringUnits gigawatts = new EngineeringUnits(47924);
+    public static final EngineeringUnits btusPerSecond = new EngineeringUnits(47848);
+    public static final EngineeringUnits btusPerMinute = new EngineeringUnits(47849);
     public static final EngineeringUnits btusPerHour = new EngineeringUnits(50);
+    public static final EngineeringUnits btusPerDay = new EngineeringUnits(47850);
+    public static final EngineeringUnits kiloBtusPerSecond = new EngineeringUnits(47851);
+    public static final EngineeringUnits kiloBtusPerMinute = new EngineeringUnits(47852);
     public static final EngineeringUnits kiloBtusPerHour = new EngineeringUnits(157);
+    public static final EngineeringUnits kiloBtusPerDay = new EngineeringUnits(47853);
+    public static final EngineeringUnits megaBtusPerSecond = new EngineeringUnits(47854);
+    public static final EngineeringUnits megaBtusPerMinute = new EngineeringUnits(47855);
+    public static final EngineeringUnits megaBtusPerHour = new EngineeringUnits(47856);
+    public static final EngineeringUnits megaBtusPerDay = new EngineeringUnits(47857);
+    public static final EngineeringUnits joulesPerSecond = new EngineeringUnits(47858);
+    public static final EngineeringUnits joulesPerMinute = new EngineeringUnits(47859);
     public static final EngineeringUnits joulesPerHour = new EngineeringUnits(247);
+    public static final EngineeringUnits joulesPerDay = new EngineeringUnits(47860);
+    public static final EngineeringUnits kilojoulesPerSecond = new EngineeringUnits(47861);
+    public static final EngineeringUnits kilojoulesPerMinute = new EngineeringUnits(47862);
+    public static final EngineeringUnits kilojoulesPerHour = new EngineeringUnits(47863);
+    public static final EngineeringUnits kilojoulesPerDay = new EngineeringUnits(47864);
+    public static final EngineeringUnits megajoulesPerSecond = new EngineeringUnits(47865);
+    public static final EngineeringUnits megajoulesPerMinute = new EngineeringUnits(47866);
+    public static final EngineeringUnits megajoulesPerHour = new EngineeringUnits(47867);
+    public static final EngineeringUnits megajoulesPerDay = new EngineeringUnits(47868);
     public static final EngineeringUnits horsepower = new EngineeringUnits(51);
     public static final EngineeringUnits tonsRefrigeration = new EngineeringUnits(52);
     // Pressure
@@ -189,6 +250,8 @@ public class EngineeringUnits extends Enumerated {
     public static final EngineeringUnits millibars = new EngineeringUnits(134);
     public static final EngineeringUnits bars = new EngineeringUnits(55);
     public static final EngineeringUnits poundsForcePerSquareInch = new EngineeringUnits(56);
+    public static final EngineeringUnits poundsForcePerSquareInchAbsolute = new EngineeringUnits(47907);
+    public static final EngineeringUnits poundsForcePerSquareInchGauge = new EngineeringUnits(47908);
     public static final EngineeringUnits millimetersOfWater = new EngineeringUnits(206);
     public static final EngineeringUnits centimetersOfWater = new EngineeringUnits(57);
     public static final EngineeringUnits inchesOfWater = new EngineeringUnits(58);
@@ -197,14 +260,22 @@ public class EngineeringUnits extends Enumerated {
     public static final EngineeringUnits inchesOfMercury = new EngineeringUnits(61);
     // Temperature
     public static final EngineeringUnits degreesCelsius = new EngineeringUnits(62);
-    public static final EngineeringUnits degreesKelvin = new EngineeringUnits(63);
-    public static final EngineeringUnits degreesKelvinPerHour = new EngineeringUnits(181);
-    public static final EngineeringUnits degreesKelvinPerMinute = new EngineeringUnits(182);
+    public static final EngineeringUnits degreesCelsiusPerDay = new EngineeringUnits(47869);
+    public static final EngineeringUnits degreesCelsiusPerHour = new EngineeringUnits(91);
+    public static final EngineeringUnits degreesCelsiusPerMinute = new EngineeringUnits(92);
+    public static final EngineeringUnits kelvin = new EngineeringUnits(63);
+    public static final EngineeringUnits kelvinPerDay = new EngineeringUnits(47870);
+    public static final EngineeringUnits kelvinPerHour = new EngineeringUnits(181);
+    public static final EngineeringUnits kelvinPerMinute = new EngineeringUnits(182);
     public static final EngineeringUnits degreesFahrenheit = new EngineeringUnits(64);
+    public static final EngineeringUnits degreesFahrenheitPerDay = new EngineeringUnits(47871);
+    public static final EngineeringUnits degreesFahrenheitPerHour = new EngineeringUnits(93);
+    public static final EngineeringUnits degreesFahrenheitPerMinute = new EngineeringUnits(94);
     public static final EngineeringUnits degreeDaysCelsius = new EngineeringUnits(65);
     public static final EngineeringUnits degreeDaysFahrenheit = new EngineeringUnits(66);
+    public static final EngineeringUnits deltaDegreesCelsius = new EngineeringUnits(47872);
     public static final EngineeringUnits deltaDegreesFahrenheit = new EngineeringUnits(120);
-    public static final EngineeringUnits deltaDegreesKelvin = new EngineeringUnits(121);
+    public static final EngineeringUnits deltaKelvin = new EngineeringUnits(121);
     // Time
     public static final EngineeringUnits years = new EngineeringUnits(67);
     public static final EngineeringUnits months = new EngineeringUnits(68);
@@ -215,8 +286,14 @@ public class EngineeringUnits extends Enumerated {
     public static final EngineeringUnits seconds = new EngineeringUnits(73);
     public static final EngineeringUnits hundredthsSeconds = new EngineeringUnits(158);
     public static final EngineeringUnits milliseconds = new EngineeringUnits(159);
+    public static final EngineeringUnits microseconds = new EngineeringUnits(47979);
+    public static final EngineeringUnits nanoseconds = new EngineeringUnits(47980);
+    public static final EngineeringUnits picoseconds = new EngineeringUnits(47981);
     // Torque
     public static final EngineeringUnits newtonMeters = new EngineeringUnits(160);
+    public static final EngineeringUnits poundForceFeet = new EngineeringUnits(47904);
+    public static final EngineeringUnits poundForceInches = new EngineeringUnits(47905);
+    public static final EngineeringUnits ounceForceInches = new EngineeringUnits(47906);
     // Velocity
     public static final EngineeringUnits millimetersPerSecond = new EngineeringUnits(161);
     public static final EngineeringUnits millimetersPerMinute = new EngineeringUnits(162);
@@ -234,6 +311,18 @@ public class EngineeringUnits extends Enumerated {
     public static final EngineeringUnits milliliters = new EngineeringUnits(197);
     public static final EngineeringUnits liters = new EngineeringUnits(82);
     public static final EngineeringUnits usGallons = new EngineeringUnits(83);
+    public static final EngineeringUnits millionsOfUsGallons = new EngineeringUnits(47912);
+    public static final EngineeringUnits millionsOfImperialGallons = new EngineeringUnits(47913);
+    public static final EngineeringUnits volume1 = new EngineeringUnits(47937);
+    public static final EngineeringUnits volume2 = new EngineeringUnits(47938);
+    public static final EngineeringUnits volume3 = new EngineeringUnits(47939);
+    public static final EngineeringUnits volume4 = new EngineeringUnits(47940);
+    public static final EngineeringUnits volume5 = new EngineeringUnits(47941);
+    public static final EngineeringUnits volume6 = new EngineeringUnits(47942);
+    public static final EngineeringUnits volume7 = new EngineeringUnits(47943);
+    public static final EngineeringUnits volume8 = new EngineeringUnits(47944);
+    public static final EngineeringUnits volume9 = new EngineeringUnits(47945);
+    public static final EngineeringUnits volume10 = new EngineeringUnits(47946);
     // Volumetric Flow
     public static final EngineeringUnits cubicFeetPerSecond = new EngineeringUnits(142);
     public static final EngineeringUnits cubicFeetPerMinute = new EngineeringUnits(84);
@@ -244,24 +333,38 @@ public class EngineeringUnits extends Enumerated {
     public static final EngineeringUnits millionStandardCubicFeetPerDay = new EngineeringUnits(47809);
     public static final EngineeringUnits thousandCubicFeetPerDay = new EngineeringUnits(47810);
     public static final EngineeringUnits thousandStandardCubicFeetPerDay = new EngineeringUnits(47811);
+    public static final EngineeringUnits millionCubicFeetPerMinute = new EngineeringUnits(47873);
+    public static final EngineeringUnits millionCubicFeetPerDay = new EngineeringUnits(47874);
     public static final EngineeringUnits poundsMassPerDay = new EngineeringUnits(47812);
     public static final EngineeringUnits cubicMetersPerSecond = new EngineeringUnits(85);
     public static final EngineeringUnits cubicMetersPerMinute = new EngineeringUnits(165);
     public static final EngineeringUnits cubicMetersPerHour = new EngineeringUnits(135);
     public static final EngineeringUnits cubicMetersPerDay = new EngineeringUnits(249);
+    public static final EngineeringUnits imperialGallonsPerSecond = new EngineeringUnits(47875);
     public static final EngineeringUnits imperialGallonsPerMinute = new EngineeringUnits(86);
     public static final EngineeringUnits millilitersPerSecond = new EngineeringUnits(198);
+    public static final EngineeringUnits millilitersPerMinute = new EngineeringUnits(47914);
     public static final EngineeringUnits litersPerSecond = new EngineeringUnits(87);
     public static final EngineeringUnits litersPerMinute = new EngineeringUnits(88);
     public static final EngineeringUnits litersPerHour = new EngineeringUnits(136);
+    public static final EngineeringUnits litersPerDay = new EngineeringUnits(47878);
+    public static final EngineeringUnits usGallonsPerSecond = new EngineeringUnits(47879);
     public static final EngineeringUnits usGallonsPerMinute = new EngineeringUnits(89);
     public static final EngineeringUnits usGallonsPerHour = new EngineeringUnits(192);
+    public static final EngineeringUnits usGallonsPerDay = new EngineeringUnits(47880);
+    public static final EngineeringUnits cubicMeterPulseValue = new EngineeringUnits(47923);
+    public static final EngineeringUnits volumetricFlow1 = new EngineeringUnits(47947);
+    public static final EngineeringUnits volumetricFlow2 = new EngineeringUnits(47948);
+    public static final EngineeringUnits volumetricFlow3 = new EngineeringUnits(47949);
+    public static final EngineeringUnits volumetricFlow4 = new EngineeringUnits(47950);
+    public static final EngineeringUnits volumetricFlow5 = new EngineeringUnits(47951);
+    public static final EngineeringUnits volumetricFlow6 = new EngineeringUnits(47952);
+    public static final EngineeringUnits volumetricFlow7 = new EngineeringUnits(47953);
+    public static final EngineeringUnits volumetricFlow8 = new EngineeringUnits(47954);
+    public static final EngineeringUnits volumetricFlow9 = new EngineeringUnits(47955);
+    public static final EngineeringUnits volumetricFlow10 = new EngineeringUnits(47956);
     // Other
     public static final EngineeringUnits degreesAngular = new EngineeringUnits(90);
-    public static final EngineeringUnits degreesCelsiusPerHour = new EngineeringUnits(91);
-    public static final EngineeringUnits degreesCelsiusPerMinute = new EngineeringUnits(92);
-    public static final EngineeringUnits degreesFahrenheitPerHour = new EngineeringUnits(93);
-    public static final EngineeringUnits degreesFahrenheitPerMinute = new EngineeringUnits(94);
     public static final EngineeringUnits jouleSeconds = new EngineeringUnits(183);
     public static final EngineeringUnits kilogramsPerCubicMeter = new EngineeringUnits(186);
     public static final EngineeringUnits kilowattHoursPerSquareMeter = new EngineeringUnits(137);
@@ -281,6 +384,9 @@ public class EngineeringUnits extends Enumerated {
     public static final EngineeringUnits percentObscurationPerFoot = new EngineeringUnits(143);
     public static final EngineeringUnits percentObscurationPerMeter = new EngineeringUnits(144);
     public static final EngineeringUnits percentPerSecond = new EngineeringUnits(99);
+    public static final EngineeringUnits percentPerMinute = new EngineeringUnits(47881);
+    public static final EngineeringUnits percentPerHour = new EngineeringUnits(47882);
+    public static final EngineeringUnits percentPerDay = new EngineeringUnits(47883);
     public static final EngineeringUnits perMinute = new EngineeringUnits(100);
     public static final EngineeringUnits perSecond = new EngineeringUnits(101);
     public static final EngineeringUnits psiPerDegreeFahrenheit = new EngineeringUnits(102);
@@ -288,23 +394,39 @@ public class EngineeringUnits extends Enumerated {
     public static final EngineeringUnits radiansPerSecond = new EngineeringUnits(184);
     public static final EngineeringUnits revolutionsPerMinute = new EngineeringUnits(104);
     public static final EngineeringUnits squareMetersPerNewton = new EngineeringUnits(185);
-    public static final EngineeringUnits wattsPerMeterPerDegreeKelvin = new EngineeringUnits(189);
-    public static final EngineeringUnits wattsPerSquareMeterDegreeKelvin = new EngineeringUnits(141);
+    public static final EngineeringUnits wattsPerMeterPerKelvin = new EngineeringUnits(189);
+    public static final EngineeringUnits wattsPerSquareMeterPerKelvin = new EngineeringUnits(141);
     public static final EngineeringUnits perMille = new EngineeringUnits(207);
+    public static final EngineeringUnits perMillion = new EngineeringUnits(47884);
+    public static final EngineeringUnits perBillion = new EngineeringUnits(47885);
     public static final EngineeringUnits gramsPerGram = new EngineeringUnits(208);
+    public static final EngineeringUnits milligramsPerGram = new EngineeringUnits(211);
     public static final EngineeringUnits kilogramsPerKilogram = new EngineeringUnits(209);
     public static final EngineeringUnits gramsPerKilogram = new EngineeringUnits(210);
-    public static final EngineeringUnits milligramsPerGram = new EngineeringUnits(211);
     public static final EngineeringUnits milligramsPerKilogram = new EngineeringUnits(212);
+    public static final EngineeringUnits microgramsPerKilogram = new EngineeringUnits(47888);
+    public static final EngineeringUnits nanogramsPerKilogram = new EngineeringUnits(47889);
     public static final EngineeringUnits gramsPerMilliliter = new EngineeringUnits(213);
+    public static final EngineeringUnits milligramsPerMilliliter = new EngineeringUnits(47890);
+    public static final EngineeringUnits microgramsPerMilliliter = new EngineeringUnits(47891);
+    public static final EngineeringUnits nanogramsPerMilliliter = new EngineeringUnits(47892);
+    public static final EngineeringUnits kilogramsPerLiter = new EngineeringUnits(47893);
     public static final EngineeringUnits gramsPerLiter = new EngineeringUnits(214);
     public static final EngineeringUnits milligramsPerLiter = new EngineeringUnits(215);
     public static final EngineeringUnits microgramsPerLiter = new EngineeringUnits(216);
+    public static final EngineeringUnits nanogramsPerLiter = new EngineeringUnits(47894);
     public static final EngineeringUnits gramsPerCubicMeter = new EngineeringUnits(217);
     public static final EngineeringUnits milligramsPerCubicMeter = new EngineeringUnits(218);
     public static final EngineeringUnits microgramsPerCubicMeter = new EngineeringUnits(219);
     public static final EngineeringUnits nanogramsPerCubicMeter = new EngineeringUnits(220);
     public static final EngineeringUnits gramsPerCubicCentimeter = new EngineeringUnits(221);
+    public static final EngineeringUnits milligramsPerCubicCentimeter = new EngineeringUnits(47895);
+    public static final EngineeringUnits microgramsPerCubicCentimeter = new EngineeringUnits(47896);
+    public static final EngineeringUnits nanogramsPerCubicCentimeter = new EngineeringUnits(47897);
+    public static final EngineeringUnits particlesPerCubicFoot = new EngineeringUnits(47968);
+    public static final EngineeringUnits particlesPerCubicMeter = new EngineeringUnits(47969);
+    public static final EngineeringUnits picocuriesPerLiter = new EngineeringUnits(47970);
+    public static final EngineeringUnits becquerelsPerCubicMeter = new EngineeringUnits(47971);
     public static final EngineeringUnits becquerels = new EngineeringUnits(222);
     public static final EngineeringUnits kilobecquerels = new EngineeringUnits(223);
     public static final EngineeringUnits megabecquerels = new EngineeringUnits(224);
@@ -321,7 +443,52 @@ public class EngineeringUnits extends Enumerated {
     public static final EngineeringUnits nephelometricTurbidityUnit = new EngineeringUnits(233);
     public static final EngineeringUnits pH = new EngineeringUnits(234);
     public static final EngineeringUnits gramsPerSquareMeter = new EngineeringUnits(235);
-    public static final EngineeringUnits minutesPerDegreeKelvin = new EngineeringUnits(236);
+    public static final EngineeringUnits minutesPerKelvin = new EngineeringUnits(236);
+    public static final EngineeringUnits degreesLovibond = new EngineeringUnits(47816);
+    public static final EngineeringUnits alcoholByVolume = new EngineeringUnits(47817);
+    public static final EngineeringUnits internationalBitteringUnits = new EngineeringUnits(47818);
+    public static final EngineeringUnits europeanBitternessUnits = new EngineeringUnits(47819);
+    public static final EngineeringUnits degreesPlato = new EngineeringUnits(47820);
+    public static final EngineeringUnits specificGravity = new EngineeringUnits(47821);
+    public static final EngineeringUnits europeanBrewingConvention = new EngineeringUnits(47822);
+    public static final EngineeringUnits milsPerYear = new EngineeringUnits(47915);
+    public static final EngineeringUnits millimetersPerYear = new EngineeringUnits(47916);
+    public static final EngineeringUnits pulsesPerMinute = new EngineeringUnits(47917);
+    public static final EngineeringUnits bitsPerSecond = new EngineeringUnits(47929);
+    public static final EngineeringUnits kilobitsPerSecond = new EngineeringUnits(47930);
+    public static final EngineeringUnits megabitsPerSecond = new EngineeringUnits(47931);
+    public static final EngineeringUnits gigabitsPerSecond = new EngineeringUnits(47932);
+    public static final EngineeringUnits bytesPerSecond = new EngineeringUnits(47933);
+    public static final EngineeringUnits kilobytesPerSecond = new EngineeringUnits(47934);
+    public static final EngineeringUnits megabytesPerSecond = new EngineeringUnits(47935);
+    public static final EngineeringUnits gigabytesPerSecond = new EngineeringUnits(47936);
+    public static final EngineeringUnits siteUnit1 = new EngineeringUnits(47958);
+    public static final EngineeringUnits siteUnit2 = new EngineeringUnits(47959);
+    public static final EngineeringUnits siteUnit3 = new EngineeringUnits(47960);
+    public static final EngineeringUnits siteUnit4 = new EngineeringUnits(47961);
+    public static final EngineeringUnits siteUnit5 = new EngineeringUnits(47962);
+    public static final EngineeringUnits siteUnit6 = new EngineeringUnits(47963);
+    public static final EngineeringUnits siteUnit7 = new EngineeringUnits(47964);
+    public static final EngineeringUnits siteUnit8 = new EngineeringUnits(47965);
+    public static final EngineeringUnits siteUnit9 = new EngineeringUnits(47966);
+    public static final EngineeringUnits siteUnit10 = new EngineeringUnits(47967);
+    public static final EngineeringUnits degreeHoursCelsius = new EngineeringUnits(47973);
+    public static final EngineeringUnits degreeHoursFahrenheit = new EngineeringUnits(47974);
+    public static final EngineeringUnits degreeMinutesCelsius = new EngineeringUnits(47975);
+    public static final EngineeringUnits degreeMinutesFahrenheit = new EngineeringUnits(47976);
+    public static final EngineeringUnits degreeSecondsCelsius = new EngineeringUnits(47977);
+    public static final EngineeringUnits degreeSecondsFahrenheit = new EngineeringUnits(47978);
+    // Uncategorized
+    public static final EngineeringUnits nanograms = new EngineeringUnits(47828);
+    public static final EngineeringUnits micrograms = new EngineeringUnits(47829);
+    public static final EngineeringUnits imperialGallonsPerHour = new EngineeringUnits(47876);
+    public static final EngineeringUnits imperialGallonsPerDay = new EngineeringUnits(47877);
+    public static final EngineeringUnits microgramsPerGram = new EngineeringUnits(47886);
+    public static final EngineeringUnits nanogramsPerGram = new EngineeringUnits(47887);
+    public static final EngineeringUnits gigajoules = new EngineeringUnits(47925);
+    public static final EngineeringUnits terajoules = new EngineeringUnits(47926);
+    public static final EngineeringUnits gigawattHours = new EngineeringUnits(47927);
+    public static final EngineeringUnits gigawattReactiveHours = new EngineeringUnits(47928);
 
     private static final Map<Integer, Enumerated> idMap = new HashMap<>();
     private static final Map<String, Enumerated> nameMap = new HashMap<>();
@@ -331,18 +498,18 @@ public class EngineeringUnits extends Enumerated {
         Enumerated.init(MethodHandles.lookup().lookupClass(), idMap, nameMap, prettyMap);
     }
 
-    public static EngineeringUnits forId(final int id) {
+    public static EngineeringUnits forId(int id) {
         EngineeringUnits e = (EngineeringUnits) idMap.get(id);
         if (e == null)
             e = new EngineeringUnits(id);
         return e;
     }
 
-    public static String nameForId(final int id) {
+    public static String nameForId(int id) {
         return prettyMap.get(id);
     }
 
-    public static EngineeringUnits forName(final String name) {
+    public static EngineeringUnits forName(String name) {
         return (EngineeringUnits) Enumerated.forName(nameMap, name);
     }
 
@@ -350,11 +517,11 @@ public class EngineeringUnits extends Enumerated {
         return idMap.size();
     }
 
-    private EngineeringUnits(final int value) {
+    private EngineeringUnits(int value) {
         super(value);
     }
 
-    public EngineeringUnits(final ByteQueue queue) throws BACnetErrorException {
+    public EngineeringUnits(ByteQueue queue) throws BACnetErrorException {
         super(queue);
     }
 

--- a/src/test/java/com/serotonin/bacnet4j/obj/CharacterStringValueObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/CharacterStringValueObjectTest.java
@@ -1,0 +1,251 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2026 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
+package com.serotonin.bacnet4j.obj;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.serotonin.bacnet4j.LocalDevice;
+import com.serotonin.bacnet4j.RemoteDevice;
+import com.serotonin.bacnet4j.exception.ErrorAPDUException;
+import com.serotonin.bacnet4j.npdu.test.TestNetwork;
+import com.serotonin.bacnet4j.npdu.test.TestNetworkMap;
+import com.serotonin.bacnet4j.service.confirmed.WritePropertyRequest;
+import com.serotonin.bacnet4j.transport.DefaultTransport;
+import com.serotonin.bacnet4j.type.constructed.BACnetArray;
+import com.serotonin.bacnet4j.type.constructed.OptionalCharacterString;
+import com.serotonin.bacnet4j.type.constructed.PropertyValue;
+import com.serotonin.bacnet4j.type.enumerated.ErrorClass;
+import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
+import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
+import com.serotonin.bacnet4j.type.primitive.CharacterString;
+import com.serotonin.bacnet4j.type.primitive.Null;
+import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
+
+public class CharacterStringValueObjectTest {
+    private final TestNetworkMap map = new TestNetworkMap();
+    private LocalDevice client;
+    private LocalDevice server;
+    private CharacterStringValueObject csv;
+    private RemoteDevice remoteServer;
+
+    @Before
+    public void before() throws Exception {
+        client = new LocalDevice(1, new DefaultTransport(new TestNetwork(map, 1, 0))).initialize();
+        server = new LocalDevice(2, new DefaultTransport(new TestNetwork(map, 2, 0))).initialize();
+
+        csv = server.addObject(new CharacterStringValueObject(server, 0, "csv0",
+                new CharacterString("initial"), false));
+
+        // Seed Fault_Values with three OptionalCharacterString elements. Element type is
+        // CHOICE { NULL, CharacterString }, so a mix of set and null entries is legal.
+        csv.writePropertyInternal(PropertyIdentifier.faultValues,
+                new BACnetArray<>(
+                        new OptionalCharacterString(new CharacterString("fault-a")),
+                        new OptionalCharacterString(new CharacterString("fault-b")),
+                        new OptionalCharacterString(new CharacterString("fault-c"))));
+
+        remoteServer = client.getRemoteDeviceBlocking(2, 1000);
+    }
+
+    @After
+    public void after() {
+        client.terminate();
+        server.terminate();
+    }
+
+    /**
+     * A client writes a bare NULL primitive to a specific index of the Fault_Values array on a
+     * CharacterString_Value object. Fault_Values' element datatype is
+     * OptionalCharacterString = CHOICE { NULL, CharacterString }, so this is a legitimate value
+     * — not the "Null write silently ignored" case from addendum 135-2016br-2. The wire path
+     * decodes the bare Null against the property's declared type and delivers an
+     * OptionalCharacterString wrapping Null to the write handler, so the array element ends up
+     * as Null and the write completes successfully.
+     */
+    @Test
+    public void writeNullToFaultValuesIndex() throws Exception {
+        client.send(remoteServer, new WritePropertyRequest(
+                        csv.getId(),
+                        PropertyIdentifier.faultValues,
+                        new UnsignedInteger(2),   // 1-based array index
+                        Null.instance,            // bare Null primitive on the wire
+                        null))                    // no priority
+                .get();
+
+        BACnetArray<OptionalCharacterString> arr = csv.get(PropertyIdentifier.faultValues);
+        assertEquals(3, arr.getCount());
+        assertTrue(arr.getBase1(1).isCharacterStringValue());
+        assertEquals("fault-a", arr.getBase1(1).getCharacterStringValue().getValue());
+        assertFalse("index 2 should have been overwritten with Null",
+                arr.getBase1(2).isCharacterStringValue());
+        assertTrue(arr.getBase1(2).isNullValue());
+        assertTrue(arr.getBase1(3).isCharacterStringValue());
+        assertEquals("fault-c", arr.getBase1(3).getCharacterStringValue().getValue());
+    }
+
+    /**
+     * Complementary case: writing an actual CharacterString to the same index round-trips
+     * intact, confirming the write path is unrelated to the Null-specific handling above.
+     */
+    @Test
+    public void writeCharacterStringToFaultValuesIndex() throws Exception {
+        client.send(remoteServer, new WritePropertyRequest(
+                        csv.getId(),
+                        PropertyIdentifier.faultValues,
+                        new UnsignedInteger(2),
+                        new OptionalCharacterString(new CharacterString("fault-b-replaced")),
+                        null))
+                .get();
+
+        BACnetArray<OptionalCharacterString> arr = csv.get(PropertyIdentifier.faultValues);
+        assertEquals(3, arr.getCount());
+        assertTrue(arr.getBase1(2).isCharacterStringValue());
+        assertEquals("fault-b-replaced", arr.getBase1(2).getCharacterStringValue().getValue());
+    }
+
+    /**
+     * Positive test for addendum 135-2016br-2 (strict reading): a client relinquishes a
+     * non-commandable property whose declared datatype does not include NULL. Object_Name is
+     * CharacterString-typed and not commandable. Under strict Clause 19.2.2 semantics a
+     * relinquish requires both a NULL value and a priority. The property shall not be changed
+     * and the write shall be reported successful.
+     */
+    @Test
+    public void br2_relinquishOfNonCommandableNonNullTypedPropertySilentlySucceeds() throws Exception {
+        CharacterString before = csv.get(PropertyIdentifier.objectName);
+
+        client.send(remoteServer, new WritePropertyRequest(
+                        csv.getId(),
+                        PropertyIdentifier.objectName,
+                        null,
+                        Null.instance,
+                        new UnsignedInteger(8)))         // priority present -> strict relinquish
+                .get();
+
+        assertEquals(before, csv.get(PropertyIdentifier.objectName));
+    }
+
+    /**
+     * br-2 strict-relinquish gate: a NULL write to a non-commandable non-Null-typed property
+     * without an explicit priority is not a "relinquish" per Clause 19.2.2. The br-2 bypass
+     * does not apply, and the write must fail with invalidDataType.
+     */
+    @Test
+    public void br2_bareNullWithoutPriorityStillFailsInvalidDataType() throws Exception {
+        try {
+            client.send(remoteServer, new WritePropertyRequest(
+                            csv.getId(),
+                            PropertyIdentifier.description,
+                            null,
+                            Null.instance,
+                            null))            // no priority — not a relinquish
+                    .get();
+            fail("Expected ErrorAPDUException with invalid-data-type");
+        } catch (ErrorAPDUException expected) {
+            assertEquals(ErrorClass.property, expected.getError().getErrorClass());
+            assertEquals(ErrorCode.invalidDataType, expected.getError().getErrorCode());
+        }
+    }
+
+    /**
+     * br-2 non-Null path: a non-NULL value written with a priority to a non-commandable
+     * property succeeds; the priority is ignored per Clause 19.2.1. Confirms the guard does
+     * not misfire on non-NULL values.
+     */
+    @Test
+    public void br2_nonNullWriteWithPriorityToNonCommandableSucceeds() throws Exception {
+        CharacterString newDescription = new CharacterString("changed via write");
+        client.send(remoteServer, new WritePropertyRequest(
+                        csv.getId(),
+                        PropertyIdentifier.description,
+                        null,
+                        newDescription,
+                        new UnsignedInteger(8)))
+                .get();
+
+        assertEquals(newDescription, csv.get(PropertyIdentifier.description));
+    }
+
+    /**
+     * br-2 direct-API path: calling {@code writeProperty} on the object with a bare NULL
+     * primitive PropertyValue behaves identically to the network path. Confirms the write-layer
+     * guard fires regardless of how the write is issued.
+     */
+    @Test
+    public void br2_directApiRelinquishSilentlySucceeds() throws Exception {
+        CharacterString before = csv.get(PropertyIdentifier.description);
+
+        csv.writeProperty(null,
+                new PropertyValue(PropertyIdentifier.description, null, Null.instance, new UnsignedInteger(6)));
+
+        assertEquals(before, csv.get(PropertyIdentifier.description));
+    }
+
+    /**
+     * br-2 commandable-instance exclusion: a NULL-with-priority write to Present_Value on a
+     * commandable CharacterString_Value (supportCommandable enabled) must be routed to
+     * CommandableMixin as a real relinquish — not silently succeeded. The priority slot is
+     * cleared and the effective Present_Value falls back through the priority array.
+     */
+    @Test
+    public void br2_relinquishOfCommandablePresentValueRoutesToCommandableMixin() throws Exception {
+        CharacterString relinquishDefault = new CharacterString("relinquished");
+        CharacterStringValueObject commandable = server.addObject(new CharacterStringValueObject(
+                server, 1, "csv1", new CharacterString("initial"), false).supportCommandable(relinquishDefault));
+
+        // Command a value at priority 8 so we have a slot to relinquish.
+        client.send(remoteServer, new WritePropertyRequest(
+                        commandable.getId(),
+                        PropertyIdentifier.presentValue,
+                        null,
+                        new CharacterString("commanded"),
+                        new UnsignedInteger(8)))
+                .get();
+        assertEquals(new CharacterString("commanded"), commandable.get(PropertyIdentifier.presentValue));
+
+        // Now relinquish priority 8 with a NULL. This is a REAL relinquish handled by
+        // CommandableMixin, not a br-2 silent success.
+        client.send(remoteServer, new WritePropertyRequest(
+                        commandable.getId(),
+                        PropertyIdentifier.presentValue,
+                        null,
+                        Null.instance,
+                        new UnsignedInteger(8)))
+                .get();
+
+        // With no other priority active, effective present value falls back to Relinquish_Default.
+        assertEquals(relinquishDefault, commandable.get(PropertyIdentifier.presentValue));
+    }
+}


### PR DESCRIPTION
https://radixiot.atlassian.net/browse/MANGO-2956

- Addendum 135-2016br-2: WriteProperty and WritePropertyMultiple now accept a NULL value written to a non-commandable property whose declared datatype does not include NULL. Per Clause 15.9.2 / 15.10.2 / 19.2.1, such a relinquish shall not fail; the property is not changed and the write is reported successful. Applied under the strict Clause 19.2.2 interpretation (a relinquish requires both NULL value and an explicit priority parameter). Commandable properties continue to be handled by CommandableMixin.
- Addendum 135-2016bq-1: Access_Credential.Absentee_Limit property type registration corrected from Unsigned to Unsigned16 per Table 12-40 and Clause 12.35.16.
- Addendum 135-2016br-2: aligned list of engineering units with spec