### PR TITLE
MANGO-2960 Return specific error codes for LifeSafetyOperation error situations

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ trendLogMult.writeProperty(PropertyIdentifier.recordCount, new UnsignedInteger(1
   rules.
 - Changes for compliance with addendum 135-2016bi-3 regarding extremely large logs
 - Time form construction of DateTime choice has been deprecated. They should no longer be created by client code
+- `LifeSafetyOperationRequest` returns error code specified in addendum bt-2
 
 *Version 6.2.0*
 

--- a/src/main/java/com/serotonin/bacnet4j/obj/DeviceObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/DeviceObject.java
@@ -224,7 +224,7 @@ public class DeviceObject extends BACnetObject {
         writePropertyInternal(PropertyIdentifier.firmwareRevision, new CharacterString("not set"));
         writePropertyInternal(PropertyIdentifier.applicationSoftwareVersion, new CharacterString(LocalDevice.VERSION));
         writePropertyInternal(PropertyIdentifier.protocolVersion, new UnsignedInteger(1));
-        writePropertyInternal(PropertyIdentifier.protocolRevision, new UnsignedInteger(20));
+        writePropertyInternal(PropertyIdentifier.protocolRevision, new UnsignedInteger(21));
 
         UnsignedInteger databaseRevision = getLocalDevice().getPersistence()
                 .loadEncodable(getPersistenceKey(PropertyIdentifier.databaseRevision), UnsignedInteger.class);

--- a/src/main/java/com/serotonin/bacnet4j/obj/LifeSafety.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/LifeSafety.java
@@ -27,8 +27,11 @@
 
 package com.serotonin.bacnet4j.obj;
 
+import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.type.Encodable;
 import com.serotonin.bacnet4j.type.constructed.Address;
+import com.serotonin.bacnet4j.type.enumerated.ErrorClass;
+import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
 import com.serotonin.bacnet4j.type.enumerated.LifeSafetyOperation;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
 import com.serotonin.bacnet4j.type.enumerated.SilencedState;
@@ -37,15 +40,22 @@ import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
 public interface LifeSafety {
     /**
-     * Override as required. Default implementation implements minimal behaviour.
+     * Handles an incoming LifeSafetyOperation. The default implementation supports the silence
+     * and unsilence variants; any other operation is rejected with
+     * {@code OBJECT / VALUE_OUT_OF_RANGE} per addendum 135-2016bt-2 (Clause 13.13.1.3.1).
      *
-     * @param from
-     * @param requestingProcessIdentifier
-     * @param requestingSource
-     * @param request
+     * <p>Overrides that add support for further operations should follow the same error mapping:
+     * throw {@code OBJECT / VALUE_OUT_OF_RANGE} for operations the object does not implement, and
+     * {@code OBJECT / INVALID_OPERATION_IN_THIS_STATE} for operations that are otherwise
+     * supported but inapplicable in the object's current state.
+     *
+     * @param from                        request sender
+     * @param requestingProcessIdentifier requesting process identifier
+     * @param requestingSource            requesting source
+     * @param request                     the request
      */
-    default void handleLifeSafetyOperation(final Address from, final UnsignedInteger requestingProcessIdentifier,
-            final CharacterString requestingSource, final LifeSafetyOperation request) {
+    default void handleLifeSafetyOperation(Address from, UnsignedInteger requestingProcessIdentifier,
+            CharacterString requestingSource, LifeSafetyOperation request) throws BACnetServiceException {
         if (request.equals(LifeSafetyOperation.silence)) {
             writePropertyInternal(PropertyIdentifier.silenced, SilencedState.allSilenced);
         } else if (request.equals(LifeSafetyOperation.silenceAudible)) {
@@ -55,8 +65,10 @@ public interface LifeSafety {
         } else if (request.isOneOf(LifeSafetyOperation.unsilence, LifeSafetyOperation.unsilenceAudible,
                 LifeSafetyOperation.unsilenceVisual)) {
             writePropertyInternal(PropertyIdentifier.silenced, SilencedState.unsilenced);
+        } else {
+            throw new BACnetServiceException(ErrorClass.object, ErrorCode.valueOutOfRange);
         }
     }
 
-    BACnetObject writePropertyInternal(final PropertyIdentifier pid, final Encodable value);
+    BACnetObject writePropertyInternal(PropertyIdentifier pid, Encodable value);
 }

--- a/src/main/java/com/serotonin/bacnet4j/service/confirmed/LifeSafetyOperationRequest.java
+++ b/src/main/java/com/serotonin/bacnet4j/service/confirmed/LifeSafetyOperationRequest.java
@@ -27,6 +27,8 @@
 
 package com.serotonin.bacnet4j.service.confirmed;
 
+import java.util.Objects;
+
 import com.serotonin.bacnet4j.LocalDevice;
 import com.serotonin.bacnet4j.exception.BACnetErrorException;
 import com.serotonin.bacnet4j.exception.BACnetException;
@@ -51,9 +53,8 @@ public class LifeSafetyOperationRequest extends ConfirmedRequestService {
     private final LifeSafetyOperation request;
     private final ObjectIdentifier objectIdentifier;
 
-    public LifeSafetyOperationRequest(final UnsignedInteger requestingProcessIdentifier,
-            final CharacterString requestingSource, final LifeSafetyOperation request,
-            final ObjectIdentifier objectIdentifier) {
+    public LifeSafetyOperationRequest(UnsignedInteger requestingProcessIdentifier, CharacterString requestingSource,
+            LifeSafetyOperation request, ObjectIdentifier objectIdentifier) {
         this.requestingProcessIdentifier = requestingProcessIdentifier;
         this.requestingSource = requestingSource;
         this.request = request;
@@ -66,40 +67,39 @@ public class LifeSafetyOperationRequest extends ConfirmedRequestService {
     }
 
     @Override
-    public AcknowledgementService handle(final LocalDevice localDevice, final Address from) throws BACnetException {
+    public AcknowledgementService handle(LocalDevice localDevice, Address from) throws BACnetException {
         try {
             if (objectIdentifier != null) {
-                final BACnetObject bo = localDevice.getObjectRequired(objectIdentifier);
+                BACnetObject bo = localDevice.getObjectRequired(objectIdentifier);
                 handleForObject(from, bo, true);
             } else {
-                for (final BACnetObject bo : localDevice.getLocalObjects()) {
+                for (BACnetObject bo : localDevice.getLocalObjects()) {
                     handleForObject(from, bo, false);
                 }
             }
-        } catch (final BACnetServiceException e) {
+        } catch (BACnetServiceException e) {
             throw new BACnetErrorException(getChoiceId(), e.getErrorClass(), e.getErrorCode());
         }
         return null;
     }
 
-    private void handleForObject(final Address from, final BACnetObject bo, final boolean throwOnBadType)
-            throws BACnetServiceException {
-        if (bo instanceof LifeSafety) {
-            ((LifeSafety) bo).handleLifeSafetyOperation(from, requestingProcessIdentifier, requestingSource, request);
+    private void handleForObject(Address from, BACnetObject bo, boolean throwOnBadType) throws BACnetServiceException {
+        if (bo instanceof LifeSafety ls) {
+            ls.handleLifeSafetyOperation(from, requestingProcessIdentifier, requestingSource, request);
         } else if (throwOnBadType) {
-            throw new BACnetServiceException(ErrorClass.object, ErrorCode.unsupportedObjectType);
+            throw new BACnetServiceException(ErrorClass.object, ErrorCode.optionalFunctionalityNotSupported);
         }
     }
 
     @Override
-    public void write(final ByteQueue queue) {
+    public void write(ByteQueue queue) {
         write(queue, requestingProcessIdentifier, 0);
         write(queue, requestingSource, 1);
         write(queue, request, 2);
         writeOptional(queue, objectIdentifier, 3);
     }
 
-    LifeSafetyOperationRequest(final ByteQueue queue) throws BACnetException {
+    LifeSafetyOperationRequest(ByteQueue queue) throws BACnetException {
         requestingProcessIdentifier = read(queue, UnsignedInteger.class, 0);
         requestingSource = read(queue, CharacterString.class, 1);
         request = read(queue, LifeSafetyOperation.class, 2);
@@ -107,45 +107,18 @@ public class LifeSafetyOperationRequest extends ConfirmedRequestService {
     }
 
     @Override
-    public int hashCode() {
-        final int PRIME = 31;
-        int result = 1;
-        result = PRIME * result + (objectIdentifier == null ? 0 : objectIdentifier.hashCode());
-        result = PRIME * result + (request == null ? 0 : request.hashCode());
-        result = PRIME * result + (requestingProcessIdentifier == null ? 0 : requestingProcessIdentifier.hashCode());
-        result = PRIME * result + (requestingSource == null ? 0 : requestingSource.hashCode());
-        return result;
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass())
+            return false;
+        LifeSafetyOperationRequest that = (LifeSafetyOperationRequest) o;
+        return Objects.equals(requestingProcessIdentifier,
+                that.requestingProcessIdentifier) && Objects.equals(requestingSource,
+                that.requestingSource) && Objects.equals(request, that.request) && Objects.equals(
+                objectIdentifier, that.objectIdentifier);
     }
 
     @Override
-    public boolean equals(final Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        final LifeSafetyOperationRequest other = (LifeSafetyOperationRequest) obj;
-        if (objectIdentifier == null) {
-            if (other.objectIdentifier != null)
-                return false;
-        } else if (!objectIdentifier.equals(other.objectIdentifier))
-            return false;
-        if (request == null) {
-            if (other.request != null)
-                return false;
-        } else if (!request.equals(other.request))
-            return false;
-        if (requestingProcessIdentifier == null) {
-            if (other.requestingProcessIdentifier != null)
-                return false;
-        } else if (!requestingProcessIdentifier.equals(other.requestingProcessIdentifier))
-            return false;
-        if (requestingSource == null) {
-            if (other.requestingSource != null)
-                return false;
-        } else if (!requestingSource.equals(other.requestingSource))
-            return false;
-        return true;
+    public int hashCode() {
+        return Objects.hash(requestingProcessIdentifier, requestingSource, request, objectIdentifier);
     }
 }

--- a/src/test/java/com/serotonin/bacnet4j/service/confirmed/LifeSafetyOperationRequestTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/service/confirmed/LifeSafetyOperationRequestTest.java
@@ -92,11 +92,20 @@ public class LifeSafetyOperationRequestTest {
                         .handle(localDevice, addr),
                 ErrorClass.object, ErrorCode.unknownObject);
 
-        // Bad object type
+        // Per addendum 135-2016bt-2 (Clause 13.13.1.3.1): a request against an object that does
+        // not support LifeSafetyOperation is rejected with OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED.
         TestUtils.assertRequestHandleException(
                 () -> new LifeSafetyOperationRequest(new UnsignedInteger(12), new CharacterString("test"),
                         LifeSafetyOperation.none, ai.getId()).handle(localDevice, addr),
-                ErrorClass.object, ErrorCode.unsupportedObjectType);
+                ErrorClass.object, ErrorCode.optionalFunctionalityNotSupported);
+
+        // Per addendum 135-2016bt-2: an operation the object does not support is rejected with
+        // VALUE_OUT_OF_RANGE. The default LifeSafety implementation handles silence/unsilence
+        // variants only; reset variants are unsupported.
+        TestUtils.assertRequestHandleException(
+                () -> new LifeSafetyOperationRequest(new UnsignedInteger(12), new CharacterString("test"),
+                        LifeSafetyOperation.reset, lsp.getId()).handle(localDevice, addr),
+                ErrorClass.object, ErrorCode.valueOutOfRange);
     }
 
     @Test


### PR DESCRIPTION
https://radixiot.atlassian.net/browse/MANGO-2960

Aligns LifeSafetyOperation error responses with the Error Type table introduced in ANSI/ASHRAE 135-2016 addendum bt-2 (Clause 13.13.1.3.1).

increases the supported protocol revision to 21.