### PR TITLE
MANGO-2958 Implement Multistate object behavior when Number_Of_States shrinks

### DIFF
--- a/src/main/java/com/serotonin/bacnet4j/obj/mixin/MultistateMixin.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/mixin/MultistateMixin.java
@@ -37,24 +37,25 @@ import com.serotonin.bacnet4j.type.constructed.ValueSource;
 import com.serotonin.bacnet4j.type.enumerated.ErrorClass;
 import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
+import com.serotonin.bacnet4j.type.enumerated.Reliability;
+import com.serotonin.bacnet4j.type.primitive.Boolean;
 import com.serotonin.bacnet4j.type.primitive.CharacterString;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
 public class MultistateMixin extends AbstractMixin {
-    public MultistateMixin(final BACnetObject bo) {
+    public MultistateMixin(BACnetObject bo) {
         super(bo);
     }
 
     @Override
-    protected boolean validateProperty(final ValueSource valueSource, final PropertyValue value)
-            throws BACnetServiceException {
+    protected boolean validateProperty(ValueSource valueSource, PropertyValue value) throws BACnetServiceException {
         if (PropertyIdentifier.presentValue.equals(value.getPropertyIdentifier())) {
-            final UnsignedInteger pv = value.getValue();
-            final UnsignedInteger numStates = get(PropertyIdentifier.numberOfStates);
+            UnsignedInteger pv = value.getValue();
+            UnsignedInteger numStates = get(PropertyIdentifier.numberOfStates);
             if (pv.intValue() < 1 || pv.intValue() > numStates.intValue())
                 throw new BACnetServiceException(ErrorClass.property, ErrorCode.inconsistentConfiguration);
         } else if (PropertyIdentifier.numberOfStates.equals(value.getPropertyIdentifier())) {
-            final UnsignedInteger numStates = value.getValue();
+            UnsignedInteger numStates = value.getValue();
             if (numStates.intValue() < 1)
                 throw new BACnetServiceException(ErrorClass.property, ErrorCode.inconsistentConfiguration);
         } else if (PropertyIdentifier.stateText.equals(value.getPropertyIdentifier())) {
@@ -88,31 +89,62 @@ public class MultistateMixin extends AbstractMixin {
     }
 
     @Override
-    protected void afterWriteProperty(final PropertyIdentifier pid, final Encodable oldValue,
-            final Encodable newValue) {
+    protected void afterWriteProperty(PropertyIdentifier pid, Encodable oldValue, Encodable newValue) {
         if (PropertyIdentifier.numberOfStates.equals(pid)) {
             if (oldValue != null && !oldValue.equals(newValue)) {
-                final BACnetArray<CharacterString> stateText = get(PropertyIdentifier.stateText);
+                BACnetArray<CharacterString> stateText = get(PropertyIdentifier.stateText);
                 if (stateText != null) {
-                    final int numStates = ((UnsignedInteger) newValue).intValue();
-                    final BACnetArray<CharacterString> newText = copyArrayWithNewSize(stateText, numStates);
+                    int numStates = ((UnsignedInteger) newValue).intValue();
+                    BACnetArray<CharacterString> newText = copyArrayWithNewSize(stateText, numStates);
                     writePropertyInternal(PropertyIdentifier.stateText, newText);
                 }
             }
+            updateMultiStateOutOfRangeReliability();
         } else if (PropertyIdentifier.stateText.equals(pid)) {
             var stateText = (BACnetArray<?>) newValue;
             UnsignedInteger numberOfStates = get(PropertyIdentifier.numberOfStates);
             if (stateText.size() != numberOfStates.intValue()) {
                 writePropertyInternal(PropertyIdentifier.numberOfStates, new UnsignedInteger(stateText.size()));
             }
+        } else if (PropertyIdentifier.presentValue.equals(pid) || PropertyIdentifier.outOfService.equals(pid)) {
+            updateMultiStateOutOfRangeReliability();
+        }
+    }
+
+    /**
+     * Per addendum 135-2016br-5: when Number_Of_States becomes less than Present_Value, Reliability shall be
+     * MULTI_STATE_OUT_OF_RANGE for as long as the situation remains, unless the object is out of service. When the
+     * situation resolves (Number_Of_States is raised again, or Present_Value is brought back in range) the reliability
+     * is restored to noFaultDetected. A pre-existing CONFIGURATION_ERROR shall not be downgraded to
+     * MULTI_STATE_OUT_OF_RANGE.
+     */
+    private void updateMultiStateOutOfRangeReliability() {
+        Boolean oos = get(PropertyIdentifier.outOfService);
+        if (Boolean.TRUE.equals(oos)) {
+            return;
+        }
+        Reliability current = get(PropertyIdentifier.reliability);
+        if (Reliability.configurationError.equals(current)) {
+            return;
+        }
+        UnsignedInteger pv = get(PropertyIdentifier.presentValue);
+        UnsignedInteger nos = get(PropertyIdentifier.numberOfStates);
+        if (pv == null || nos == null) {
+            return; // Should this be a configuration error?
+        }
+        boolean outOfRange = pv.intValue() > nos.intValue();
+        if (outOfRange && !Reliability.multiStateOutOfRange.equals(current)) {
+            writePropertyInternal(PropertyIdentifier.reliability, Reliability.multiStateOutOfRange);
+        } else if (!outOfRange && Reliability.multiStateOutOfRange.equals(current)) {
+            writePropertyInternal(PropertyIdentifier.reliability, Reliability.noFaultDetected);
         }
     }
 
     private BACnetArray<CharacterString> copyArrayWithNewSize(BACnetArray<CharacterString> oldText, int newSize) {
-        final BACnetArray<CharacterString> newText = new BACnetArray<>(newSize, CharacterString.EMPTY);
+        BACnetArray<CharacterString> newText = new BACnetArray<>(newSize, CharacterString.EMPTY);
 
         // Copy the old state values in.
-        final int min = Math.min(newText.getCount(), oldText.getCount());
+        int min = Math.min(newText.getCount(), oldText.getCount());
         for (int i = 0; i < min; i++)
             newText.set(i, oldText.get(i));
 

--- a/src/main/java/com/serotonin/bacnet4j/type/enumerated/Reliability.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/enumerated/Reliability.java
@@ -61,6 +61,7 @@ public class Reliability extends Enumerated {
     public static final Reliability proprietaryCommandFailure = new Reliability(22);
     public static final Reliability faultsListed = new Reliability(23);
     public static final Reliability referencedObjectFault = new Reliability(24);
+    public static final Reliability multiStateOutOfRange = new Reliability(25);
 
     private static final Map<Integer, Enumerated> idMap = new HashMap<>();
     private static final Map<String, Enumerated> nameMap = new HashMap<>();
@@ -70,18 +71,18 @@ public class Reliability extends Enumerated {
         Enumerated.init(MethodHandles.lookup().lookupClass(), idMap, nameMap, prettyMap);
     }
 
-    public static Reliability forId(final int id) {
+    public static Reliability forId(int id) {
         Reliability e = (Reliability) idMap.get(id);
         if (e == null)
             e = new Reliability(id);
         return e;
     }
 
-    public static String nameForId(final int id) {
+    public static String nameForId(int id) {
         return prettyMap.get(id);
     }
 
-    public static Reliability forName(final String name) {
+    public static Reliability forName(String name) {
         return (Reliability) Enumerated.forName(nameMap, name);
     }
 
@@ -89,11 +90,11 @@ public class Reliability extends Enumerated {
         return idMap.size();
     }
 
-    private Reliability(final int value) {
+    private Reliability(int value) {
         super(value);
     }
 
-    public Reliability(final ByteQueue queue) throws BACnetErrorException {
+    public Reliability(ByteQueue queue) throws BACnetErrorException {
         super(queue);
     }
 

--- a/src/test/java/com/serotonin/bacnet4j/obj/MultistateInputObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/MultistateInputObjectTest.java
@@ -83,7 +83,7 @@ public class MultistateInputObjectTest extends AbstractTest {
         try {
             new MultistateInputObject(d1, 2, "mi2", 0, null, 1, false);
             Assert.fail("Should have thrown an IllegalArgumentException");
-        } catch (@SuppressWarnings("unused") final IllegalArgumentException e) {
+        } catch (@SuppressWarnings("unused") IllegalArgumentException e) {
             // Expected
         }
     }
@@ -91,12 +91,12 @@ public class MultistateInputObjectTest extends AbstractTest {
     @SuppressWarnings("unchecked")
     @Test
     public void intrinsicReporting() throws Exception {
-        final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
+        SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
         recipients.add(new Destination(new Recipient(rd2.getAddress()), new UnsignedInteger(10), Boolean.TRUE,
                 new EventTransitionBits(true, true, true)));
 
         // Create an event listener on d2 to catch the event notifications.
-        final EventNotifListener listener = new EventNotifListener();
+        EventNotifListener listener = new EventNotifListener();
         d2.getEventHandler().addListener(listener);
 
         mi.supportIntrinsicReporting(5, 17, new BACnetArray<>(new UnsignedInteger(4), new UnsignedInteger(5)), null,
@@ -172,21 +172,21 @@ public class MultistateInputObjectTest extends AbstractTest {
         // Check the starting values.
         assertEquals(new UnsignedInteger(1), mi.get(PropertyIdentifier.presentValue));
 
-        final DeviceObjectPropertyReference ref =
+        DeviceObjectPropertyReference ref =
                 new DeviceObjectPropertyReference(1, mi.getId(), PropertyIdentifier.presentValue);
-        final EventEnrollmentObject ee = d1.addObject(new EventEnrollmentObject(
+        EventEnrollmentObject ee = d1.addObject(new EventEnrollmentObject(
                 d1, 0, "ee", ref, NotifyType.alarm,
                 new EventParameter(new ChangeOfState(new UnsignedInteger(30),
                         new SequenceOf<>(new PropertyStates(new UnsignedInteger(4))))),
                 new EventTransitionBits(true, true, true), 17, 1000, null, null));
 
         // Set up the notification destination
-        final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
+        SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
         recipients.add(new Destination(new Recipient(rd2.getAddress()), new UnsignedInteger(10), Boolean.TRUE,
                 new EventTransitionBits(true, true, true)));
 
         // Create an event listener on d2 to catch the event notifications.
-        final EventNotifListener listener = new EventNotifListener();
+        EventNotifListener listener = new EventNotifListener();
         d2.getEventHandler().addListener(listener);
 
         // Ensure that initializing the event enrollment object didn't fire any notifications.
@@ -266,12 +266,12 @@ public class MultistateInputObjectTest extends AbstractTest {
     @SuppressWarnings("unchecked")
     @Test
     public void fault() throws Exception {
-        final SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
+        SequenceOf<Destination> recipients = nc.get(PropertyIdentifier.recipientList);
         recipients.add(new Destination(new Recipient(rd2.getAddress()), new UnsignedInteger(10), Boolean.TRUE,
                 new EventTransitionBits(true, true, true)));
 
         // Create an event listener on d2 to catch the event notifications.
-        final EventNotifListener listener = new EventNotifListener();
+        EventNotifListener listener = new EventNotifListener();
         d2.getEventHandler().addListener(listener);
 
         mi.supportIntrinsicReporting(5, 17, new BACnetArray<>(),
@@ -337,5 +337,59 @@ public class MultistateInputObjectTest extends AbstractTest {
                         new ChangeOfReliabilityNotif(Reliability.noFaultDetected, new StatusFlags(false, false, false, false),
                                 new SequenceOf<>(new PropertyValue(PropertyIdentifier.presentValue, new UnsignedInteger(2))))),
                 notif.eventValues());
+    }
+
+    /**
+     * Addendum 135-2016br-5: when Number_Of_States becomes less than Present_Value, Reliability shall be
+     * MULTI_STATE_OUT_OF_RANGE for as long as the situation remains, unless the object is out of service. When
+     * Number_Of_States is raised again, Reliability shall return to noFaultDetected.
+     */
+    @Test
+    public void br5_numberOfStatesShrinkBelowPresentValueSetsReliabilityMultiStateOutOfRange() throws Exception {
+        // Baseline: MSI starts with Number_Of_States=5, Present_Value=1, OOS=false, reliability=noFaultDetected.
+        // Move the Present_Value to 3 so the shrink puts it out of range.
+        mi.writePropertyInternal(PropertyIdentifier.presentValue, new UnsignedInteger(3));
+        assertEquals(Reliability.noFaultDetected, mi.get(PropertyIdentifier.reliability));
+
+        // Shrink Number_Of_States below the current Present_Value.
+        mi.writeProperty(null,
+                new PropertyValue(PropertyIdentifier.numberOfStates, new UnsignedInteger(2)));
+        assertEquals(Reliability.multiStateOutOfRange, mi.get(PropertyIdentifier.reliability));
+
+        // Raising Number_Of_States back above Present_Value clears the condition.
+        mi.writeProperty(null,
+                new PropertyValue(PropertyIdentifier.numberOfStates, new UnsignedInteger(5)));
+        assertEquals(Reliability.noFaultDetected, mi.get(PropertyIdentifier.reliability));
+    }
+
+    /**
+     * Br-5: while the object is out of service, Reliability is not automatically overridden when Number_Of_States
+     * shrinks below Present_Value.
+     */
+    @Test
+    public void br5_outOfServiceSuppressesMultiStateOutOfRangeUpdate() throws Exception {
+        mi.writePropertyInternal(PropertyIdentifier.presentValue, new UnsignedInteger(3));
+        mi.writeProperty(null, new PropertyValue(PropertyIdentifier.outOfService, Boolean.TRUE));
+
+        mi.writeProperty(null,
+                new PropertyValue(PropertyIdentifier.numberOfStates, new UnsignedInteger(2)));
+
+        // Reliability must not be forced to multiStateOutOfRange while OOS.
+        assertEquals(Reliability.noFaultDetected, mi.get(PropertyIdentifier.reliability));
+    }
+
+    /**
+     * Br-5: a pre-existing CONFIGURATION_ERROR reliability shall remain in place and not be downgraded to
+     * MULTI_STATE_OUT_OF_RANGE.
+     */
+    @Test
+    public void br5_configurationErrorReliabilityIsPreserved() throws Exception {
+        mi.writePropertyInternal(PropertyIdentifier.presentValue, new UnsignedInteger(3));
+        mi.writePropertyInternal(PropertyIdentifier.reliability, Reliability.configurationError);
+
+        mi.writeProperty(null,
+                new PropertyValue(PropertyIdentifier.numberOfStates, new UnsignedInteger(2)));
+
+        assertEquals(Reliability.configurationError, mi.get(PropertyIdentifier.reliability));
     }
 }


### PR DESCRIPTION
https://radixiot.atlassian.net/browse/MANGO-2958

- Per addendum 135-2016br-5, when Number_Of_States becomes less than Present_Value on a Multi_State_Input/Value/Output object, Reliability shall be MULTI_STATE_OUT_OF_RANGE for as long as the situation remains, unless the object is out of service.
- Added Reliability.multiStateOutOfRange = 25 to the enum.
- Extended MultistateMixin.afterWriteProperty to update Reliability on writes to Number_Of_States, Present_Value, and Out_Of_Service. A helper preserves a pre-existing CONFIGURATION_ERROR reliability and suppresses the update while the object is out of service, per spec.