### PR TITLE
MANGO-2955 Stop generating Time-form timestamps; use DateTime form

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,11 @@ Releases
 ========
 *Version 7.0.0*
 
-- Breaking change: BACnet objects are no longer added to the local device in their constructors because of
-  initialization problems. Instead, objects need to be explicitly added to the local device after instantiation. Many
-  examples can be found in the unit tests, but e.g.:
+This version contains many breaking changes. Please review carefully.
+
+- BACnet objects are no longer added to the local device in their constructors because of initialization problems.
+  Instead, objects need to be explicitly added to the local device after instantiation. Many examples can be found in
+  the unit tests, but e.g.:
 
 ```
 // Old code
@@ -100,6 +102,7 @@ trendLogMult.writeProperty(PropertyIdentifier.recordCount, new UnsignedInteger(1
 - LifeSafetyPoint and LifeSafetyZone now handle `trackingValue` and `reliability` properly according to out of service
   rules.
 - Changes for compliance with addendum 135-2016bi-3 regarding extremely large logs
+- Time form construction of DateTime choice has been deprecated. They should no longer be created by client code
 
 *Version 6.2.0*
 

--- a/src/main/java/com/serotonin/bacnet4j/obj/mixin/CommandableMixin.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/mixin/CommandableMixin.java
@@ -118,7 +118,7 @@ public class CommandableMixin extends AbstractMixin {
         if (supportsValueSource) {
             addProperty(valueSourceArray, new BACnetArray<>(16, new ValueSource()), false);
             addProperty(lastCommandTime, new TimeStamp(new DateTime(getLocalDevice())), false);
-            addProperty(commandTimeArray, new BACnetArray<>(16, TimeStamp.UNSPECIFIED_TIME), false);
+            addProperty(commandTimeArray, new BACnetArray<>(16, TimeStamp.UNSPECIFIED_DATETIME), false);
         }
     }
 
@@ -133,7 +133,7 @@ public class CommandableMixin extends AbstractMixin {
         if (supportsCommandable) {
             addProperty(valueSourceArray, new BACnetArray<>(16, new ValueSource()), false);
             addProperty(lastCommandTime, new TimeStamp(new DateTime(getLocalDevice())), false);
-            addProperty(commandTimeArray, new BACnetArray<>(16, TimeStamp.UNSPECIFIED_TIME), false);
+            addProperty(commandTimeArray, new BACnetArray<>(16, TimeStamp.UNSPECIFIED_DATETIME), false);
         }
     }
 
@@ -142,18 +142,19 @@ public class CommandableMixin extends AbstractMixin {
     }
 
     @Override
-    synchronized protected boolean validateProperty(ValueSource valueSource, PropertyValue value)
+    protected synchronized boolean validateProperty(ValueSource valueSource, PropertyValue value)
             throws BACnetServiceException {
         if (pvProperty.equals(value.getPropertyIdentifier())) {
-            if (overridden)
+            if (overridden) {
                 return false;
+            }
 
             Boolean oos = get(outOfService);
-            if (oos.booleanValue())
+            if (oos.booleanValue()) {
                 return false;
+            }
 
-            if (supportsCommandable && value.getValue() instanceof Null)
-                return true;
+            return supportsCommandable && value.getValue() instanceof Null;
         } else if (value.getPropertyIdentifier().isOneOf(PropertyIdentifier.priorityArray,
                 PropertyIdentifier.currentCommandPriority, PropertyIdentifier.valueSourceArray,
                 PropertyIdentifier.lastCommandTime, PropertyIdentifier.commandTimeArray)) {
@@ -168,7 +169,7 @@ public class CommandableMixin extends AbstractMixin {
             if (!vs.getAddress().equals(valueSource.getAddress()))
                 throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
 
-            ValueSource newVs = (ValueSource) value.getValue();
+            ValueSource newVs = value.getValue();
             if (!newVs.isObject())
                 throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
 
@@ -181,7 +182,7 @@ public class CommandableMixin extends AbstractMixin {
     }
 
     @Override
-    synchronized protected boolean writeProperty(ValueSource valueSource, PropertyValue value)
+    protected synchronized boolean writeProperty(ValueSource valueSource, PropertyValue value)
             throws BACnetServiceException {
         if (pvProperty.equals(value.getPropertyIdentifier())) {
             if (overridden) {
@@ -226,14 +227,12 @@ public class CommandableMixin extends AbstractMixin {
     }
 
     @Override
-    synchronized protected void afterWriteProperty(PropertyIdentifier pid, Encodable oldValue,
-            Encodable newValue) {
+    protected synchronized void afterWriteProperty(PropertyIdentifier pid, Encodable oldValue, Encodable newValue) {
         if (relinquishDefault.equals(pid)) {
             // The relinquish default was changed. Ensure that the present value gets updated if necessary.
             updatePresentValue(null, new TimeStamp(new DateTime(getLocalDevice())));
-        } else if (minimumOffTime.equals(pid) || minimumOnTime.equals(pid)) {
-            if (supportsValueSource)
-                updateValueSourceArray(MIN_OFF_ON_PRIORITY, getLocalValueSource());
+        } else if ((minimumOffTime.equals(pid) || minimumOnTime.equals(pid)) && supportsValueSource) {
+            updateValueSourceArray(MIN_OFF_ON_PRIORITY, getLocalValueSource());
         }
     }
 
@@ -296,41 +295,39 @@ public class CommandableMixin extends AbstractMixin {
         Encodable oldValue = get(pvProperty);
         Unsigned32 minOff = get(minimumOffTime);
         Unsigned32 minOn = get(minimumOnTime);
-        if (minOff != null && minOn != null) {
-            if (!newValue.equals(oldValue)) {
-                // The value has changed. Check for updates to the timer.
+        if (minOff != null && minOn != null && !newValue.equals(oldValue)) {
+            // The value has changed. Check for updates to the timer.
 
-                // If the write was to a priority higher than 6, cancel any existing timer.
-                if (topIndex < MIN_OFF_ON_PRIORITY && minOnOffTimerTask != null) {
-                    minOnOffTimerTask.cancel(false);
-                    minOnOffTimerTask = null;
+            // If the write was to a priority higher than 6, cancel any existing timer.
+            if (topIndex < MIN_OFF_ON_PRIORITY && minOnOffTimerTask != null) {
+                minOnOffTimerTask.cancel(false);
+                minOnOffTimerTask = null;
+            }
+
+            // If a timer task already exists, there is no action to take.
+            if (minOnOffTimerTask == null) {
+                // Initialize the timer.
+                pa.setBase1(MIN_OFF_ON_PRIORITY, new PriorityValue(newValue));
+                updateCommandTimeArray(MIN_OFF_ON_PRIORITY, now);
+
+                int time;
+                if (BinaryPV.inactive.equals(newValue)) {
+                    time = minOff.intValue();
+                    LOG.debug("Starting min off timer: {}s", time);
+                } else {
+                    time = minOn.intValue();
+                    LOG.debug("Starting min on timer: {}s", time);
                 }
 
-                // If a timer task already exists, there is no action to take.
-                if (minOnOffTimerTask == null) {
-                    // Initialize the timer.
-                    pa.setBase1(MIN_OFF_ON_PRIORITY, new PriorityValue(newValue));
-                    updateCommandTimeArray(MIN_OFF_ON_PRIORITY, now);
+                minOnOffTimerTask = getLocalDevice().schedule(() -> {
+                    // Min time has elapsed.
+                    LOG.debug("Min off/on timer has expired");
+                    minOnOffCompleted();
+                }, time, TimeUnit.SECONDS);
 
-                    int time;
-                    if (BinaryPV.inactive.equals(newValue)) {
-                        time = minOff.intValue();
-                        LOG.debug("Starting min off timer: {}s", time);
-                    } else {
-                        time = minOn.intValue();
-                        LOG.debug("Starting min on timer: {}s", time);
-                    }
-
-                    minOnOffTimerTask = getLocalDevice().schedule(() -> {
-                        // Min time has elapsed.
-                        LOG.debug("Min off/on timer has expired");
-                        minOnOffCompleted();
-                    }, time, TimeUnit.SECONDS);
-
-                    // Update the new index if it is less than 6.
-                    if (topIndex > MIN_OFF_ON_PRIORITY)
-                        topIndex = MIN_OFF_ON_PRIORITY;
-                }
+                // Update the new index if it is less than 6.
+                if (topIndex > MIN_OFF_ON_PRIORITY)
+                    topIndex = MIN_OFF_ON_PRIORITY;
             }
         }
 

--- a/src/main/java/com/serotonin/bacnet4j/type/constructed/TimeStamp.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/constructed/TimeStamp.java
@@ -41,13 +41,19 @@ public class TimeStamp extends BaseType {
         choiceOptions.addContextual(2, DateTime.class);
     }
 
-    @Deprecated(since = "7.0.0") // 135-2016br-4
+    /**
+     * @deprecated 135-2016br-4
+     */
+    @Deprecated(since = "7.0.0")
     public static final TimeStamp UNSPECIFIED_TIME = new TimeStamp(Time.UNSPECIFIED);
     public static final TimeStamp UNSPECIFIED_SEQUENCE = new TimeStamp(UnsignedInteger.ZERO);
     public static final TimeStamp UNSPECIFIED_DATETIME = new TimeStamp(DateTime.UNSPECIFIED);
 
     private final Choice choice;
 
+    /**
+     * @deprecated 135-2016br-4
+     */
     @Deprecated(since = "7.0.0") // 135-2016br-4
     public TimeStamp(Time time) {
         choice = new Choice(0, time, choiceOptions);

--- a/src/main/java/com/serotonin/bacnet4j/type/constructed/TimeStamp.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/constructed/TimeStamp.java
@@ -27,49 +27,46 @@
 
 package com.serotonin.bacnet4j.type.constructed;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.serotonin.bacnet4j.exception.BACnetException;
 import com.serotonin.bacnet4j.type.primitive.Time;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
 
 public class TimeStamp extends BaseType {
-    static final Logger LOG = LoggerFactory.getLogger(TimeStamp.class);
-
     private static final ChoiceOptions choiceOptions = new ChoiceOptions();
 
     static {
-        choiceOptions.addContextual(0, Time.class);
+        choiceOptions.addContextual(0, Time.class); // Deprecated
         choiceOptions.addContextual(1, UnsignedInteger.class);
         choiceOptions.addContextual(2, DateTime.class);
     }
 
+    @Deprecated(since = "7.0.0") // 135-2016br-4
     public static final TimeStamp UNSPECIFIED_TIME = new TimeStamp(Time.UNSPECIFIED);
     public static final TimeStamp UNSPECIFIED_SEQUENCE = new TimeStamp(UnsignedInteger.ZERO);
     public static final TimeStamp UNSPECIFIED_DATETIME = new TimeStamp(DateTime.UNSPECIFIED);
 
     private final Choice choice;
 
-    public TimeStamp(final Time time) {
+    @Deprecated(since = "7.0.0") // 135-2016br-4
+    public TimeStamp(Time time) {
         choice = new Choice(0, time, choiceOptions);
     }
 
-    public TimeStamp(final UnsignedInteger sequenceNumber) {
+    public TimeStamp(UnsignedInteger sequenceNumber) {
         choice = new Choice(1, sequenceNumber, choiceOptions);
     }
 
-    public TimeStamp(final DateTime dateTime) {
+    public TimeStamp(DateTime dateTime) {
         choice = new Choice(2, dateTime, choiceOptions);
     }
 
     @Override
-    public void write(final ByteQueue queue) {
+    public void write(ByteQueue queue) {
         write(queue, choice);
     }
 
-    public TimeStamp(final ByteQueue queue) throws BACnetException {
+    public TimeStamp(ByteQueue queue) throws BACnetException {
         choice = new Choice(queue, choiceOptions);
     }
 
@@ -104,21 +101,21 @@ public class TimeStamp extends BaseType {
 
     @Override
     public int hashCode() {
-        final int PRIME = 31;
+        int PRIME = 31;
         int result = 1;
         result = PRIME * result + (choice == null ? 0 : choice.hashCode());
         return result;
     }
 
     @Override
-    public boolean equals(final Object obj) {
+    public boolean equals(Object obj) {
         if (this == obj)
             return true;
         if (obj == null)
             return false;
         if (getClass() != obj.getClass())
             return false;
-        final TimeStamp other = (TimeStamp) obj;
+        TimeStamp other = (TimeStamp) obj;
         if (choice == null) {
             if (other.choice != null)
                 return false;

--- a/src/test/java/com/serotonin/bacnet4j/obj/mixin/CommandableMixinTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/mixin/CommandableMixinTest.java
@@ -73,9 +73,9 @@ import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 public class CommandableMixinTest extends AbstractTest {
     @Test
     public void avNotCommandableNotValueSource() throws BACnetServiceException {
-        final AnalogValueObject av = d1.addObject(new AnalogValueObject(
+        AnalogValueObject av = d1.addObject(new AnalogValueObject(
                 d1, 0, "av0", 0, EngineeringUnits.noUnits, false));
-        final ValueSource valueSource = createValueSource(12);
+        ValueSource valueSource = createValueSource(12);
 
         assertEquals(new Real(0), av.get(PropertyIdentifier.presentValue));
         assertFalse(av.isOverridden());
@@ -119,7 +119,7 @@ public class CommandableMixinTest extends AbstractTest {
 
     @Test
     public void bvCommandableNotValueSource() throws Exception {
-        final BinaryValueObject bv = d1.addObject(new BinaryValueObject(
+        BinaryValueObject bv = d1.addObject(new BinaryValueObject(
                 d1, 0, "bv0", BinaryPV.inactive, false).supportCommandable(BinaryPV.inactive));
 
         // Assert default values.
@@ -189,7 +189,7 @@ public class CommandableMixinTest extends AbstractTest {
 
     @Test
     public void bvNotCommandableValueSource() throws Exception {
-        final BinaryValueObject bv = d1.addObject(new BinaryValueObject(
+        BinaryValueObject bv = d1.addObject(new BinaryValueObject(
                 d1, 0, "bv0", BinaryPV.inactive, false).supportValueSource());
         bv.writeProperty(null, new PropertyValue(PropertyIdentifier.outOfService, Boolean.TRUE));
 
@@ -213,7 +213,7 @@ public class CommandableMixinTest extends AbstractTest {
         assertEquals(BinaryPV.active, bv.get(PropertyIdentifier.presentValue));
         assertEquals(createValueSource(2), bv.get(PropertyIdentifier.valueSource));
 
-        final ValueSource vs = new ValueSource(new DeviceObjectReference(new ObjectIdentifier(ObjectType.device, 123),
+        ValueSource vs = new ValueSource(new DeviceObjectReference(new ObjectIdentifier(ObjectType.device, 123),
                 new ObjectIdentifier(ObjectType.group, 124)));
         // Try to set the value directly but with an invalid source.
         assertBACnetServiceException(() -> bv.writeProperty(createValueSource(3),
@@ -231,7 +231,7 @@ public class CommandableMixinTest extends AbstractTest {
 
     @Test
     public void bvCommandableValueSource() throws Exception {
-        final BinaryValueObject bv = d1.addObject(new BinaryValueObject(
+        BinaryValueObject bv = d1.addObject(new BinaryValueObject(
                 d1, 0, "bv0", BinaryPV.inactive, false).supportCommandable(BinaryPV.inactive).supportValueSource());
 
         // Assert default values.
@@ -283,7 +283,7 @@ public class CommandableMixinTest extends AbstractTest {
                 bv.get(PropertyIdentifier.commandTimeArray));
 
         // Update the value source at priority 10
-        final ValueSource vs10 = new ValueSource(new DeviceObjectReference(new ObjectIdentifier(ObjectType.device, 123),
+        ValueSource vs10 = new ValueSource(new DeviceObjectReference(new ObjectIdentifier(ObjectType.device, 123),
                 new ObjectIdentifier(ObjectType.group, 124)));
         bv.writeProperty(createValueSource(10), PropertyIdentifier.valueSource, vs10);
 
@@ -330,7 +330,7 @@ public class CommandableMixinTest extends AbstractTest {
 
     @Test
     public void boMinOnOffTime() throws Exception {
-        final BinaryOutputObject bo = d1.addObject(new BinaryOutputObject(
+        BinaryOutputObject bo = d1.addObject(new BinaryOutputObject(
                 d1, 0, "bo0", BinaryPV.inactive, false, Polarity.normal, BinaryPV.inactive));
 
         // Assert default values.
@@ -375,7 +375,7 @@ public class CommandableMixinTest extends AbstractTest {
         assertEquals(createLocalValueSource(bo), bo.get(PropertyIdentifier.valueSource));
         assertEquals(emptyValueSources().putBase1(6, createLocalValueSource(bo)).putBase1(8, createValueSource(8)),
                 bo.get(PropertyIdentifier.valueSourceArray));
-        final TimeStamp time6 = bo.get(PropertyIdentifier.lastCommandTime);
+        TimeStamp time6 = bo.get(PropertyIdentifier.lastCommandTime);
         TestUtils.assertEquals(new TimeStamp(new DateTime(d1)), time6, 1);
         assertEquals(emptyCommandTimes().putBase1(6, time6).putBase1(8, time6),
                 bo.get(PropertyIdentifier.commandTimeArray));
@@ -387,8 +387,8 @@ public class CommandableMixinTest extends AbstractTest {
         assertEquals(createLocalValueSource(bo), bo.get(PropertyIdentifier.valueSource));
         assertEquals(emptyValueSources().putBase1(6, createLocalValueSource(bo)).putBase1(8, createValueSource(8)),
                 bo.get(PropertyIdentifier.valueSourceArray));
-        final BACnetArray<TimeStamp> cta = bo.get(PropertyIdentifier.commandTimeArray);
-        final TimeStamp time8 = cta.getBase1(8);
+        BACnetArray<TimeStamp> cta = bo.get(PropertyIdentifier.commandTimeArray);
+        TimeStamp time8 = cta.getBase1(8);
         TestUtils.assertEquals(new TimeStamp(new DateTime(d1)), time8, 1);
         assertEquals(time6, bo.get(PropertyIdentifier.lastCommandTime));
         assertEquals(emptyCommandTimes().putBase1(6, time6).putBase1(8, time8),
@@ -400,20 +400,20 @@ public class CommandableMixinTest extends AbstractTest {
         assertEquals(createLocalValueSource(bo), bo.get(PropertyIdentifier.valueSource));
         assertEquals(emptyValueSources().putBase1(6, createLocalValueSource(bo)).putBase1(8, createValueSource(8)),
                 bo.get(PropertyIdentifier.valueSourceArray));
-        final TimeStamp timeComplete = bo.get(PropertyIdentifier.lastCommandTime);
-        final GregorianCalendar gc = time6.getDateTime().getGC();
+        TimeStamp timeComplete = bo.get(PropertyIdentifier.lastCommandTime);
+        GregorianCalendar gc = time6.getDateTime().getGC();
         gc.add(Calendar.SECOND, 2);
-        final TimeStamp time6Plus2s = new TimeStamp(new DateTime(gc));
+        TimeStamp time6Plus2s = new TimeStamp(new DateTime(gc));
         TestUtils.assertEquals(time6Plus2s, timeComplete, 2);
         assertEquals(emptyCommandTimes().putBase1(6, timeComplete).putBase1(8, time8),
                 bo.get(PropertyIdentifier.commandTimeArray));
     }
 
-    private static ValueSource createValueSource(final int address) {
+    private static ValueSource createValueSource(int address) {
         return new ValueSource(new Address(new byte[] {(byte) address}));
     }
 
-    private ValueSource createLocalValueSource(final BACnetObject bo) {
+    private ValueSource createLocalValueSource(BACnetObject bo) {
         return new ValueSource(new DeviceObjectReference(d1.getId(), bo.getId()));
     }
 
@@ -422,12 +422,12 @@ public class CommandableMixinTest extends AbstractTest {
     }
 
     private static BACnetArray<TimeStamp> emptyCommandTimes() {
-        return new BACnetArray<>(16, TimeStamp.UNSPECIFIED_TIME);
+        return new BACnetArray<>(16, TimeStamp.UNSPECIFIED_DATETIME);
     }
 
     @Test
     public void writable() throws BACnetServiceException {
-        final BinaryValueObject bv = d1.addObject(new BinaryValueObject(
+        BinaryValueObject bv = d1.addObject(new BinaryValueObject(
                 d1, 0, "bv", BinaryPV.inactive, false).supportWritable());
 
         // Write with priority not allowed.
@@ -443,7 +443,7 @@ public class CommandableMixinTest extends AbstractTest {
 
     @Test
     public void notWritable() throws BACnetServiceException {
-        final BinaryValueObject bv = d1.addObject(new BinaryValueObject(d1, 0, "bv", BinaryPV.inactive, false));
+        BinaryValueObject bv = d1.addObject(new BinaryValueObject(d1, 0, "bv", BinaryPV.inactive, false));
 
         // Write with priority not allowed.
         assertBACnetServiceException(() -> bv.writeProperty(null,


### PR DESCRIPTION
https://radixiot.atlassian.net/browse/MANGO-2955

- Per addendum 135-2016br-4, the time [0] alternative of BACnetTimeStamp is deprecated. Production code in CommandableMixin no longer initializes Command_Time_Array with the Time-form; it uses TimeStamp.UNSPECIFIED_DATETIME instead.
- TimeStamp.UNSPECIFIED_TIME and the TimeStamp(Time) constructor are marked @Deprecated(since = "7.0.0") so downstream callers get a clear migration signal, while the API remains available for wire-encoding tests and legacy interop.
- Time.class is still registered in the choice options, so decoding legacy Time-form timestamps from pre-revision-12 peers continues to work.

Cleanup of "final" and SQ warnings included.