### PR TITLE
MANGO-2957 Support Network Port wildcard instance 4194303 in RP and RPM

### DIFF
--- a/src/main/java/com/serotonin/bacnet4j/LocalDevice.java
+++ b/src/main/java/com/serotonin/bacnet4j/LocalDevice.java
@@ -523,8 +523,13 @@ public class LocalDevice implements AutoCloseable {
      *-----------------------------------------------------------
      -----------------------------------------------------------*/
 
-    public BACnetObject getObjectRequired(ObjectIdentifier id) throws BACnetServiceException {
-        BACnetObject o = getObject(id);
+    public <T extends BACnetObject> T getObjectRequired(ObjectIdentifier id) throws BACnetServiceException {
+        return getObjectRequired(id, false);
+    }
+
+    public <T extends BACnetObject> T getObjectRequired(ObjectIdentifier id, boolean allowWildcard)
+            throws BACnetServiceException {
+        T o = getObject(id, allowWildcard);
         if (o == null)
             throw new BACnetServiceException(ErrorClass.object, ErrorCode.unknownObject);
         return o;
@@ -534,20 +539,31 @@ public class LocalDevice implements AutoCloseable {
         return localObjects;
     }
 
-    @SuppressWarnings("unchecked")
     public <T extends BACnetObject> T getObject(ObjectIdentifier id) {
-        ObjectIdentifier oidToFind = id;
-        // Treat calls for device 0x3FFFFF as calls for the local device object. See 15.5.2.
-        if (id.getObjectType().equals(ObjectType.device) && id.getInstanceNumber() == ObjectIdentifier.UNINITIALIZED) {
-            oidToFind = new ObjectIdentifier(ObjectType.device, getInstanceNumber());
+        return getObject(id, false);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T extends BACnetObject> T getObject(ObjectIdentifier id, boolean allowWildcard) {
+        BACnetObject obj = null;
+        if (id.getInstanceNumber() == ObjectIdentifier.UNINITIALIZED && allowWildcard) {
+            // 15.5.2.
+            if (id.getObjectType().equals(ObjectType.device)) {
+                obj = deviceObject;
+            } else if (id.getObjectType().equals(ObjectType.networkPort)) {
+                // BACnet4J has only one transport and one network, and so returning the first network port object found
+                // is sufficient.
+                obj = localObjects.stream()
+                        .filter(o -> o.getId().getObjectType().equals(ObjectType.networkPort))
+                        .findFirst().orElse(null);
+            }
+        } else {
+            obj = localObjects.stream()
+                    .filter(o -> o.getId().equals(id))
+                    .findFirst().orElse(null);
         }
 
-        for (BACnetObject obj : localObjects) {
-            if (obj.getId().equals(oidToFind))
-                return (T) obj;
-        }
-
-        return null;
+        return (T) obj;
     }
 
     public BACnetObject getObject(String name) {
@@ -658,12 +674,13 @@ public class LocalDevice implements AutoCloseable {
      * Finds a remote device for the given instanceNumber by notifying a given callback. If a cached instance is found
      * the callback is called by the calling thread. Otherwise, a finder will be used to try to find it. If this is
      * successful the device will be cached.
-     *
+     * <p>
      * The benefits of this method are: 1) It will cache the remote device if it is found 2) No blocking is performed
      *
      * @param instanceNumber  the instance number of the desired device
      * @param callback        the callback with which to receive the device
      * @param timeoutCallback the callback to notify of a timeout
+     * @param finallyCallback the callback to call in any case
      * @param timeout         the timeout scalar
      * @param unit            the timeout unit
      */
@@ -703,10 +720,10 @@ public class LocalDevice implements AutoCloseable {
      * Returns a future to get the remote device for the given instanceNumber. If a cached instance is found the future
      * will be set immediately. Otherwise, a finder will be used to try to find it. If this is successful the device
      * will be cached.
-     *
+     * <p>
      * The benefits of this method are: 1) It will cache the remote device if it is found. 2) It returns a cancelable
      * future.
-     *
+     * <p>
      * If multiple threads are likely to request a remote device reference around the same time, it may be better to use
      * the blocking method below.
      *
@@ -925,7 +942,6 @@ public class LocalDevice implements AutoCloseable {
             case ALWAYS -> d -> true;
             case NEVER -> d -> false;
             case IF_EXPIRED -> d -> remoteDeviceCache.getCachedEntity(d.getInstanceNumber()) == null;
-            default -> throw new IllegalArgumentException("Unknown value: " + cacheUpdate);
         };
     }
 
@@ -1141,15 +1157,13 @@ public class LocalDevice implements AutoCloseable {
         synchronized (communicationControlMonitor) {
             communicationControlState = enableDisable;
             cancelCommunicationControlFuture();
-            if (EnableDisable.disableInitiation.equals(enableDisable)) {
-                if (minutes > 0) {
-                    communicationControlFuture = schedule(() -> {
-                        synchronized (communicationControlMonitor) {
-                            communicationControlState = EnableDisable.enable;
-                            communicationControlFuture = null;
-                        }
-                    }, minutes, TimeUnit.MINUTES);
-                }
+            if (EnableDisable.disableInitiation.equals(enableDisable) && minutes > 0) {
+                communicationControlFuture = schedule(() -> {
+                    synchronized (communicationControlMonitor) {
+                        communicationControlState = EnableDisable.enable;
+                        communicationControlFuture = null;
+                    }
+                }, minutes, TimeUnit.MINUTES);
             }
         }
     }

--- a/src/main/java/com/serotonin/bacnet4j/service/confirmed/ReadPropertyMultipleRequest.java
+++ b/src/main/java/com/serotonin/bacnet4j/service/confirmed/ReadPropertyMultipleRequest.java
@@ -29,6 +29,7 @@ package com.serotonin.bacnet4j.service.confirmed;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.serotonin.bacnet4j.LocalDevice;
@@ -108,28 +109,15 @@ public class ReadPropertyMultipleRequest extends ConfirmedRequestService {
     }
 
     @Override
-    public int hashCode() {
-        int PRIME = 31;
-        int result = 1;
-        result = PRIME * result + (listOfReadAccessSpecs == null ? 0 : listOfReadAccessSpecs.hashCode());
-        return result;
+    public boolean equals(Object o) {
+        if (!(o instanceof ReadPropertyMultipleRequest that))
+            return false;
+        return Objects.equals(listOfReadAccessSpecs, that.listOfReadAccessSpecs);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        ReadPropertyMultipleRequest other = (ReadPropertyMultipleRequest) obj;
-        if (listOfReadAccessSpecs == null) {
-            if (other.listOfReadAccessSpecs != null)
-                return false;
-        } else if (!listOfReadAccessSpecs.equals(other.listOfReadAccessSpecs))
-            return false;
-        return true;
+    public int hashCode() {
+        return Objects.hashCode(listOfReadAccessSpecs);
     }
 
     @Override

--- a/src/main/java/com/serotonin/bacnet4j/service/confirmed/ReadPropertyMultipleRequest.java
+++ b/src/main/java/com/serotonin/bacnet4j/service/confirmed/ReadPropertyMultipleRequest.java
@@ -47,10 +47,8 @@ import com.serotonin.bacnet4j.type.constructed.ReadAccessSpecification;
 import com.serotonin.bacnet4j.type.constructed.SequenceOf;
 import com.serotonin.bacnet4j.type.enumerated.ErrorClass;
 import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
-import com.serotonin.bacnet4j.type.enumerated.ObjectType;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
 import com.serotonin.bacnet4j.type.error.ErrorClassAndCode;
-import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
 
@@ -59,7 +57,7 @@ public class ReadPropertyMultipleRequest extends ConfirmedRequestService {
 
     private final SequenceOf<ReadAccessSpecification> listOfReadAccessSpecs;
 
-    public ReadPropertyMultipleRequest(final SequenceOf<ReadAccessSpecification> listOfReadAccessSpecs) {
+    public ReadPropertyMultipleRequest(SequenceOf<ReadAccessSpecification> listOfReadAccessSpecs) {
         this.listOfReadAccessSpecs = listOfReadAccessSpecs;
     }
 
@@ -69,35 +67,25 @@ public class ReadPropertyMultipleRequest extends ConfirmedRequestService {
     }
 
     @Override
-    public void write(final ByteQueue queue) {
+    public void write(ByteQueue queue) {
         write(queue, listOfReadAccessSpecs);
     }
 
-    ReadPropertyMultipleRequest(final ByteQueue queue) throws BACnetException {
+    ReadPropertyMultipleRequest(ByteQueue queue) throws BACnetException {
         listOfReadAccessSpecs = readSequenceOf(queue, ReadAccessSpecification.class);
     }
 
     @Override
-    public AcknowledgementService handle(final LocalDevice localDevice, final Address from) throws BACnetException {
-        BACnetObject obj;
-        ObjectIdentifier oid;
-        final List<ReadAccessResult> readAccessResults = new ArrayList<>();
-        List<Result> results;
+    public AcknowledgementService handle(LocalDevice localDevice, Address from) throws BACnetException {
+        List<ReadAccessResult> readAccessResults = new ArrayList<>();
 
-        for (final ReadAccessSpecification req : listOfReadAccessSpecs) {
-            results = new ArrayList<>();
-            oid = req.getObjectIdentifier();
-            //Handling for uninitialized device request. See 15.7.2 and standard test 135.1-2013 9.18.1.3
-            if (oid.getObjectType()
-                    .equals(ObjectType.device) && oid.getInstanceNumber() == ObjectIdentifier.UNINITIALIZED) {
-                oid = new ObjectIdentifier(ObjectType.device, localDevice.getInstanceNumber());
-            }
-
-            obj = localDevice.getObject(oid);
-            for (final PropertyReference propRef : req.getListOfPropertyReferences()) {
+        for (ReadAccessSpecification req : listOfReadAccessSpecs) {
+            var oid = req.getObjectIdentifier();
+            var obj = localDevice.getObject(oid, true);
+            var results = new ArrayList<Result>();
+            for (PropertyReference propRef : req.getListOfPropertyReferences()) {
                 addProperty(obj, results, propRef.getPropertyIdentifier(), propRef.getPropertyArrayIndex());
             }
-
             readAccessResults.add(new ReadAccessResult(oid, new SequenceOf<>(results)));
         }
 
@@ -110,7 +98,7 @@ public class ReadPropertyMultipleRequest extends ConfirmedRequestService {
 
     public int getNumberOfProperties() {
         int sum = 0;
-        for (final ReadAccessSpecification spec : listOfReadAccessSpecs) {
+        for (ReadAccessSpecification spec : listOfReadAccessSpecs) {
             sum += spec.getNumberOfProperties();
         }
         return sum;
@@ -118,21 +106,21 @@ public class ReadPropertyMultipleRequest extends ConfirmedRequestService {
 
     @Override
     public int hashCode() {
-        final int PRIME = 31;
+        int PRIME = 31;
         int result = 1;
         result = PRIME * result + (listOfReadAccessSpecs == null ? 0 : listOfReadAccessSpecs.hashCode());
         return result;
     }
 
     @Override
-    public boolean equals(final Object obj) {
+    public boolean equals(Object obj) {
         if (this == obj)
             return true;
         if (obj == null)
             return false;
         if (getClass() != obj.getClass())
             return false;
-        final ReadPropertyMultipleRequest other = (ReadPropertyMultipleRequest) obj;
+        ReadPropertyMultipleRequest other = (ReadPropertyMultipleRequest) obj;
         if (listOfReadAccessSpecs == null) {
             if (other.listOfReadAccessSpecs != null)
                 return false;
@@ -146,8 +134,8 @@ public class ReadPropertyMultipleRequest extends ConfirmedRequestService {
         return "ReadPropertyMultipleRequest [listOfReadAccessSpecs=" + listOfReadAccessSpecs + "]";
     }
 
-    private static void addProperty(final BACnetObject obj, final List<Result> results, final PropertyIdentifier pid,
-            final UnsignedInteger pin) {
+    private static void addProperty(BACnetObject obj, List<Result> results, PropertyIdentifier pid,
+            UnsignedInteger pin) {
         if (obj == null) {
             results.add(new Result(pid, pin, new ErrorClassAndCode(ErrorClass.object, ErrorCode.unknownObject)));
         } else if (pid.intValue() == PropertyIdentifier.all.intValue()) {
@@ -166,7 +154,7 @@ public class ReadPropertyMultipleRequest extends ConfirmedRequestService {
                 }
             }
         } else if (pid.intValue() == PropertyIdentifier.required.intValue()) {
-            for (final ObjectPropertyTypeDefinition def : ObjectProperties
+            for (ObjectPropertyTypeDefinition def : ObjectProperties
                     .getRequiredObjectPropertyTypeDefinitions(obj.getId().getObjectType())) {
                 // Do not add the property list
                 if (def.getPropertyTypeDefinition().getPropertyIdentifier() != PropertyIdentifier.propertyList) {
@@ -175,7 +163,7 @@ public class ReadPropertyMultipleRequest extends ConfirmedRequestService {
                 }
             }
         } else if (pid.intValue() == PropertyIdentifier.optional.intValue()) {
-            for (final ObjectPropertyTypeDefinition def : ObjectProperties
+            for (ObjectPropertyTypeDefinition def : ObjectProperties
                     .getOptionalObjectPropertyTypeDefinitions(obj.getId().getObjectType())) {
                 addNonSpecialProperty(obj, results, def.getPropertyTypeDefinition().getPropertyIdentifier(), pin, true);
             }
@@ -185,11 +173,11 @@ public class ReadPropertyMultipleRequest extends ConfirmedRequestService {
         }
     }
 
-    private static void addNonSpecialProperty(final BACnetObject obj, final List<Result> results,
-            final PropertyIdentifier pid, final UnsignedInteger pin, final boolean ignoreNotFound) {
+    private static void addNonSpecialProperty(BACnetObject obj, List<Result> results, PropertyIdentifier pid,
+            UnsignedInteger pin, boolean ignoreNotFound) {
         try {
             results.add(new Result(pid, pin, obj.readPropertyRequired(pid, pin)));
-        } catch (final BACnetServiceException e) {
+        } catch (BACnetServiceException e) {
             if (ignoreNotFound && e.getErrorClass() == ErrorClass.property && e.getErrorCode() == ErrorCode.unknownProperty) {
                 return;
             }

--- a/src/main/java/com/serotonin/bacnet4j/service/confirmed/ReadPropertyMultipleRequest.java
+++ b/src/main/java/com/serotonin/bacnet4j/service/confirmed/ReadPropertyMultipleRequest.java
@@ -82,6 +82,9 @@ public class ReadPropertyMultipleRequest extends ConfirmedRequestService {
         for (ReadAccessSpecification req : listOfReadAccessSpecs) {
             var oid = req.getObjectIdentifier();
             var obj = localDevice.getObject(oid, true);
+            if (obj != null) {
+                oid = obj.getId();
+            }
             var results = new ArrayList<Result>();
             for (PropertyReference propRef : req.getListOfPropertyReferences()) {
                 addProperty(obj, results, propRef.getPropertyIdentifier(), propRef.getPropertyArrayIndex());

--- a/src/main/java/com/serotonin/bacnet4j/service/confirmed/ReadPropertyRequest.java
+++ b/src/main/java/com/serotonin/bacnet4j/service/confirmed/ReadPropertyRequest.java
@@ -39,7 +39,6 @@ import com.serotonin.bacnet4j.type.Encodable;
 import com.serotonin.bacnet4j.type.constructed.Address;
 import com.serotonin.bacnet4j.type.enumerated.ErrorClass;
 import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
-import com.serotonin.bacnet4j.type.enumerated.ObjectType;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
 import com.serotonin.bacnet4j.type.enumerated.RejectReason;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
@@ -53,13 +52,13 @@ public class ReadPropertyRequest extends ConfirmedRequestService {
     private final PropertyIdentifier propertyIdentifier;
     private UnsignedInteger propertyArrayIndex;
 
-    public ReadPropertyRequest(final ObjectIdentifier objectIdentifier, final PropertyIdentifier propertyIdentifier) {
+    public ReadPropertyRequest(ObjectIdentifier objectIdentifier, PropertyIdentifier propertyIdentifier) {
         this.objectIdentifier = objectIdentifier;
         this.propertyIdentifier = propertyIdentifier;
     }
 
-    public ReadPropertyRequest(final ObjectIdentifier objectIdentifier, final PropertyIdentifier propertyIdentifier,
-            final UnsignedInteger propertyArrayIndex) {
+    public ReadPropertyRequest(ObjectIdentifier objectIdentifier, PropertyIdentifier propertyIdentifier,
+            UnsignedInteger propertyArrayIndex) {
         this.objectIdentifier = objectIdentifier;
         this.propertyIdentifier = propertyIdentifier;
         this.propertyArrayIndex = propertyArrayIndex;
@@ -71,13 +70,13 @@ public class ReadPropertyRequest extends ConfirmedRequestService {
     }
 
     @Override
-    public void write(final ByteQueue queue) {
+    public void write(ByteQueue queue) {
         write(queue, objectIdentifier, 0);
         write(queue, propertyIdentifier, 1);
         writeOptional(queue, propertyArrayIndex, 2);
     }
 
-    ReadPropertyRequest(final ByteQueue queue) throws BACnetException {
+    ReadPropertyRequest(ByteQueue queue) throws BACnetException {
         try {
             objectIdentifier = read(queue, ObjectIdentifier.class, 0);
             propertyIdentifier = read(queue, PropertyIdentifier.class, 1);
@@ -92,28 +91,22 @@ public class ReadPropertyRequest extends ConfirmedRequestService {
     }
 
     @Override
-    public AcknowledgementService handle(final LocalDevice localDevice, final Address from) throws BACnetException {
+    public AcknowledgementService handle(LocalDevice localDevice, Address from) throws BACnetException {
         Encodable prop;
-        ObjectIdentifier oid = objectIdentifier;
+        BACnetObject obj;
         try {
-            //Handling for unitialized device request. See 15.5.2 and standard test 135.1-2013 9.18.1.3
-            if (oid.getObjectType()
-                    .equals(ObjectType.device) && oid.getInstanceNumber() == ObjectIdentifier.UNINITIALIZED) {
-                oid = new ObjectIdentifier(ObjectType.device, localDevice.getInstanceNumber());
-            }
-
             // Handling for special properties
             if (propertyIdentifier.isOneOf(PropertyIdentifier.all, PropertyIdentifier.required,
                     PropertyIdentifier.optional)) {
                 throw new BACnetServiceException(ErrorClass.services, ErrorCode.inconsistentParameters);
             }
 
-            final BACnetObject obj = localDevice.getObjectRequired(oid);
+            obj = localDevice.getObjectRequired(objectIdentifier, true);
             prop = obj.readPropertyRequired(propertyIdentifier, propertyArrayIndex);
-        } catch (final BACnetServiceException e) {
+        } catch (BACnetServiceException e) {
             throw new BACnetErrorException(getChoiceId(), e);
         }
-        return new ReadPropertyAck(oid, propertyIdentifier, propertyArrayIndex, prop);
+        return new ReadPropertyAck(obj.getId(), propertyIdentifier, propertyArrayIndex, prop);
     }
 
     public ObjectIdentifier getObjectIdentifier() {
@@ -136,7 +129,7 @@ public class ReadPropertyRequest extends ConfirmedRequestService {
 
     @Override
     public int hashCode() {
-        final int PRIME = 31;
+        int PRIME = 31;
         int result = 1;
         result = PRIME * result + (objectIdentifier == null ? 0 : objectIdentifier.hashCode());
         result = PRIME * result + (propertyArrayIndex == null ? 0 : propertyArrayIndex.hashCode());
@@ -145,14 +138,14 @@ public class ReadPropertyRequest extends ConfirmedRequestService {
     }
 
     @Override
-    public boolean equals(final Object obj) {
+    public boolean equals(Object obj) {
         if (this == obj)
             return true;
         if (obj == null)
             return false;
         if (getClass() != obj.getClass())
             return false;
-        final ReadPropertyRequest other = (ReadPropertyRequest) obj;
+        ReadPropertyRequest other = (ReadPropertyRequest) obj;
         if (objectIdentifier == null) {
             if (other.objectIdentifier != null)
                 return false;

--- a/src/main/java/com/serotonin/bacnet4j/service/confirmed/ReadPropertyRequest.java
+++ b/src/main/java/com/serotonin/bacnet4j/service/confirmed/ReadPropertyRequest.java
@@ -27,6 +27,8 @@
 
 package com.serotonin.bacnet4j.service.confirmed;
 
+import java.util.Objects;
+
 import com.serotonin.bacnet4j.LocalDevice;
 import com.serotonin.bacnet4j.exception.BACnetErrorException;
 import com.serotonin.bacnet4j.exception.BACnetException;
@@ -128,39 +130,16 @@ public class ReadPropertyRequest extends ConfirmedRequestService {
     }
 
     @Override
-    public int hashCode() {
-        int PRIME = 31;
-        int result = 1;
-        result = PRIME * result + (objectIdentifier == null ? 0 : objectIdentifier.hashCode());
-        result = PRIME * result + (propertyArrayIndex == null ? 0 : propertyArrayIndex.hashCode());
-        result = PRIME * result + (propertyIdentifier == null ? 0 : propertyIdentifier.hashCode());
-        return result;
+    public boolean equals(Object o) {
+        if (!(o instanceof ReadPropertyRequest that))
+            return false;
+        return Objects.equals(objectIdentifier, that.objectIdentifier) && Objects.equals(
+                propertyIdentifier, that.propertyIdentifier) && Objects.equals(propertyArrayIndex,
+                that.propertyArrayIndex);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        ReadPropertyRequest other = (ReadPropertyRequest) obj;
-        if (objectIdentifier == null) {
-            if (other.objectIdentifier != null)
-                return false;
-        } else if (!objectIdentifier.equals(other.objectIdentifier))
-            return false;
-        if (propertyArrayIndex == null) {
-            if (other.propertyArrayIndex != null)
-                return false;
-        } else if (!propertyArrayIndex.equals(other.propertyArrayIndex))
-            return false;
-        if (propertyIdentifier == null) {
-            if (other.propertyIdentifier != null)
-                return false;
-        } else if (!propertyIdentifier.equals(other.propertyIdentifier))
-            return false;
-        return true;
+    public int hashCode() {
+        return Objects.hash(objectIdentifier, propertyIdentifier, propertyArrayIndex);
     }
 }

--- a/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadPropertyMultipleRequestTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadPropertyMultipleRequestTest.java
@@ -43,8 +43,6 @@ import com.serotonin.bacnet4j.exception.BACnetException;
 import com.serotonin.bacnet4j.npdu.test.TestNetwork;
 import com.serotonin.bacnet4j.npdu.test.TestNetworkMap;
 import com.serotonin.bacnet4j.npdu.test.TestNetworkUtils;
-import java.util.Set;
-
 import com.serotonin.bacnet4j.obj.GroupObject;
 import com.serotonin.bacnet4j.obj.NetworkPortObject;
 import com.serotonin.bacnet4j.service.acknowledgement.ReadPropertyMultipleAck;
@@ -68,6 +66,7 @@ import com.serotonin.bacnet4j.type.primitive.CharacterString;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
+
 
 public class ReadPropertyMultipleRequestTest {
     private final TestNetworkMap map = new TestNetworkMap();

--- a/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadPropertyMultipleRequestTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadPropertyMultipleRequestTest.java
@@ -43,7 +43,10 @@ import com.serotonin.bacnet4j.exception.BACnetException;
 import com.serotonin.bacnet4j.npdu.test.TestNetwork;
 import com.serotonin.bacnet4j.npdu.test.TestNetworkMap;
 import com.serotonin.bacnet4j.npdu.test.TestNetworkUtils;
+import java.util.Set;
+
 import com.serotonin.bacnet4j.obj.GroupObject;
+import com.serotonin.bacnet4j.obj.NetworkPortObject;
 import com.serotonin.bacnet4j.service.acknowledgement.ReadPropertyMultipleAck;
 import com.serotonin.bacnet4j.transport.DefaultTransport;
 import com.serotonin.bacnet4j.type.constructed.Address;
@@ -55,8 +58,10 @@ import com.serotonin.bacnet4j.type.constructed.ReadAccessSpecification;
 import com.serotonin.bacnet4j.type.constructed.SequenceOf;
 import com.serotonin.bacnet4j.type.enumerated.ErrorClass;
 import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
+import com.serotonin.bacnet4j.type.enumerated.NetworkType;
 import com.serotonin.bacnet4j.type.enumerated.ObjectType;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
+import com.serotonin.bacnet4j.type.enumerated.ProtocolLevel;
 import com.serotonin.bacnet4j.type.error.ErrorClassAndCode;
 import com.serotonin.bacnet4j.type.primitive.Boolean;
 import com.serotonin.bacnet4j.type.primitive.CharacterString;
@@ -276,5 +281,32 @@ public class ReadPropertyMultipleRequestTest {
         public int hashCode() {
             return Objects.hash(testUnsigned, testBoolean);
         }
+    }
+
+    /**
+     * Addendum 135-2016br-8: ReadPropertyMultiple with (NETWORK_PORT, 4194303) shall be treated as
+     * the local Network Port object representing the network port through which the request was
+     * received.
+     */
+    @Test
+    public void networkPortWildcardInstance() throws Exception {
+        NetworkPortObject npo = localDevice.addObject(new NetworkPortObject(localDevice, 42, "port42",
+                false, NetworkType.virtual, ProtocolLevel.bacnetApplication, Set.of()));
+
+        SequenceOf<ReadAccessSpecification> listOfReadAccessSpecs = new SequenceOf<>(
+                new ReadAccessSpecification(
+                        new ObjectIdentifier(ObjectType.networkPort, ObjectIdentifier.UNINITIALIZED),
+                        PropertyIdentifier.objectName));
+
+        ReadPropertyMultipleAck ack = (ReadPropertyMultipleAck) new ReadPropertyMultipleRequest(listOfReadAccessSpecs)
+                .handle(localDevice, addr);
+
+        List<ReadAccessResult> readAccessResults = ack.getListOfReadAccessResults().getValues();
+        assertEquals(1, readAccessResults.size());
+        assertEquals(npo.getId(), readAccessResults.get(0).getObjectIdentifier());
+        List<Result> results = readAccessResults.get(0).getListOfResults().getValues();
+        assertEquals(1, results.size());
+        assertEquals(new Result(PropertyIdentifier.objectName, null, new CharacterString("port42")),
+                results.get(0));
     }
 }

--- a/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadPropertyRequestTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadPropertyRequestTest.java
@@ -29,11 +29,11 @@ package com.serotonin.bacnet4j.service.confirmed;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Set;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.Set;
 
 import com.serotonin.bacnet4j.LocalDevice;
 import com.serotonin.bacnet4j.TestUtils;

--- a/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadPropertyRequestTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadPropertyRequestTest.java
@@ -33,19 +33,25 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Set;
+
 import com.serotonin.bacnet4j.LocalDevice;
 import com.serotonin.bacnet4j.TestUtils;
 import com.serotonin.bacnet4j.exception.BACnetException;
 import com.serotonin.bacnet4j.npdu.test.TestNetwork;
 import com.serotonin.bacnet4j.npdu.test.TestNetworkMap;
 import com.serotonin.bacnet4j.npdu.test.TestNetworkUtils;
+import com.serotonin.bacnet4j.obj.NetworkPortObject;
 import com.serotonin.bacnet4j.service.acknowledgement.ReadPropertyAck;
 import com.serotonin.bacnet4j.transport.DefaultTransport;
 import com.serotonin.bacnet4j.type.constructed.Address;
 import com.serotonin.bacnet4j.type.enumerated.ErrorClass;
 import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
+import com.serotonin.bacnet4j.type.enumerated.NetworkType;
 import com.serotonin.bacnet4j.type.enumerated.ObjectType;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
+import com.serotonin.bacnet4j.type.enumerated.ProtocolLevel;
+import com.serotonin.bacnet4j.type.primitive.CharacterString;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
@@ -116,5 +122,24 @@ public class ReadPropertyRequestTest {
                 () -> new ReadPropertyRequest(new ObjectIdentifier(ObjectType.device, 4194303),
                         PropertyIdentifier.optional).handle(localDevice, addr),
                 ErrorClass.services, ErrorCode.inconsistentParameters);
+    }
+
+    /**
+     * Per Clause 15.5.2 (base standard, reinforced by addendum 135-2016br-8): a ReadProperty with
+     * (NETWORK_PORT, 4194303) shall be treated as the local Network Port object representing the
+     * network port through which the request was received.
+     */
+    @Test
+    public void networkPortWildcardInstance() throws Exception {
+        NetworkPortObject npo = localDevice.addObject(new NetworkPortObject(localDevice, 42, "port42",
+                false, NetworkType.virtual, ProtocolLevel.bacnetApplication, Set.of()));
+
+        ReadPropertyAck ack = (ReadPropertyAck) new ReadPropertyRequest(
+                new ObjectIdentifier(ObjectType.networkPort, ObjectIdentifier.UNINITIALIZED),
+                PropertyIdentifier.objectName)
+                .handle(localDevice, addr);
+
+        assertEquals(npo.getId(), ack.getEventObjectIdentifier());
+        assertEquals(new CharacterString("port42"), ack.getValue());
     }
 }


### PR DESCRIPTION
https://radixiot.atlassian.net/browse/MANGO-2957

- Per addendum 135-2016br-8, ReadPropertyMultiple is extended so that (NETWORK_PORT, 4194303) is treated as the local Network_Port object representing the network port through which the request was received. The same treatment is added to ReadProperty, closing a pre-existing gap versus Clause 15.5.2 (which had this requirement for NETWORK_PORT since the object was introduced).
- Wildcard resolution is centralized on LocalDevice to an optional hosted NetworkPortObject. BACnet4J's single-transport architecture makes "the receiving network port" the sole NetworkPortObject; the first one found is returned.
- Both service handlers now echo the resolved object identifier in the response, per the spec's stated purpose for the wildcard