### PR TITLE
MANGO-3010 Implement basic Who-Am-I / You-Are support

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ trendLogMult.writeProperty(PropertyIdentifier.recordCount, new UnsignedInteger(1
 - Changes for compliance with addendum 135-2016bi-3 regarding extremely large logs
 - Time form construction of DateTime choice has been deprecated. They should no longer be created by client code
 - `LifeSafetyOperationRequest` returns error code specified in addendum bt-2
+- The method `ExceptionListener.receivedThrowable` has been removed
+- The method `DeviceEventListener.whoAmIReceived` has been added
+- The method `DeviceEventListener.youAreReceived` has been added
+- Code that allowed an unconfigured device to find an unused device id has been removed
 
 *Version 6.2.0*
 

--- a/src/main/java/com/serotonin/bacnet4j/LocalDevice.java
+++ b/src/main/java/com/serotonin/bacnet4j/LocalDevice.java
@@ -27,6 +27,7 @@
 
 package com.serotonin.bacnet4j;
 
+import java.security.SecureRandom;
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -34,7 +35,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Random;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -45,8 +45,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,12 +54,12 @@ import com.serotonin.bacnet4j.cache.RemoteEntityCache;
 import com.serotonin.bacnet4j.cache.RemoteEntityCachePolicy;
 import com.serotonin.bacnet4j.enums.MaxApduLength;
 import com.serotonin.bacnet4j.event.DefaultReinitializeDeviceHandler;
-import com.serotonin.bacnet4j.event.DeviceEventAdapter;
 import com.serotonin.bacnet4j.event.DeviceEventHandler;
 import com.serotonin.bacnet4j.event.ExceptionDispatcher;
 import com.serotonin.bacnet4j.event.PrivateTransferHandler;
 import com.serotonin.bacnet4j.event.ReinitializeDeviceHandler;
 import com.serotonin.bacnet4j.exception.BACnetException;
+import com.serotonin.bacnet4j.exception.BACnetRuntimeException;
 import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.exception.BACnetTimeoutException;
 import com.serotonin.bacnet4j.npdu.Network;
@@ -71,13 +69,14 @@ import com.serotonin.bacnet4j.obj.DeviceObject;
 import com.serotonin.bacnet4j.obj.mixin.CovContext;
 import com.serotonin.bacnet4j.persistence.IPersistence;
 import com.serotonin.bacnet4j.persistence.NullPersistence;
+import com.serotonin.bacnet4j.service.Service;
 import com.serotonin.bacnet4j.service.VendorServiceKey;
 import com.serotonin.bacnet4j.service.confirmed.ConfirmedRequestService;
 import com.serotonin.bacnet4j.service.confirmed.DeviceCommunicationControlRequest.EnableDisable;
 import com.serotonin.bacnet4j.service.unconfirmed.IAmRequest;
 import com.serotonin.bacnet4j.service.unconfirmed.UnconfirmedCovNotificationRequest;
 import com.serotonin.bacnet4j.service.unconfirmed.UnconfirmedRequestService;
-import com.serotonin.bacnet4j.service.unconfirmed.WhoIsRequest;
+import com.serotonin.bacnet4j.service.unconfirmed.WhoAmIRequest;
 import com.serotonin.bacnet4j.transport.Transport;
 import com.serotonin.bacnet4j.type.Encodable;
 import com.serotonin.bacnet4j.type.constructed.Address;
@@ -101,7 +100,6 @@ import com.serotonin.bacnet4j.util.RemoteDeviceFinder;
 import com.serotonin.bacnet4j.util.RemoteDeviceFinder.RemoteDeviceFuture;
 
 import lohbihler.warp.WarpScheduledExecutorService;
-import lohbihler.warp.WarpUtils;
 
 /**
  * Enhancements: - Optional persistence of COV subscriptions - default character string encoding - persistence of
@@ -111,6 +109,7 @@ public class LocalDevice implements AutoCloseable {
     static final Logger LOG = LoggerFactory.getLogger(LocalDevice.class);
     public static final String VERSION =
             Objects.requireNonNullElse(LocalDevice.class.getPackage().getImplementationVersion(), "unknown");
+    public static final SecureRandom RANDOM = new SecureRandom();
 
     private Transport transport;
 
@@ -199,7 +198,7 @@ public class LocalDevice implements AutoCloseable {
             addObject(new DeviceObject(this, deviceNumber));
         } catch (BACnetServiceException e) {
             // Should not happen
-            throw new RuntimeException(e);
+            throw new BACnetRuntimeException(e);
         }
     }
 
@@ -305,84 +304,51 @@ public class LocalDevice implements AutoCloseable {
         return transport.getBytesIn();
     }
 
-    public synchronized LocalDevice initialize() throws Exception {
+    public boolean isUnconfigured() {
+        return deviceObject.getId().isUninitialized();
+    }
+
+    public synchronized LocalDevice initialize() throws BACnetException {
         return initialize(RestartReason.unknown);
     }
 
-    public synchronized LocalDevice initialize(RestartReason lastRestartReason) throws Exception {
+    public synchronized LocalDevice initialize(RestartReason lastRestartReason) throws BACnetException {
         deviceObject.writePropertyInternal(PropertyIdentifier.lastRestartReason, lastRestartReason);
 
         timer = createScheduledExecutorService();
         transport.initialize();
         initialized = true;
 
-        // If the device id is uninitialized, try to find an available number to use.
-        if (getInstanceNumber() == ObjectIdentifier.UNINITIALIZED) {
-            int attempts = 10;
-            int rangeSize = 20;
-
-            Random random = new Random();
-            int remaining = attempts;
-            while (remaining > 0) {
-                int from = random.nextInt(ObjectIdentifier.UNINITIALIZED - rangeSize);
-                List<Integer> idList = IntStream.range(from, from + rangeSize).boxed().collect(Collectors.toList());
-
-                DeviceEventAdapter listener = new DeviceEventAdapter() {
-                    @Override
-                    public void iAmReceived(RemoteDevice d) {
-                        LOG.info("Device id {} is not available", d.getInstanceNumber());
-                        idList.remove(Integer.valueOf(d.getInstanceNumber()));
-                    }
-                };
-
-                getEventHandler().addListener(listener);
-                sendGlobalBroadcast(new WhoIsRequest(from, from + rangeSize - 1));
-
-                LOG.info("Waiting for incoming IAms");
-                WarpUtils.sleep(clock, 10, TimeUnit.SECONDS);
-                getEventHandler().removeListener(listener);
-
-                if (!idList.isEmpty()) {
-                    LOG.info("Found {} ids that are still available. Choosing {}", idList.size(), idList.get(0));
-                    deviceObject.writePropertyInternal(PropertyIdentifier.objectIdentifier,
-                            new ObjectIdentifier(ObjectType.device, idList.get(0)));
-                    break;
-                }
-
-                remaining--;
-            }
-
-            if (remaining == 0)
-                throw new Exception("Could not find an available device id after " + attempts + " attempts");
-        }
-
         // Notify objects.
         for (BACnetObject bo : localObjects) {
             bo.initialize();
         }
 
-        //
-        // Send restart notifications.
+        if (!isUnconfigured()) {
+            //
+            // Send restart notifications. Note an uninitialized device will not send these.
 
-        // The defaulting of the list of recipients is done here because sometimes the network has to be initialized
-        // before the local broadcast address is known.
-        SequenceOf<Recipient> restartNotificationRecipients = getPersistence().loadSequenceOf(
-                deviceObject.getPersistenceKey(PropertyIdentifier.restartNotificationRecipients), Recipient.class);
-        if (restartNotificationRecipients == null) {
-            restartNotificationRecipients = new SequenceOf<>(new Recipient(getLocalBroadcastAddress()));
-            deviceObject.writePropertyInternal(PropertyIdentifier.restartNotificationRecipients,
-                    restartNotificationRecipients);
-        }
-        UnconfirmedCovNotificationRequest restartNotif = new UnconfirmedCovNotificationRequest(
-                UnsignedInteger.ZERO, getId(), getId(), UnsignedInteger.ZERO, new SequenceOf<>(
-                new PropertyValue(PropertyIdentifier.systemStatus, deviceObject.get(PropertyIdentifier.systemStatus)),
-                new PropertyValue(PropertyIdentifier.timeOfDeviceRestart,
-                        deviceObject.get(PropertyIdentifier.timeOfDeviceRestart)),
-                new PropertyValue(PropertyIdentifier.lastRestartReason,
-                        deviceObject.get(PropertyIdentifier.lastRestartReason))));
-        for (Recipient recipient : restartNotificationRecipients) {
-            Address address = recipient.toAddress(this);
-            send(address, restartNotif);
+            // The defaulting of the list of recipients is done here because sometimes the network has to be initialized
+            // before the local broadcast address is known.
+            SequenceOf<Recipient> restartNotificationRecipients = getPersistence().loadSequenceOf(
+                    deviceObject.getPersistenceKey(PropertyIdentifier.restartNotificationRecipients), Recipient.class);
+            if (restartNotificationRecipients == null) {
+                restartNotificationRecipients = new SequenceOf<>(new Recipient(getLocalBroadcastAddress()));
+                deviceObject.writePropertyInternal(PropertyIdentifier.restartNotificationRecipients,
+                        restartNotificationRecipients);
+            }
+            UnconfirmedCovNotificationRequest restartNotif = new UnconfirmedCovNotificationRequest(
+                    UnsignedInteger.ZERO, getId(), getId(), UnsignedInteger.ZERO, new SequenceOf<>(
+                    new PropertyValue(PropertyIdentifier.systemStatus,
+                            deviceObject.get(PropertyIdentifier.systemStatus)),
+                    new PropertyValue(PropertyIdentifier.timeOfDeviceRestart,
+                            deviceObject.get(PropertyIdentifier.timeOfDeviceRestart)),
+                    new PropertyValue(PropertyIdentifier.lastRestartReason,
+                            deviceObject.get(PropertyIdentifier.lastRestartReason))));
+            for (Recipient recipient : restartNotificationRecipients) {
+                Address address = recipient.toAddress(this);
+                send(address, restartNotif);
+            }
         }
 
         return this;
@@ -392,7 +358,7 @@ public class LocalDevice implements AutoCloseable {
      * Allows updating the device's network while preserving local objects and other state. Note that network port
      * objects may also need to be recreated with the new network too.w
      */
-    public void replaceTransport(Transport newTransport) throws Exception {
+    public void replaceTransport(Transport newTransport) throws BACnetException {
         transport.terminate();
         transport = newTransport;
         transport.setLocalDevice(this);
@@ -1077,13 +1043,13 @@ public class LocalDevice implements AutoCloseable {
      -----------------------------------------------------------*/
 
     public ServiceFuture send(RemoteDevice d, ConfirmedRequestService serviceRequest) {
-        ensureInitialized();
+        ensureInitialized(serviceRequest);
         return transport.send(d.getAddress(), d.getMaxAPDULengthAccepted(), d.getSegmentationSupported(),
                 serviceRequest);
     }
 
     public ServiceFuture send(Address address, ConfirmedRequestService serviceRequest) {
-        ensureInitialized();
+        ensureInitialized(serviceRequest);
         RemoteDevice d = getCachedRemoteDevice(address);
         if (d == null) {
             // Just use some hopeful defaults.
@@ -1094,13 +1060,13 @@ public class LocalDevice implements AutoCloseable {
     }
 
     public void send(RemoteDevice d, ConfirmedRequestService serviceRequest, ResponseConsumer consumer) {
-        ensureInitialized();
+        ensureInitialized(serviceRequest);
         transport.send(d.getAddress(), d.getMaxAPDULengthAccepted(), d.getSegmentationSupported(), serviceRequest,
                 consumer);
     }
 
     public void send(Address address, ConfirmedRequestService serviceRequest, ResponseConsumer consumer) {
-        ensureInitialized();
+        ensureInitialized(serviceRequest);
         RemoteDevice d = getCachedRemoteDevice(address);
         if (d == null) {
             // Just use some hopeful defaults.
@@ -1111,28 +1077,36 @@ public class LocalDevice implements AutoCloseable {
     }
 
     public void send(RemoteDevice d, UnconfirmedRequestService serviceRequest) {
-        ensureInitialized();
+        ensureInitialized(serviceRequest);
         transport.send(d.getAddress(), serviceRequest);
     }
 
     public void send(Address address, UnconfirmedRequestService serviceRequest) {
-        ensureInitialized();
+        ensureInitialized(serviceRequest);
         transport.send(address, serviceRequest);
     }
 
     public void sendLocalBroadcast(UnconfirmedRequestService serviceRequest) {
-        ensureInitialized();
+        ensureInitialized(serviceRequest);
         transport.send(getLocalBroadcastAddress(), serviceRequest);
     }
 
     public void sendGlobalBroadcast(UnconfirmedRequestService serviceRequest) {
-        ensureInitialized();
+        ensureInitialized(serviceRequest);
         transport.send(Address.GLOBAL, serviceRequest);
     }
 
-    private void ensureInitialized() {
+    private void ensureInitialized(Service service) {
         if (!initialized) {
-            throw new RuntimeException("LocalDevice is not initialized");
+            throw new BACnetRuntimeException("LocalDevice is not initialized");
+        }
+
+        if (isUnconfigured() && !(service instanceof WhoAmIRequest)) {
+            // Per clause 19.7, an unconfigured device (Device Identifier 4194303) may only
+            // initiate Who-Am-I. Any other service initiation is a spec violation.
+            throw new BACnetRuntimeException(
+                    "Unconfigured device (Device Identifier 4194303) may only initiate Who-Am-I; "
+                            + "attempted to send " + service.getClass().getSimpleName());
         }
     }
 

--- a/src/main/java/com/serotonin/bacnet4j/RemoteDevice.java
+++ b/src/main/java/com/serotonin/bacnet4j/RemoteDevice.java
@@ -29,6 +29,7 @@ package com.serotonin.bacnet4j;
 
 import java.io.Serial;
 import java.io.Serializable;
+import java.util.Objects;
 
 import com.serotonin.bacnet4j.cache.RemoteEntityCache;
 import com.serotonin.bacnet4j.type.Encodable;
@@ -54,7 +55,7 @@ public class RemoteDevice implements Serializable {
     private int maxReadMultipleReferences = -1;
     private final transient RemoteEntityCache<ObjectIdentifier, RemoteObject> remoteObjectCache;
 
-    public RemoteDevice(final LocalDevice localDevice, final int instanceNumber) {
+    public RemoteDevice(LocalDevice localDevice, int instanceNumber) {
         this.localDevice = localDevice;
 
         // Create the remote cache.
@@ -66,7 +67,7 @@ public class RemoteDevice implements Serializable {
                 localDevice.getCachePolicies().getObjectPolicy(instanceNumber, deviceOid));
     }
 
-    public RemoteDevice(final LocalDevice localDevice, final int instanceNumber, final Address address) {
+    public RemoteDevice(LocalDevice localDevice, int instanceNumber, Address address) {
         this(localDevice, instanceNumber);
         this.address = address;
     }
@@ -79,35 +80,35 @@ public class RemoteDevice implements Serializable {
         return deviceOid;
     }
 
-    public void setObject(final RemoteObject remoteObject) {
+    public void setObject(RemoteObject remoteObject) {
         remoteObjectCache.putEntity(remoteObject.getObjectIdentifier(), remoteObject, //
                 localDevice.getCachePolicies().getObjectPolicy( //
                         deviceOid.getInstanceNumber(), //
                         remoteObject.getObjectIdentifier()));
     }
 
-    public RemoteObject getObject(final ObjectIdentifier oid) {
+    public RemoteObject getObject(ObjectIdentifier oid) {
         return remoteObjectCache.getCachedEntity(oid);
     }
 
     //
     // Get properties
     //
-    public <T extends Encodable> T getDeviceProperty(final PropertyIdentifier pid) {
+    public <T extends Encodable> T getDeviceProperty(PropertyIdentifier pid) {
         return getObjectProperty(deviceOid, pid, null);
     }
 
-    public <T extends Encodable> T getDeviceProperty(final PropertyIdentifier pid, final UnsignedInteger pin) {
+    public <T extends Encodable> T getDeviceProperty(PropertyIdentifier pid, UnsignedInteger pin) {
         return getObjectProperty(deviceOid, pid, pin);
     }
 
-    public <T extends Encodable> T getObjectProperty(final ObjectIdentifier oid, final PropertyIdentifier pid) {
+    public <T extends Encodable> T getObjectProperty(ObjectIdentifier oid, PropertyIdentifier pid) {
         return getObjectProperty(oid, pid, null);
     }
 
-    public <T extends Encodable> T getObjectProperty(final ObjectIdentifier oid, final PropertyIdentifier pid,
-            final UnsignedInteger pin) {
-        final RemoteObject ro = getObject(oid);
+    public <T extends Encodable> T getObjectProperty(ObjectIdentifier oid, PropertyIdentifier pid,
+            UnsignedInteger pin) {
+        RemoteObject ro = getObject(oid);
         if (ro == null)
             return null;
         return ro.getProperty(pid, pin);
@@ -117,20 +118,19 @@ public class RemoteDevice implements Serializable {
     // Set properties
     //
 
-    public void setDeviceProperty(final PropertyIdentifier pid, final Encodable value) {
+    public void setDeviceProperty(PropertyIdentifier pid, Encodable value) {
         setObjectProperty(deviceOid, pid, null, value);
     }
 
-    public void setDeviceProperty(final PropertyIdentifier pid, final UnsignedInteger pin, final Encodable value) {
+    public void setDeviceProperty(PropertyIdentifier pid, UnsignedInteger pin, Encodable value) {
         setObjectProperty(deviceOid, pid, pin, value);
     }
 
-    public void setObjectProperty(final ObjectIdentifier oid, final PropertyIdentifier pid, final Encodable value) {
+    public void setObjectProperty(ObjectIdentifier oid, PropertyIdentifier pid, Encodable value) {
         setObjectProperty(oid, pid, null, value);
     }
 
-    public void setObjectProperty(final ObjectIdentifier oid, final PropertyIdentifier pid, final UnsignedInteger pin,
-            final Encodable value) {
+    public void setObjectProperty(ObjectIdentifier oid, PropertyIdentifier pid, UnsignedInteger pin, Encodable value) {
         if (value instanceof ErrorClassAndCode e && ErrorClass.object.equals(e.getErrorClass())) {
             // Don't create objects if the error is about the object.
             // But don't remove the object because it is possible to get error responses on objects that
@@ -156,21 +156,21 @@ public class RemoteDevice implements Serializable {
     // Remove properties
     //
 
-    public <T extends Encodable> T removeDeviceProperty(final PropertyIdentifier pid) {
+    public <T extends Encodable> T removeDeviceProperty(PropertyIdentifier pid) {
         return removeObjectProperty(deviceOid, pid, null);
     }
 
-    public <T extends Encodable> T removeDeviceProperty(final PropertyIdentifier pid, final UnsignedInteger pin) {
+    public <T extends Encodable> T removeDeviceProperty(PropertyIdentifier pid, UnsignedInteger pin) {
         return removeObjectProperty(deviceOid, pid, pin);
     }
 
-    public <T extends Encodable> T removeObjectProperty(final ObjectIdentifier oid, final PropertyIdentifier pid) {
+    public <T extends Encodable> T removeObjectProperty(ObjectIdentifier oid, PropertyIdentifier pid) {
         return removeObjectProperty(oid, pid, null);
     }
 
-    public <T extends Encodable> T removeObjectProperty(final ObjectIdentifier oid, final PropertyIdentifier pid,
-            final UnsignedInteger pin) {
-        final RemoteObject ro = remoteObjectCache.getCachedEntity(oid);
+    public <T extends Encodable> T removeObjectProperty(ObjectIdentifier oid, PropertyIdentifier pid,
+            UnsignedInteger pin) {
+        RemoteObject ro = remoteObjectCache.getCachedEntity(oid);
         if (ro == null)
             return null;
         return ro.removeProperty(pid, pin);
@@ -180,7 +180,7 @@ public class RemoteDevice implements Serializable {
         return address;
     }
 
-    public void setAddress(final Address address) {
+    public void setAddress(Address address) {
         this.address = address;
     }
 
@@ -193,6 +193,7 @@ public class RemoteDevice implements Serializable {
     }
 
     public int getVendorIdentifier() {
+        // This is actually an Unsigned16, but it will work anyway.
         return getUnsignedIntegerProperty(PropertyIdentifier.vendorIdentifier);
     }
 
@@ -212,15 +213,15 @@ public class RemoteDevice implements Serializable {
         return getDeviceProperty(PropertyIdentifier.protocolServicesSupported);
     }
 
-    public int getUnsignedIntegerProperty(final PropertyIdentifier pid) {
-        final UnsignedInteger p = getDeviceProperty(pid);
+    public int getUnsignedIntegerProperty(PropertyIdentifier pid) {
+        UnsignedInteger p = getDeviceProperty(pid);
         if (p == null)
             return -1;
         return p.intValue();
     }
 
-    public String getCharacterStringProperty(final PropertyIdentifier pid) {
-        final CharacterString p = getDeviceProperty(pid);
+    public String getCharacterStringProperty(PropertyIdentifier pid) {
+        CharacterString p = getDeviceProperty(pid);
         if (p == null)
             return null;
         return p.getValue();
@@ -242,11 +243,11 @@ public class RemoteDevice implements Serializable {
         return userData;
     }
 
-    public void setUserData(final Object userData) {
+    public void setUserData(Object userData) {
         this.userData = userData;
     }
 
-    public void setMaxReadMultipleReferences(final int maxReadMultipleReferences) {
+    public void setMaxReadMultipleReferences(int maxReadMultipleReferences) {
         this.maxReadMultipleReferences = maxReadMultipleReferences;
     }
 
@@ -256,7 +257,7 @@ public class RemoteDevice implements Serializable {
         return maxReadMultipleReferences;
     }
 
-    public void reduceMaxReadMultipleReferences(final int from) {
+    public void reduceMaxReadMultipleReferences(int from) {
         int current = getMaxReadMultipleReferences();
         if (current > from)
             current = from;
@@ -266,27 +267,18 @@ public class RemoteDevice implements Serializable {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + (deviceOid == null ? 0 : deviceOid.hashCode());
-        return result;
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass())
+            return false;
+        RemoteDevice that = (RemoteDevice) o;
+        return maxReadMultipleReferences == that.maxReadMultipleReferences && Objects.equals(localDevice,
+                that.localDevice) && Objects.equals(deviceOid, that.deviceOid) && Objects.equals(
+                address, that.address) && Objects.equals(userData, that.userData) && Objects.equals(
+                remoteObjectCache, that.remoteObjectCache);
     }
 
     @Override
-    public boolean equals(final Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        final RemoteDevice other = (RemoteDevice) obj;
-        if (deviceOid == null) {
-            if (other.deviceOid != null)
-                return false;
-        } else if (!deviceOid.equals(other.deviceOid))
-            return false;
-        return true;
+    public int hashCode() {
+        return Objects.hash(localDevice, deviceOid, address, userData, maxReadMultipleReferences, remoteObjectCache);
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/event/DefaultDeviceEventListener.java
+++ b/src/main/java/com/serotonin/bacnet4j/event/DefaultDeviceEventListener.java
@@ -45,17 +45,17 @@ import com.serotonin.bacnet4j.type.notificationParameters.NotificationParameters
 import com.serotonin.bacnet4j.type.primitive.Boolean;
 import com.serotonin.bacnet4j.type.primitive.CharacterString;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
+import com.serotonin.bacnet4j.type.primitive.OctetString;
+import com.serotonin.bacnet4j.type.primitive.Unsigned16;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
 /**
  * Default implementation for all methods is to do nothing
  * useful to create functional interfaces that extend this
- *
- * @author Terry Packer
  */
 public interface DefaultDeviceEventListener extends DeviceEventListener {
     @Override
-    default void listenerException(Throwable e) {
+    default void listenerException(Exception e) {
     }
 
     @Override
@@ -83,10 +83,10 @@ public interface DefaultDeviceEventListener extends DeviceEventListener {
 
     @Override
     default void eventNotificationReceived(UnsignedInteger processIdentifier,
-            ObjectIdentifier initiatingDeviceIdentifier,
-            ObjectIdentifier eventObjectIdentifier, TimeStamp timeStamp, UnsignedInteger notificationClass,
-            UnsignedInteger priority, EventType eventType, CharacterString messageText, NotifyType notifyType,
-            Boolean ackRequired, EventState fromState, EventState toState, NotificationParameters eventValues) {
+            ObjectIdentifier initiatingDeviceIdentifier, ObjectIdentifier eventObjectIdentifier, TimeStamp timeStamp,
+            UnsignedInteger notificationClass, UnsignedInteger priority, EventType eventType,
+            CharacterString messageText, NotifyType notifyType, Boolean ackRequired, EventState fromState,
+            EventState toState, NotificationParameters eventValues) {
     }
 
     @Override
@@ -100,5 +100,14 @@ public interface DefaultDeviceEventListener extends DeviceEventListener {
 
     @Override
     default void requestReceived(Address from, Service service) {
+    }
+
+    @Override
+    default void whoAmIReceived(Address from, Unsigned16 vendorId, CharacterString modelName,
+            CharacterString serialNumber) {
+    }
+
+    @Override
+    default void youAreReceived(Address from, ObjectIdentifier deviceIdentifier, OctetString deviceMacAddress) {
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/event/DefaultExceptionListener.java
+++ b/src/main/java/com/serotonin/bacnet4j/event/DefaultExceptionListener.java
@@ -34,21 +34,16 @@ import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
 
 public class DefaultExceptionListener implements ExceptionListener {
-    static final Logger LOG = LoggerFactory.getLogger(DefaultExceptionListener.class);
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultExceptionListener.class);
 
     @Override
     public void unimplementedVendorService(UnsignedInteger vendorId, UnsignedInteger serviceNumber, ByteQueue queue) {
-        LOG.warn("Received unimplemented vendor service: vendor id={}, service number={}, bytes (with context id)=",
+        LOG.warn("Received unimplemented vendor service: vendor id={}, service number={}, bytes (with context id)={}",
                 vendorId, serviceNumber, queue);
     }
 
     @Override
     public void receivedException(Exception e) {
         LOG.error("", e);
-    }
-
-    @Override
-    public void receivedThrowable(Throwable t) {
-        LOG.error("", t);
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/event/DeviceEventAdapter.java
+++ b/src/main/java/com/serotonin/bacnet4j/event/DeviceEventAdapter.java
@@ -27,6 +27,9 @@
 
 package com.serotonin.bacnet4j.event;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.serotonin.bacnet4j.RemoteDevice;
 import com.serotonin.bacnet4j.RemoteObject;
 import com.serotonin.bacnet4j.obj.BACnetObject;
@@ -45,71 +48,83 @@ import com.serotonin.bacnet4j.type.notificationParameters.NotificationParameters
 import com.serotonin.bacnet4j.type.primitive.Boolean;
 import com.serotonin.bacnet4j.type.primitive.CharacterString;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
+import com.serotonin.bacnet4j.type.primitive.OctetString;
+import com.serotonin.bacnet4j.type.primitive.Unsigned16;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
 /**
- * A default class for easy implementation of the DeviceEventListener interface. Instead of having to implement all of
+ * A default class for easy implementation of the DeviceEventListener interface. Instead of having to implement all
  * the defined methods, listener classes can override this and only implement the desired methods.
- *
- * @author Matthew Lohbihler
  */
 public class DeviceEventAdapter implements DeviceEventListener {
+    private static final Logger LOG = LoggerFactory.getLogger(DeviceEventAdapter.class);
+
     @Override
-    public void listenerException(final Throwable e) {
+    public void listenerException(Exception e) {
         // Override as required
-        e.printStackTrace();
+        LOG.error(e.getMessage(), e);
     }
 
     @Override
-    public boolean allowPropertyWrite(final Address from, final BACnetObject obj, final PropertyValue pv) {
+    public boolean allowPropertyWrite(Address from, BACnetObject obj, PropertyValue pv) {
         return true;
     }
 
     @Override
-    public void iAmReceived(final RemoteDevice d) {
+    public void iAmReceived(RemoteDevice d) {
         // Override as required
     }
 
     @Override
-    public void propertyWritten(final Address from, final BACnetObject obj, final PropertyValue pv) {
+    public void propertyWritten(Address from, BACnetObject obj, PropertyValue pv) {
         // Override as required
     }
 
     @Override
-    public void iHaveReceived(final RemoteDevice d, final RemoteObject o) {
+    public void iHaveReceived(RemoteDevice d, RemoteObject o) {
         // Override as required
     }
 
     @Override
-    public void covNotificationReceived(final UnsignedInteger subscriberProcessIdentifier,
-            final ObjectIdentifier initiatingDeviceIdentifier, final ObjectIdentifier monitoredObjectIdentifier,
-            final UnsignedInteger timeRemaining, final SequenceOf<PropertyValue> listOfValues) {
+    public void covNotificationReceived(UnsignedInteger subscriberProcessIdentifier,
+            ObjectIdentifier initiatingDeviceIdentifier, ObjectIdentifier monitoredObjectIdentifier,
+            UnsignedInteger timeRemaining, SequenceOf<PropertyValue> listOfValues) {
         // Override as required
     }
 
     @Override
-    public void eventNotificationReceived(final UnsignedInteger processIdentifier,
-            final ObjectIdentifier initiatingDeviceIdentifier, final ObjectIdentifier eventObjectIdentifier,
-            final TimeStamp timeStamp, final UnsignedInteger notificationClass, final UnsignedInteger priority,
-            final EventType eventType, final CharacterString messageText, final NotifyType notifyType,
-            final Boolean ackRequired, final EventState fromState, final EventState toState,
-            final NotificationParameters eventValues) {
+    public void eventNotificationReceived(UnsignedInteger processIdentifier,
+            ObjectIdentifier initiatingDeviceIdentifier, ObjectIdentifier eventObjectIdentifier, TimeStamp timeStamp,
+            UnsignedInteger notificationClass, UnsignedInteger priority, EventType eventType,
+            CharacterString messageText, NotifyType notifyType, Boolean ackRequired, EventState fromState,
+            EventState toState, NotificationParameters eventValues) {
         // Override as required
     }
 
     @Override
-    public void textMessageReceived(final ObjectIdentifier textMessageSourceDevice, final Choice messageClass,
-            final MessagePriority messagePriority, final CharacterString message) {
+    public void textMessageReceived(ObjectIdentifier textMessageSourceDevice, Choice messageClass,
+            MessagePriority messagePriority, CharacterString message) {
         // Override as required
     }
 
     @Override
-    public void synchronizeTime(final Address from, final DateTime dateTime, final boolean utc) {
+    public void synchronizeTime(Address from, DateTime dateTime, boolean utc) {
         // Override as required
     }
 
     @Override
-    public void requestReceived(final Address from, final Service service) {
+    public void requestReceived(Address from, Service service) {
         // Override as required
+    }
+
+    @Override
+    public void whoAmIReceived(Address from, Unsigned16 vendorId, CharacterString modelName,
+            CharacterString serialNumber) {
+        // Override as required
+    }
+
+    @Override
+    public void youAreReceived(Address from, ObjectIdentifier deviceIdentifier, OctetString deviceMacAddress) {
+        // Override as required. See 16.11.4
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/event/DeviceEventHandler.java
+++ b/src/main/java/com/serotonin/bacnet4j/event/DeviceEventHandler.java
@@ -47,6 +47,8 @@ import com.serotonin.bacnet4j.type.notificationParameters.NotificationParameters
 import com.serotonin.bacnet4j.type.primitive.Boolean;
 import com.serotonin.bacnet4j.type.primitive.CharacterString;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
+import com.serotonin.bacnet4j.type.primitive.OctetString;
+import com.serotonin.bacnet4j.type.primitive.Unsigned16;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
 /**
@@ -56,17 +58,17 @@ import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
  * @author Matthew Lohbihler
  */
 public class DeviceEventHandler {
-    final ConcurrentLinkedQueue<DeviceEventListener> listeners = new ConcurrentLinkedQueue<>();
+    protected final ConcurrentLinkedQueue<DeviceEventListener> listeners = new ConcurrentLinkedQueue<>();
 
     //
     //
     // Listener management
     //
-    public void addListener(final DeviceEventListener l) {
+    public void addListener(DeviceEventListener l) {
         listeners.add(l);
     }
 
-    public void removeListener(final DeviceEventListener l) {
+    public void removeListener(DeviceEventListener l) {
         listeners.remove(l);
     }
 
@@ -78,118 +80,139 @@ public class DeviceEventHandler {
     //
     // Checks and notifications
     //
-    public boolean checkAllowPropertyWrite(final Address from, final BACnetObject obj, final PropertyValue pv) {
-        for (final DeviceEventListener l : listeners) {
+    public boolean checkAllowPropertyWrite(Address from, BACnetObject obj, PropertyValue pv) {
+        for (DeviceEventListener l : listeners) {
             try {
                 if (!l.allowPropertyWrite(from, obj, pv))
                     return false;
-            } catch (final Exception e) {
+            } catch (Exception e) {
                 handleException(l, e);
             }
         }
         return true;
     }
 
-    public void fireIAmReceived(final RemoteDevice d) {
-        for (final DeviceEventListener l : listeners) {
+    public void fireIAmReceived(RemoteDevice d) {
+        for (DeviceEventListener l : listeners) {
             try {
                 l.iAmReceived(d);
-            } catch (final Exception e) {
+            } catch (Exception e) {
                 handleException(l, e);
             }
         }
     }
 
-    public void propertyWritten(final Address from, final BACnetObject obj, final PropertyValue pv) {
-        for (final DeviceEventListener l : listeners) {
+    public void propertyWritten(Address from, BACnetObject obj, PropertyValue pv) {
+        for (DeviceEventListener l : listeners) {
             try {
                 l.propertyWritten(from, obj, pv);
-            } catch (final Exception e) {
+            } catch (Exception e) {
                 handleException(l, e);
             }
         }
     }
 
-    public void fireIHaveReceived(final RemoteDevice d, final RemoteObject o) {
-        for (final DeviceEventListener l : listeners) {
+    public void fireIHaveReceived(RemoteDevice d, RemoteObject o) {
+        for (DeviceEventListener l : listeners) {
             try {
                 l.iHaveReceived(d, o);
-            } catch (final Exception e) {
+            } catch (Exception e) {
                 handleException(l, e);
             }
         }
     }
 
-    public void fireCovNotification(final UnsignedInteger subscriberProcessIdentifier,
-            final ObjectIdentifier initiatingDeviceIdentifier, final ObjectIdentifier monitoredObjectIdentifier,
-            final UnsignedInteger timeRemaining, final SequenceOf<PropertyValue> listOfValues) {
-        for (final DeviceEventListener l : listeners) {
+    public void fireCovNotification(UnsignedInteger subscriberProcessIdentifier,
+            ObjectIdentifier initiatingDeviceIdentifier, ObjectIdentifier monitoredObjectIdentifier,
+            UnsignedInteger timeRemaining, SequenceOf<PropertyValue> listOfValues) {
+        for (DeviceEventListener l : listeners) {
             try {
                 l.covNotificationReceived(subscriberProcessIdentifier, initiatingDeviceIdentifier,
                         monitoredObjectIdentifier, timeRemaining, listOfValues);
-            } catch (final Exception e) {
+            } catch (Exception e) {
                 handleException(l, e);
             }
         }
     }
 
-    public void fireEventNotification(final UnsignedInteger processIdentifier,
-            final ObjectIdentifier initiatingDeviceIdentifier, final ObjectIdentifier eventObjectIdentifier,
-            final TimeStamp timeStamp, final UnsignedInteger notificationClass, final UnsignedInteger priority,
-            final EventType eventType, final CharacterString messageText, final NotifyType notifyType,
-            final Boolean ackRequired, final EventState fromState, final EventState toState,
-            final NotificationParameters eventValues) {
-        for (final DeviceEventListener l : listeners) {
+    public void fireEventNotification(UnsignedInteger processIdentifier, ObjectIdentifier initiatingDeviceIdentifier,
+            ObjectIdentifier eventObjectIdentifier, TimeStamp timeStamp, UnsignedInteger notificationClass,
+            UnsignedInteger priority, EventType eventType, CharacterString messageText, NotifyType notifyType,
+            Boolean ackRequired, EventState fromState, EventState toState, NotificationParameters eventValues) {
+        for (DeviceEventListener l : listeners) {
             try {
                 l.eventNotificationReceived(processIdentifier, initiatingDeviceIdentifier, eventObjectIdentifier,
                         timeStamp, notificationClass, priority, eventType, messageText, notifyType, ackRequired,
                         fromState, toState, eventValues);
-            } catch (final Exception e) {
+            } catch (Exception e) {
                 handleException(l, e);
             }
         }
     }
 
-    public void fireTextMessage(final ObjectIdentifier textMessageSourceDevice, final Choice messageClass,
-            final MessagePriority messagePriority, final CharacterString message) {
-        for (final DeviceEventListener l : listeners) {
+    public void fireTextMessage(ObjectIdentifier textMessageSourceDevice, Choice messageClass,
+            MessagePriority messagePriority, CharacterString message) {
+        for (DeviceEventListener l : listeners) {
             try {
                 l.textMessageReceived(textMessageSourceDevice, messageClass, messagePriority, message);
-            } catch (final Exception e) {
+            } catch (Exception e) {
                 handleException(l, e);
             }
         }
     }
 
-    public void synchronizeTime(final Address from, final DateTime dateTime, final boolean utc) {
-        for (final DeviceEventListener l : listeners) {
+    public void synchronizeTime(Address from, DateTime dateTime, boolean utc) {
+        for (DeviceEventListener l : listeners) {
             try {
                 l.synchronizeTime(from, dateTime, utc);
-            } catch (final Exception e) {
+            } catch (Exception e) {
                 handleException(l, e);
             }
         }
     }
 
-    public void requestReceived(final Address from, final Service service) {
-        for (final DeviceEventListener l : listeners) {
+    public void requestReceived(Address from, Service service) {
+        for (DeviceEventListener l : listeners) {
             try {
                 l.requestReceived(from, service);
-            } catch (final Exception e) {
+            } catch (Exception e) {
                 handleException(l, e);
             }
         }
     }
 
-    public void handleException(final Exception e) {
-        for (final DeviceEventListener l : listeners)
-            handleException(l, e);
+    public void fireWhoAmIReceived(Address from, Unsigned16 vendorId, CharacterString modelName,
+            CharacterString serialNumber) {
+        for (DeviceEventListener l : listeners) {
+            try {
+                l.whoAmIReceived(from, vendorId, modelName, serialNumber);
+            } catch (Exception e) {
+                handleException(l, e);
+            }
+        }
     }
 
-    private static void handleException(final DeviceEventListener l, final Exception e) {
+    public void fireYouAreReceived(Address from, ObjectIdentifier deviceIdentifier, OctetString deviceMacAddress) {
+        for (DeviceEventListener l : listeners) {
+            try {
+                l.youAreReceived(from, deviceIdentifier, deviceMacAddress);
+            } catch (Exception e) {
+                handleException(l, e);
+            }
+        }
+    }
+
+
+    public void handleException(Exception e) {
+        for (DeviceEventListener l : listeners) {
+            handleException(l, e);
+        }
+    }
+
+    private static void handleException(DeviceEventListener l, Exception e) {
         try {
             l.listenerException(e);
-        } catch (@SuppressWarnings("unused") final Exception e1) {
+        } catch (@SuppressWarnings("unused") Exception e1) {
             // no op
         }
     }

--- a/src/main/java/com/serotonin/bacnet4j/event/DeviceEventListener.java
+++ b/src/main/java/com/serotonin/bacnet4j/event/DeviceEventListener.java
@@ -45,6 +45,8 @@ import com.serotonin.bacnet4j.type.notificationParameters.NotificationParameters
 import com.serotonin.bacnet4j.type.primitive.Boolean;
 import com.serotonin.bacnet4j.type.primitive.CharacterString;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
+import com.serotonin.bacnet4j.type.primitive.OctetString;
+import com.serotonin.bacnet4j.type.primitive.Unsigned16;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
 /**
@@ -57,7 +59,7 @@ public interface DeviceEventListener {
     /**
      * Notification of an exception while calling a listener method.
      */
-    void listenerException(Throwable e);
+    void listenerException(Exception e);
 
     /**
      * Notification of receipt of an IAm message.
@@ -159,4 +161,16 @@ public interface DeviceEventListener {
      * @param service the service received
      */
     void requestReceived(Address from, Service service);
+
+    /**
+     * Notification of receipt of a WhoAmI message.
+     */
+    void whoAmIReceived(Address from, Unsigned16 vendorId, CharacterString modelName, CharacterString serialNumber);
+
+    /**
+     * Notification of receipt of a YouAre message. The MAC address has not been validated at this point. See 16.11.4.
+     * "After accepting the 'Device Identifier' or 'Device MAC Address' if provided, the device shall subsequently
+     * generate an I-Am, except when the receiving BACnet-user is an MS/TP subordinate node."
+     */
+    void youAreReceived(Address from, ObjectIdentifier deviceIdentifier, OctetString deviceMacAddress);
 }

--- a/src/main/java/com/serotonin/bacnet4j/event/ExceptionDispatcher.java
+++ b/src/main/java/com/serotonin/bacnet4j/event/ExceptionDispatcher.java
@@ -41,11 +41,11 @@ public class ExceptionDispatcher {
         listeners.add(defaultExceptionListener);
     }
 
-    public void addListener(final ExceptionListener l) {
+    public void addListener(ExceptionListener l) {
         listeners.add(l);
     }
 
-    public void removeListener(final ExceptionListener l) {
+    public void removeListener(ExceptionListener l) {
         listeners.remove(l);
     }
 
@@ -53,19 +53,15 @@ public class ExceptionDispatcher {
         listeners.remove(defaultExceptionListener);
     }
 
-    public void fireUnimplementedVendorService(final UnsignedInteger vendorId, final UnsignedInteger serviceNumber,
-            final ByteQueue queue) {
-        for (final ExceptionListener l : listeners)
+    public void fireUnimplementedVendorService(UnsignedInteger vendorId, UnsignedInteger serviceNumber,
+            ByteQueue queue) {
+        for (ExceptionListener l : listeners)
             l.unimplementedVendorService(vendorId, serviceNumber, queue);
     }
 
-    public void fireReceivedException(final Exception e) {
-        for (final ExceptionListener l : listeners)
+    public void fireReceivedException(Exception e) {
+        for (ExceptionListener l : listeners) {
             l.receivedException(e);
-    }
-
-    public void fireReceivedThrowable(final Throwable t) {
-        for (final ExceptionListener l : listeners)
-            l.receivedThrowable(t);
+        }
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/event/ExceptionListener.java
+++ b/src/main/java/com/serotonin/bacnet4j/event/ExceptionListener.java
@@ -34,6 +34,4 @@ public interface ExceptionListener {
     void unimplementedVendorService(UnsignedInteger vendorId, UnsignedInteger serviceNumber, ByteQueue queue);
 
     void receivedException(Exception e);
-
-    void receivedThrowable(Throwable t);
 }

--- a/src/main/java/com/serotonin/bacnet4j/event/IAmListener.java
+++ b/src/main/java/com/serotonin/bacnet4j/event/IAmListener.java
@@ -29,9 +29,6 @@ package com.serotonin.bacnet4j.event;
 
 import com.serotonin.bacnet4j.RemoteDevice;
 
-/**
- * @author Terry Packer
- */
 @FunctionalInterface
 public interface IAmListener extends DefaultDeviceEventListener {
     @Override

--- a/src/main/java/com/serotonin/bacnet4j/npdu/MessageValidationException.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/MessageValidationException.java
@@ -27,7 +27,12 @@
 
 package com.serotonin.bacnet4j.npdu;
 
-public class MessageValidationException extends Exception {
+import java.io.Serial;
+
+import com.serotonin.bacnet4j.exception.BACnetException;
+
+public class MessageValidationException extends BACnetException {
+    @Serial
     private static final long serialVersionUID = -1;
 
     public MessageValidationException(String message) {

--- a/src/main/java/com/serotonin/bacnet4j/npdu/Network.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/Network.java
@@ -84,6 +84,10 @@ public abstract class Network {
         return null;
     }
 
+    /**
+     * @param transport the transport to use
+     * @throws BACnetException subclasses may throw
+     */
     public void initialize(Transport transport) throws BACnetException {
         this.transport = transport;
     }

--- a/src/main/java/com/serotonin/bacnet4j/npdu/Network.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/Network.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 import com.serotonin.bacnet4j.apdu.APDU;
 import com.serotonin.bacnet4j.enums.MaxApduLength;
 import com.serotonin.bacnet4j.exception.BACnetException;
+import com.serotonin.bacnet4j.exception.BACnetRuntimeException;
 import com.serotonin.bacnet4j.transport.Transport;
 import com.serotonin.bacnet4j.type.constructed.Address;
 import com.serotonin.bacnet4j.type.constructed.NetworkSourceAddress;
@@ -83,7 +84,7 @@ public abstract class Network {
         return null;
     }
 
-    public void initialize(Transport transport) throws Exception {
+    public void initialize(Transport transport) throws BACnetException {
         this.transport = transport;
     }
 
@@ -112,12 +113,12 @@ public abstract class Network {
             npci = new NPCI(getSourceAddress(apdu));
         else if (isThisNetwork(recipient)) {
             if (router != null)
-                throw new RuntimeException(
+                throw new BACnetRuntimeException(
                         "Invalid arguments: router address provided for local recipient " + recipient);
             npci = new NPCI(null, getSourceAddress(apdu), apdu.expectsReply());
         } else {
             if (router == null)
-                throw new RuntimeException(
+                throw new BACnetRuntimeException(
                         "Invalid arguments: router address not provided for remote recipient " + recipient);
             npci = new NPCI(recipient, getSourceAddress(apdu), apdu.expectsReply());
         }
@@ -141,11 +142,12 @@ public abstract class Network {
             npci = new NPCI(null, null, expectsReply, messageType, 0);
         else if (isThisNetwork(recipient)) {
             if (router != null)
-                throw new RuntimeException("Invalid arguments: router address provided for a local recipient");
+                throw new BACnetRuntimeException("Invalid arguments: router address provided for a local recipient");
             npci = new NPCI(null, null, expectsReply, messageType, 0);
         } else {
             if (router == null)
-                throw new RuntimeException("Invalid arguments: router address not provided for a remote recipient");
+                throw new BACnetRuntimeException(
+                        "Invalid arguments: router address not provided for a remote recipient");
             npci = new NPCI(recipient, null, expectsReply, messageType, 0);
         }
         npci.write(npdu);
@@ -157,7 +159,7 @@ public abstract class Network {
         sendNPDU(recipient, router, npdu, broadcast, expectsReply);
     }
 
-    abstract public void sendNPDU(Address recipient, OctetString router, ByteQueue npdu, boolean broadcast,
+    public abstract void sendNPDU(Address recipient, OctetString router, ByteQueue npdu, boolean broadcast,
             boolean expectsReply) throws BACnetException;
 
     protected OctetString getDestination(Address recipient, OctetString link) {
@@ -182,12 +184,10 @@ public abstract class Network {
             }
         } catch (Exception e) {
             transport.getLocalDevice().getExceptionDispatcher().fireReceivedException(e);
-        } catch (Throwable t) {
-            transport.getLocalDevice().getExceptionDispatcher().fireReceivedThrowable(t);
         }
     }
 
-    abstract protected NPDU handleIncomingDataImpl(ByteQueue queue, OctetString linkService) throws Exception;
+    protected abstract NPDU handleIncomingDataImpl(ByteQueue queue, OctetString linkService) throws BACnetException;
 
     public NPDU parseNpduData(ByteQueue queue, OctetString linkService) throws MessageValidationException {
         // Network layer protocol control information. See 6.2.2
@@ -233,27 +233,5 @@ public abstract class Network {
 
         // APDU message
         return new NPDU(from, ls, queue);
-    }
-
-    @Override
-    public int hashCode() {
-        int prime = 31;
-        int result = 1;
-        result = prime * result + localNetworkNumber;
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        Network other = (Network) obj;
-        if (localNetworkNumber != other.localNetworkNumber)
-            return false;
-        return true;
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/npdu/ip/IpNetwork.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/ip/IpNetwork.java
@@ -52,6 +52,7 @@ import org.slf4j.LoggerFactory;
 
 import com.serotonin.bacnet4j.enums.MaxApduLength;
 import com.serotonin.bacnet4j.exception.BACnetException;
+import com.serotonin.bacnet4j.exception.BACnetRuntimeException;
 import com.serotonin.bacnet4j.npdu.MessageValidationException;
 import com.serotonin.bacnet4j.npdu.NPDU;
 import com.serotonin.bacnet4j.npdu.Network;
@@ -114,8 +115,8 @@ public class IpNetwork extends Network {
     /**
      * Use an IpNetworkBuilder to create instances.
      */
-    IpNetwork(final int port, final String localBindAddress, final String broadcastAddress, final String subnetMask,
-            final int localNetworkNumber, final boolean reuseAddress) {
+    IpNetwork(int port, String localBindAddress, String broadcastAddress, String subnetMask, int localNetworkNumber,
+            boolean reuseAddress) {
         super(localNetworkNumber);
         this.port = port;
         this.localBindAddressStr = localBindAddress;
@@ -172,6 +173,7 @@ public class IpNetwork extends Network {
         return IPMode.normal;
     }
 
+    @Override
     public boolean isInitialized() {
         return localAddress != null;
     }
@@ -225,11 +227,15 @@ public class IpNetwork extends Network {
     }
 
     @Override
-    public void initialize(final Transport transport) throws Exception {
+    public void initialize(Transport transport) throws BACnetException {
         super.initialize(transport);
 
         localBindAddress = InetAddrCache.get(localBindAddressStr, port);
-        unicastSocket = createSocket(localBindAddress);
+        try {
+            unicastSocket = createSocket(localBindAddress);
+        } catch (SocketException e) {
+            throw new BACnetException(e);
+        }
 
         broadcastMAC = IpNetworkUtils.toOctetString(broadcastAddressStr, port);
         subnetMask = BACnetUtils.dottedStringToBytes(subnetMaskStr);
@@ -241,9 +247,9 @@ public class IpNetwork extends Network {
             try {
                 InetSocketAddress broadcastAddress = InetAddrCache.get(broadcastAddressStr, port);
                 broadcastSocket = createSocket(broadcastAddress);
-            } catch (final SocketException e) {
+            } catch (SocketException e) {
                 unicastSocket.close();
-                throw e;
+                throw new BACnetException(e);
             }
         }
 
@@ -264,9 +270,9 @@ public class IpNetwork extends Network {
         initializeBBMD();
     }
 
-    protected DatagramSocket createSocket(final InetSocketAddress bindAddress) throws SocketException {
+    protected DatagramSocket createSocket(InetSocketAddress bindAddress) throws SocketException {
         LOG.info("Binding to address {}", bindAddress);
-        final DatagramSocket socket;
+        DatagramSocket socket;
         if (reuseAddress) {
             socket = new DatagramSocket(null);
             socket.setReuseAddress(true);
@@ -296,7 +302,7 @@ public class IpNetwork extends Network {
         return broadcastMAC;
     }
 
-    public Address getBroadcastAddress(final int port) {
+    public Address getBroadcastAddress(int port) {
         return IpNetworkUtils.toAddress(broadcastAddressStr, port);
     }
 
@@ -405,7 +411,7 @@ public class IpNetwork extends Network {
                         interval = 15;
                     }
                     delay = interval;
-                } catch (final BACnetException e) {
+                } catch (BACnetException e) {
                     LOG.warn("Failed to register foreign device", e);
                     fdRegistered = false;
                     // Failure. Ask the retry provider what to do.
@@ -430,7 +436,7 @@ public class IpNetwork extends Network {
             if (fDRegistrant != null) {
                 try {
                     deleteForeignDeviceTableEntry(foreignBBMD, localAddress);
-                } catch (final BACnetException e) {
+                } catch (BACnetException e) {
                     LOG.info("Device de-registration failed", e);
                 }
             }
@@ -444,9 +450,9 @@ public class IpNetwork extends Network {
     }
 
     @Override
-    public void sendNPDU(final Address recipient, final OctetString router, final ByteQueue npdu,
-            final boolean broadcast, final boolean expectsReply) throws BACnetException {
-        final ByteQueue queue = new ByteQueue();
+    public void sendNPDU(Address recipient, OctetString router, ByteQueue npdu, boolean broadcast, boolean expectsReply)
+            throws BACnetException {
+        ByteQueue queue = new ByteQueue();
 
         // BACnet virtual link layer detail
         queue.push(BVLC_TYPE);
@@ -460,7 +466,7 @@ public class IpNetwork extends Network {
             // Original-Unicast-NPDU, or Original-Broadcast-NPDU
             queue.push(broadcast ? 0xb : 0xa);
 
-            final OctetString dest = getDestination(recipient, router);
+            OctetString dest = getDestination(recipient, router);
             addr = IpNetworkUtils.getInetSocketAddress(dest);
         }
 
@@ -472,21 +478,21 @@ public class IpNetwork extends Network {
         sendPacket(addr, queue.popAll());
     }
 
-    protected void sendPacket(final InetSocketAddress addr, final byte[] data) throws BACnetException {
+    protected void sendPacket(InetSocketAddress addr, byte[] data) throws BACnetException {
         try {
-            final DatagramPacket packet = new DatagramPacket(data, data.length, addr);
+            DatagramPacket packet = new DatagramPacket(data, data.length, addr);
             unicastSocket.send(packet);
             bytesOut += data.length;
-        } catch (final Exception e) {
+        } catch (Exception e) {
             throw new BACnetException(e);
         }
     }
 
     //
     // For receiving
-    protected void listen(final DatagramSocket socket) {
-        final byte[] buffer = new byte[MESSAGE_LENGTH];
-        final DatagramPacket p = new DatagramPacket(buffer, buffer.length);
+    protected void listen(DatagramSocket socket) {
+        byte[] buffer = new byte[MESSAGE_LENGTH];
+        DatagramPacket p = new DatagramPacket(buffer, buffer.length);
 
         while (!socket.isClosed()) {
             try {
@@ -495,22 +501,21 @@ public class IpNetwork extends Network {
                 bytesIn += p.getLength();
                 // Create a new byte queue for the message, because the queue will probably be processed in the
                 // transport thread.
-                final ByteQueue queue = new ByteQueue(p.getData(), 0, p.getLength());
-                final OctetString link = IpNetworkUtils.toOctetString(p.getAddress().getAddress(), p.getPort());
+                ByteQueue queue = new ByteQueue(p.getData(), 0, p.getLength());
+                OctetString link = IpNetworkUtils.toOctetString(p.getAddress().getAddress(), p.getPort());
 
                 handleIncomingData(queue, link);
 
                 // Reset the packet.
                 p.setData(buffer);
-            } catch (@SuppressWarnings("unused") final IOException e) {
+            } catch (@SuppressWarnings("unused") IOException e) {
                 // no op. This happens if the socket gets closed by the destroy method.
             }
         }
     }
 
     @Override
-    protected NPDU handleIncomingDataImpl(final ByteQueue queue, final OctetString linkService)
-            throws Exception {
+    protected NPDU handleIncomingDataImpl(ByteQueue queue, OctetString linkService) throws BACnetException {
         LOG.trace("Received request from {}", linkService);
 
         // Initial parsing of IP message.
@@ -518,16 +523,16 @@ public class IpNetwork extends Network {
         if (queue.pop() != BVLC_TYPE)
             throw new MessageValidationException("Protocol id is not BACnet/IP (0x81)");
 
-        final byte function = queue.pop();
+        byte function = queue.pop();
 
-        final int length = BACnetUtils.popShort(queue);
+        int length = BACnetUtils.popShort(queue);
         if (length != queue.size() + 4)
             throw new MessageValidationException(
                     "Length field does not match data: given=" + length + ", expected=" + (queue.size() + 4));
 
         NPDU npdu = null;
         if (function == 0x0) {
-            final int result = BACnetUtils.popShort(queue);
+            int result = BACnetUtils.popShort(queue);
 
             if (result == 0x10)
                 LOG.error("Write-Broadcast-Distribution-Table failed!");
@@ -546,7 +551,7 @@ public class IpNetwork extends Network {
 
             // Response management.
             bbmdResponse = result;
-            final InetSocketAddress addr = foreignBBMD;
+            InetSocketAddress addr = foreignBBMD;
             if (addr != null) {
                 synchronized (addr) {
                     addr.notifyAll();
@@ -570,9 +575,9 @@ public class IpNetwork extends Network {
                 forwardNPDU(queue, linkService);
 
                 // Process the NPDU locally
-                final byte[] address = new byte[6];
+                byte[] address = new byte[6];
                 queue.pop(address);
-                final OctetString origin = new OctetString(address);
+                OctetString origin = new OctetString(address);
                 npdu = parseNpduData(queue, origin);
             }
         } else if (function == 0x5)
@@ -590,7 +595,7 @@ public class IpNetwork extends Network {
             deleteFDT(queue, linkService);
         else if (function == 0x9) {
             // Distribute-Broadcast-To-Network
-            final boolean ok = distributeBroadcastToNetwork(queue, linkService);
+            boolean ok = distributeBroadcastToNetwork(queue, linkService);
             if (ok)
                 // Only process locally if the foreign device is valid.
                 npdu = parseNpduData(queue, linkService);
@@ -613,18 +618,18 @@ public class IpNetwork extends Network {
     //
     // Convenience methods
     //
-    public Address getAddress(final InetAddress inetAddress) {
+    public Address getAddress(InetAddress inetAddress) {
         try {
             return IpNetworkUtils.toAddress(getLocalNetworkNumber(), inetAddress.getAddress(), port);
-        } catch (final Exception e) {
+        } catch (Exception e) {
             // Should never happen, so just wrap in a RuntimeException
-            throw new RuntimeException(e);
+            throw new BACnetRuntimeException(e);
         }
     }
 
     public static InetAddress getDefaultLocalInetAddress() throws UnknownHostException, SocketException {
-        for (final NetworkInterface iface : Collections.list(NetworkInterface.getNetworkInterfaces())) {
-            for (final InetAddress addr : Collections.list(iface.getInetAddresses())) {
+        for (NetworkInterface iface : Collections.list(NetworkInterface.getNetworkInterfaces())) {
+            for (InetAddress addr : Collections.list(iface.getInetAddresses())) {
                 if (!addr.isLoopbackAddress())
                     return addr;
             }
@@ -635,9 +640,9 @@ public class IpNetwork extends Network {
 
     protected List<Address> getLocalAddressList() {
         try {
-            final ArrayList<Address> result = new ArrayList<>();
-            for (final NetworkInterface iface : Collections.list(NetworkInterface.getNetworkInterfaces())) {
-                for (final InetAddress addr : Collections.list(iface.getInetAddresses())) {
+            ArrayList<Address> result = new ArrayList<>();
+            for (NetworkInterface iface : Collections.list(NetworkInterface.getNetworkInterfaces())) {
+                for (InetAddress addr : Collections.list(iface.getInetAddresses())) {
                     if (!addr.isLoopbackAddress() && addr instanceof Inet4Address)
                         result.add(getAddress(addr));
                 }
@@ -645,9 +650,9 @@ public class IpNetwork extends Network {
 
             // Check if the configured local bind address is one of the addresses. If not, add it. This is
             // necessary if the local bind address is a loopback.
-            final Address config = IpNetworkUtils.toAddress(localBindAddress);
+            Address config = IpNetworkUtils.toAddress(localBindAddress);
             boolean found = false;
-            for (final Address addr : result) {
+            for (Address addr : result) {
                 if (addr.equals(config)) {
                     found = true;
                     break;
@@ -657,9 +662,9 @@ public class IpNetwork extends Network {
                 result.add(config);
 
             return result;
-        } catch (final Exception e) {
+        } catch (Exception e) {
             // Should never happen, so just wrap in a RuntimeException
-            throw new RuntimeException(e);
+            throw new BACnetRuntimeException(e);
         }
     }
 
@@ -688,46 +693,12 @@ public class IpNetwork extends Network {
         return IpNetworkUtils.toAddress("127.0.0.1", DEFAULT_PORT);
     }
 
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + (broadcastAddressStr == null ? 0 : broadcastAddressStr.hashCode());
-        result = prime * result + (localBindAddressStr == null ? 0 : localBindAddressStr.hashCode());
-        result = prime * result + port;
-        return result;
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        if (this == obj)
-            return true;
-        if (!super.equals(obj))
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        final IpNetwork other = (IpNetwork) obj;
-        if (broadcastAddressStr == null) {
-            if (other.broadcastAddressStr != null)
-                return false;
-        } else if (!broadcastAddressStr.equals(other.broadcastAddressStr))
-            return false;
-        if (localBindAddressStr == null) {
-            if (other.localBindAddressStr != null)
-                return false;
-        } else if (!localBindAddressStr.equals(other.localBindAddressStr))
-            return false;
-        if (port != other.port)
-            return false;
-        return true;
-    }
-
     //
     //
     // BBMD
     //
     public static class BDTEntry {
-        public static final byte[] DEFAULT_DISTRIBUTION_MASK =
+        protected static final byte[] DEFAULT_DISTRIBUTION_MASK =
                 new byte[] {(byte) 255, (byte) 255, (byte) 255, (byte) 255};
 
         // The IP address of the other BBMD
@@ -788,15 +759,15 @@ public class IpNetwork extends Network {
         }
     }
 
-    protected void writeBDT(final ByteQueue queue, final OctetString origin) throws BACnetException {
-        final ByteQueue response = new ByteQueue();
+    protected void writeBDT(ByteQueue queue, OctetString origin) throws BACnetException {
+        ByteQueue response = new ByteQueue();
         response.push(BVLC_TYPE);
         response.push(0); // Result
         response.pushU2B(6); // Length
 
         if (bbmdEnabled.get()) {
             try {
-                final List<BDTEntry> list = new ArrayList<>();
+                List<BDTEntry> list = new ArrayList<>();
 
                 while (queue.size() > 0) {
                     var address = new byte[4];
@@ -811,7 +782,7 @@ public class IpNetwork extends Network {
                 broadcastDistributionTable = list;
 
                 response.pushU2B(0); // Ok
-            } catch (final Exception e) {
+            } catch (Exception e) {
                 LOG.error("BDT write failed", e);
                 response.pushU2B(0x10); // NAK
             }
@@ -821,14 +792,14 @@ public class IpNetwork extends Network {
         sendPacket(IpNetworkUtils.getInetSocketAddress(origin), response.popAll());
     }
 
-    private void readBDT(final OctetString origin) throws BACnetException {
-        final ByteQueue response = new ByteQueue();
+    private void readBDT(OctetString origin) throws BACnetException {
+        ByteQueue response = new ByteQueue();
         response.push(BVLC_TYPE);
         if (bbmdEnabled.get()) {
             try {
-                final ByteQueue list = new ByteQueue();
+                ByteQueue list = new ByteQueue();
 
-                for (final BDTEntry e : broadcastDistributionTable) {
+                for (BDTEntry e : broadcastDistributionTable) {
                     list.push(e.address);
                     list.pushU2B(e.port);
                     list.push(e.distributionMask);
@@ -838,7 +809,7 @@ public class IpNetwork extends Network {
                 response.push(3); // Read-Broadcast-Distribution-Table-Ack
                 response.pushU2B(4 + list.size()); // Length
                 response.push(list); // List
-            } catch (final Exception e) {
+            } catch (Exception e) {
                 LOG.error("BDT read failed", e);
                 response.push(0); // Result
                 response.pushU2B(6); // Length
@@ -852,7 +823,7 @@ public class IpNetwork extends Network {
         sendPacket(IpNetworkUtils.getInetSocketAddress(origin), response.popAll());
     }
 
-    protected void forwardNPDU(final ByteQueue partial, final OctetString origin) throws BACnetException {
+    protected void forwardNPDU(ByteQueue partial, OctetString origin) throws BACnetException {
         // Determine whether to the message should be broadcast locally.
         boolean doLocalBroadcast = !broadcastDistributionTable.isEmpty();
 
@@ -864,7 +835,7 @@ public class IpNetwork extends Network {
 
         if (doLocalBroadcast) {
             // 2) If the mask of the BDT entry for this BBMD is not all 1s, do not broadcast locally.
-            final byte[] myAddress = localAddress.getAddress().getAddress();
+            byte[] myAddress = localAddress.getAddress().getAddress();
             // Find the BDT entry matching this.
             BDTEntry thisEntry = broadcastDistributionTable.stream()
                     .filter(e -> Arrays.equals(e.address, myAddress) && e.port == port)
@@ -885,40 +856,40 @@ public class IpNetwork extends Network {
             return;
 
         // The BVLC type, function and length were removed from this queue, so recreate.
-        final ByteQueue fwd = new ByteQueue();
+        ByteQueue fwd = new ByteQueue();
         fwd.push(BVLC_TYPE);
         fwd.push(4); // Forward
         fwd.pushU2B(4 + partial.size()); // Length
         fwd.push(partial);
-        final byte[] toSend = fwd.popAll();
+        byte[] toSend = fwd.popAll();
 
         if (doLocalBroadcast) {
             sendPacket(InetAddrCache.get(broadcastAddressStr, port), toSend);
         }
 
         // Forward to all foreign devices.
-        for (final FDTEntry fd : foreignDeviceTable)
+        for (FDTEntry fd : foreignDeviceTable)
             sendPacket(fd.address, toSend);
     }
 
-    protected void originalBroadcast(final ByteQueue partial, final OctetString originStr) throws BACnetException {
+    protected void originalBroadcast(ByteQueue partial, OctetString originStr) throws BACnetException {
         // Check if anything needs to be done.
         if (foreignDeviceTable.isEmpty() && broadcastDistributionTable.isEmpty())
             return;
 
-        final ByteQueue fwd = new ByteQueue();
+        ByteQueue fwd = new ByteQueue();
         fwd.push(BVLC_TYPE);
         fwd.push(4); // Forward
         fwd.pushU2B(10 + partial.size()); // Length
         fwd.push(originStr.getBytes()); // Origin
         fwd.push(partial);
-        final byte[] toSend = fwd.popAll();
+        byte[] toSend = fwd.popAll();
 
         try {
-            final byte[] myAddress = localAddress.getAddress().getAddress();
+            byte[] myAddress = localAddress.getAddress().getAddress();
 
             // Send to all subnets except own
-            for (final BDTEntry e : broadcastDistributionTable) {
+            for (BDTEntry e : broadcastDistributionTable) {
                 if (Arrays.equals(e.address, myAddress) && e.port == port) {
                     continue;
                 }
@@ -926,31 +897,31 @@ public class IpNetwork extends Network {
             }
 
             // Forward to all foreign devices.
-            for (final FDTEntry fd : foreignDeviceTable)
+            for (FDTEntry fd : foreignDeviceTable)
                 sendPacket(fd.address, toSend);
-        } catch (final UnknownHostException e) {
+        } catch (UnknownHostException e) {
             throw new BACnetException(e);
         }
     }
 
-    private void registerForeignDevice(final ByteQueue queue, final OctetString originStr) throws BACnetException {
-        final InetSocketAddress origin = IpNetworkUtils.getInetSocketAddress(originStr);
+    private void registerForeignDevice(ByteQueue queue, OctetString originStr) throws BACnetException {
+        InetSocketAddress origin = IpNetworkUtils.getInetSocketAddress(originStr);
         LOG.debug("Received registerForeignDevice request from {}", origin);
 
-        final ByteQueue response = new ByteQueue();
+        ByteQueue response = new ByteQueue();
         response.push(BVLC_TYPE);
         response.push(0); // Response type
         response.pushU2B(6); // Length
 
         if (bbmdEnabled.get()) {
-            final int timeToLive = queue.popU2B();
+            int timeToLive = queue.popU2B();
             if (timeToLive < 1) {
                 response.pushU2B(0x30); // NAK
             } else {
                 // Check if the device is already in the list. If so, update its start time. Otherwise, add it.
                 FDTEntry fd = null;
                 synchronized (foreignDeviceTable) {
-                    for (final FDTEntry e : foreignDeviceTable) {
+                    for (FDTEntry e : foreignDeviceTable) {
                         if (e.address.equals(origin)) {
                             fd = e;
                             break;
@@ -973,16 +944,16 @@ public class IpNetwork extends Network {
         sendPacket(origin, response.popAll());
     }
 
-    private void readFDT(final OctetString origin) throws BACnetException {
-        final ByteQueue response = new ByteQueue();
+    private void readFDT(OctetString origin) throws BACnetException {
+        ByteQueue response = new ByteQueue();
         response.push(BVLC_TYPE);
 
         if (bbmdEnabled.get()) {
-            final long now = getTransport().getLocalDevice().getClock().millis();
+            long now = getTransport().getLocalDevice().getClock().millis();
             try {
-                final ByteQueue list = new ByteQueue();
+                ByteQueue list = new ByteQueue();
 
-                for (final FDTEntry e : foreignDeviceTable) {
+                for (FDTEntry e : foreignDeviceTable) {
                     pushISA(list, e.address);
                     list.pushU2B(e.timeToLive);
 
@@ -1000,7 +971,7 @@ public class IpNetwork extends Network {
                 response.push(7); // Read-Foreign-Device-Table-Ack
                 response.pushU2B(4 + list.size()); // Length
                 response.push(list); // List
-            } catch (final Exception e) {
+            } catch (Exception e) {
                 LOG.error("FDT read failed", e);
                 response.push(0); // Result
                 response.pushU2B(6); // Length
@@ -1015,19 +986,19 @@ public class IpNetwork extends Network {
         sendPacket(IpNetworkUtils.getInetSocketAddress(origin), response.popAll());
     }
 
-    private void deleteFDT(final ByteQueue queue, final OctetString origin) throws BACnetException {
-        final byte[] addr = new byte[4];
+    private void deleteFDT(ByteQueue queue, OctetString origin) throws BACnetException {
+        byte[] addr = new byte[4];
         queue.pop(addr);
-        final int fdtPort = queue.popU2B();
+        int fdtPort = queue.popU2B();
 
-        final ByteQueue response = new ByteQueue();
+        ByteQueue response = new ByteQueue();
         response.push(BVLC_TYPE);
         response.push(0); // Response type
         response.pushU2B(6); // Length
 
         synchronized (foreignDeviceTable) {
             FDTEntry toDelete = null;
-            for (final FDTEntry fd : foreignDeviceTable) {
+            for (FDTEntry fd : foreignDeviceTable) {
                 if (Arrays.equals(fd.address.getAddress().getAddress(), addr) && fd.address.getPort() == fdtPort) {
                     toDelete = fd;
                     break;
@@ -1044,14 +1015,13 @@ public class IpNetwork extends Network {
         sendPacket(IpNetworkUtils.getInetSocketAddress(origin), response.popAll());
     }
 
-    protected boolean distributeBroadcastToNetwork(final ByteQueue queue, final OctetString originStr)
-            throws BACnetException {
-        final InetSocketAddress origin = IpNetworkUtils.getInetSocketAddress(originStr);
+    protected boolean distributeBroadcastToNetwork(ByteQueue queue, OctetString originStr) throws BACnetException {
+        InetSocketAddress origin = IpNetworkUtils.getInetSocketAddress(originStr);
 
         // Find the foreign device.
         FDTEntry originFDT = foreignDeviceTable.stream().filter(e -> e.address.equals(origin)).findFirst().orElse(null);
 
-        final ByteQueue response = new ByteQueue();
+        ByteQueue response = new ByteQueue();
         response.push(BVLC_TYPE);
         response.push(0); // Response type
         response.pushU2B(6); // Length
@@ -1064,32 +1034,32 @@ public class IpNetwork extends Network {
         }
 
         // The FDT was found. Forward the message around.
-        final ByteQueue fwd = new ByteQueue();
+        ByteQueue fwd = new ByteQueue();
         fwd.push(BVLC_TYPE);
         fwd.push(4); // Forward
         fwd.pushU2B(10 + queue.size()); // Length
         fwd.push(originStr.getBytes()); // Origin
         fwd.push(queue);
-        final byte[] toSend = fwd.popAll();
+        byte[] toSend = fwd.popAll();
 
         // Send locally
         sendPacket(InetAddrCache.get(broadcastAddressStr, port), toSend);
 
         try {
             // Send to all BDTs except own
-            final byte[] myAddress = localAddress.getAddress().getAddress();
-            for (final BDTEntry e : broadcastDistributionTable) {
+            byte[] myAddress = localAddress.getAddress().getAddress();
+            for (BDTEntry e : broadcastDistributionTable) {
                 if (Arrays.equals(e.address, myAddress) && e.port == port) {
                     continue;
                 }
                 sendToBDT(e, toSend);
             }
-        } catch (final UnknownHostException e1) {
+        } catch (UnknownHostException e1) {
             LOG.warn("Error forwarding to BDT", e1);
         }
 
         // Forward to all foreign devices except the origin.
-        for (final FDTEntry fd : foreignDeviceTable) {
+        for (FDTEntry fd : foreignDeviceTable) {
             if (fd != originFDT)
                 sendPacket(fd.address, toSend);
         }
@@ -1099,18 +1069,18 @@ public class IpNetwork extends Network {
         return true;
     }
 
-    protected void sendToBDT(final BDTEntry e, final byte[] toSend) throws UnknownHostException, BACnetException {
+    protected void sendToBDT(BDTEntry e, byte[] toSend) throws UnknownHostException, BACnetException {
         // J.4.5: The B/IP address to which the Forwarded-NPDU message is sent is formed by inverting the broadcast
         // distribution mask in the BDT entry and logically ORing it with the BBMD address of the same entry.
-        final byte[] target = new byte[4];
+        byte[] target = new byte[4];
         for (int i = 0; i < 4; i++)
             target[i] = (byte) (e.address[i] | ~e.distributionMask[i]);
 
-        final InetSocketAddress to = InetAddrCache.get(InetAddress.getByAddress(target), e.port);
+        InetSocketAddress to = InetAddrCache.get(InetAddress.getByAddress(target), e.port);
         sendPacket(to, toSend);
     }
 
-    private static void pushISA(final ByteQueue queue, final InetSocketAddress isa) {
+    private static void pushISA(ByteQueue queue, InetSocketAddress isa) {
         queue.push(isa.getAddress().getAddress());
         queue.pushU2B(isa.getPort());
     }
@@ -1120,11 +1090,11 @@ public class IpNetwork extends Network {
     // Foreign device registration (of this local device in a foreign BBMD)
     //
     public void sendForeignDeviceRegistration() throws BACnetException {
-        final InetSocketAddress addr = foreignBBMD;
+        InetSocketAddress addr = foreignBBMD;
         if (addr == null)
             return;
 
-        final ByteQueue queue = new ByteQueue();
+        ByteQueue queue = new ByteQueue();
         queue.push(BVLC_TYPE);
         queue.push(0x05); // Register foreign device
         queue.pushU2B(6); // Length
@@ -1136,7 +1106,7 @@ public class IpNetwork extends Network {
             sendPacket(addr, queue.popAll());
             try {
                 addr.wait(5000); // Wait up to 5 seconds.
-            } catch (@SuppressWarnings("unused") final InterruptedException e) {
+            } catch (@SuppressWarnings("unused") InterruptedException e) {
                 // no op
             }
 
@@ -1155,9 +1125,9 @@ public class IpNetwork extends Network {
      * @param fdtEntry the entry to remove
      * @throws BACnetException if something goes wrong
      */
-    public void deleteForeignDeviceTableEntry(final InetSocketAddress addr, final InetSocketAddress fdtEntry)
+    public void deleteForeignDeviceTableEntry(InetSocketAddress addr, InetSocketAddress fdtEntry)
             throws BACnetException {
-        final ByteQueue queue = new ByteQueue();
+        ByteQueue queue = new ByteQueue();
         queue.push(BVLC_TYPE);
         queue.push(0x08); // Delete foreign device table entry
         queue.pushU2B(0xA); // Length
@@ -1186,12 +1156,12 @@ public class IpNetwork extends Network {
 
             // Add a job to expire foreign device registrations.
             ftdMaintenance = getTransport().getLocalDevice().scheduleAtFixedRate(() -> {
-                final long now = getTransport().getLocalDevice().getClock().millis();
+                long now = getTransport().getLocalDevice().getClock().millis();
 
                 synchronized (foreignDeviceTable) {
-                    final List<FDTEntry> toRemove = new ArrayList<>();
+                    List<FDTEntry> toRemove = new ArrayList<>();
 
-                    for (final FDTEntry e : foreignDeviceTable) {
+                    for (FDTEntry e : foreignDeviceTable) {
                         if (e.endTime < now) {
                             LOG.debug("Removing expired foreign device: {}", e);
                             toRemove.add(e);

--- a/src/main/java/com/serotonin/bacnet4j/npdu/ipv6/Ipv6Network.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/ipv6/Ipv6Network.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
 
 import com.serotonin.bacnet4j.enums.MaxApduLength;
 import com.serotonin.bacnet4j.exception.BACnetException;
+import com.serotonin.bacnet4j.exception.BACnetRuntimeException;
 import com.serotonin.bacnet4j.npdu.MessageValidationException;
 import com.serotonin.bacnet4j.npdu.NPDU;
 import com.serotonin.bacnet4j.npdu.Network;
@@ -81,20 +82,19 @@ public class Ipv6Network extends Network implements Runnable {
 
     private final List<PendingAddressResolution> pendingAddressResolutions = new CopyOnWriteArrayList<>();
 
-    public Ipv6Network(final String multicastAddress) {
+    public Ipv6Network(String multicastAddress) {
         this(multicastAddress, DEFAULT_PORT);
     }
 
-    public Ipv6Network(final String multicastAddress, final int port) {
+    public Ipv6Network(String multicastAddress, int port) {
         this(multicastAddress, port, DEFAULT_BIND_ADDRESS);
     }
 
-    public Ipv6Network(final String multicastAddress, final int port, final String localBindAddress) {
+    public Ipv6Network(String multicastAddress, int port, String localBindAddress) {
         this(multicastAddress, port, localBindAddress, 0);
     }
 
-    public Ipv6Network(final String multicastAddress, final int port, final String localBindAddress,
-            final int localNetworkNumber) {
+    public Ipv6Network(String multicastAddress, int port, String localBindAddress, int localNetworkNumber) {
         super(localNetworkNumber);
         this.multicastAddress = multicastAddress;
         this.port = port;
@@ -133,6 +133,7 @@ public class Ipv6Network extends Network implements Runnable {
         return bytesIn;
     }
 
+    @Override
     public boolean isInitialized() {
         return thisVMAC != null;
     }
@@ -150,15 +151,20 @@ public class Ipv6Network extends Network implements Runnable {
     }
 
     @Override
-    public void initialize(final Transport transport) throws Exception {
+    public void initialize(Transport transport) throws BACnetException {
         super.initialize(transport);
 
-        if (DEFAULT_BIND_ADDRESS.equals(localBindAddress))
-            socket = new MulticastSocket(port);
-        else
-            socket = new MulticastSocket(new InetSocketAddress(InetAddress.getByName(localBindAddress), port));
-        final InetAddress ia = InetAddress.getByName(multicastAddress);
-        socket.joinGroup(ia);
+        InetAddress ia;
+        try {
+            if (DEFAULT_BIND_ADDRESS.equals(localBindAddress))
+                socket = new MulticastSocket(port);
+            else
+                socket = new MulticastSocket(new InetSocketAddress(InetAddress.getByName(localBindAddress), port));
+            ia = InetAddress.getByName(multicastAddress);
+            socket.joinGroup(ia);
+        } catch (IOException e) {
+            throw new BACnetException("Failed to initialize Ipv6 network", e);
+        }
 
         broadcastMAC = Ipv6NetworkUtils.toOctetString(ia.getAddress(), port);
 
@@ -166,9 +172,9 @@ public class Ipv6Network extends Network implements Runnable {
 
         try {
             vmacTable.put(thisVMAC, Ipv6NetworkUtils.toOctetString(InetAddress.getByName("::1").getAddress(), port));
-        } catch (final UnknownHostException e) {
+        } catch (UnknownHostException e) {
             // Should never happen
-            throw new RuntimeException(e);
+            throw new BACnetRuntimeException(e);
         }
 
         new Thread(this, "BACnet4J IPv6 socket listener").start();
@@ -191,11 +197,10 @@ public class Ipv6Network extends Network implements Runnable {
      *
      * @param addr       The address of the device where our device wants to be registered as foreign device
      * @param timeToLive The time until we are automatically removed out of the FDT.
-     * @throws BACnetException
+     * @throws BACnetException if the packet can't be sent
      */
-    public void sendRegisterForeignDeviceMessage(final InetSocketAddress addr, final int timeToLive)
-            throws BACnetException {
-        final ByteQueue queue = new ByteQueue();
+    public void sendRegisterForeignDeviceMessage(InetSocketAddress addr, int timeToLive) throws BACnetException {
+        ByteQueue queue = new ByteQueue();
         queue.push(BVLC_TYPE);
         queue.push(0x09); // Register-Foreign-Device
         queue.pushU2B(9); // Length
@@ -205,11 +210,11 @@ public class Ipv6Network extends Network implements Runnable {
     }
 
     @Override
-    public void sendNPDU(final Address recipient, final OctetString router, final ByteQueue npdu,
-            final boolean broadcast, final boolean expectsReply) throws BACnetException {
+    public void sendNPDU(Address recipient, OctetString router, ByteQueue npdu, boolean broadcast, boolean expectsReply)
+            throws BACnetException {
         LOG.debug("Sending npdu: recipient={}, router={}, npdu={}, broadcast={}", recipient, router, npdu, broadcast);
 
-        final ByteQueue queue = new ByteQueue();
+        ByteQueue queue = new ByteQueue();
 
         // BACnet virtual link layer detail
         queue.push(BVLC_TYPE);
@@ -230,24 +235,24 @@ public class Ipv6Network extends Network implements Runnable {
         // Combine the queues
         queue.push(npdu);
 
-        final OctetString dest = getDestination(recipient, router);
+        OctetString dest = getDestination(recipient, router);
 
         // Get the IP address for this destination.
         if (broadcast)
             sendPacket(Ipv6NetworkUtils.getInetSocketAddress(dest), queue.popAll());
         else {
-            final OctetString ipAddr = vmacTable.get(dest);
+            OctetString ipAddr = vmacTable.get(dest);
             if (ipAddr == null) {
                 purgePendingAddressResolutions();
 
                 // The IP address for this destination is not known. Queue the message and send an address
                 // resolution request.
-                final PendingAddressResolution par = new PendingAddressResolution();
+                PendingAddressResolution par = new PendingAddressResolution();
                 par.destination = dest;
                 par.data = queue.popAll();
                 pendingAddressResolutions.add(par);
 
-                final ByteQueue req = new ByteQueue();
+                ByteQueue req = new ByteQueue();
                 req.push(BVLC_TYPE);
                 req.push(0x3); // Function
                 req.pushU2B(0xa); // Length
@@ -260,13 +265,15 @@ public class Ipv6Network extends Network implements Runnable {
         }
     }
 
-    private void sendPacket(final InetSocketAddress addr, final byte[] data) throws BACnetException {
+    private void sendPacket(InetSocketAddress addr, byte[] data) throws BACnetException {
         try {
-            LOG.debug("Sending datagram to {}: {}", addr, StreamUtils.dumpArrayHex(data));
-            final DatagramPacket packet = new DatagramPacket(data, data.length, addr);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Sending datagram to {}: {}", addr, StreamUtils.dumpArrayHex(data));
+            }
+            DatagramPacket packet = new DatagramPacket(data, data.length, addr);
             socket.send(packet);
             bytesOut += data.length;
-        } catch (final IOException e) {
+        } catch (IOException e) {
             throw new BACnetException(e);
         }
     }
@@ -275,16 +282,16 @@ public class Ipv6Network extends Network implements Runnable {
     // For receiving
     @Override
     public void run() {
-        final byte[] buffer = new byte[MESSAGE_LENGTH];
-        final DatagramPacket p = new DatagramPacket(buffer, buffer.length);
+        byte[] buffer = new byte[MESSAGE_LENGTH];
+        DatagramPacket p = new DatagramPacket(buffer, buffer.length);
 
         while (!socket.isClosed()) {
             try {
                 socket.receive(p);
 
                 bytesIn += p.getLength();
-                final ByteQueue queue = new ByteQueue(p.getData(), p.getOffset(), p.getLength());
-                final OctetString link = Ipv6NetworkUtils.toOctetString(p.getAddress().getAddress(), p.getPort());
+                ByteQueue queue = new ByteQueue(p.getData(), p.getOffset(), p.getLength());
+                OctetString link = Ipv6NetworkUtils.toOctetString(p.getAddress().getAddress(), p.getPort());
 
                 LOG.debug("Received datagram from {}: {}", link, queue);
 
@@ -292,14 +299,14 @@ public class Ipv6Network extends Network implements Runnable {
 
                 // Reset the packet.
                 p.setData(buffer);
-            } catch (@SuppressWarnings("unused") final IOException e) {
+            } catch (@SuppressWarnings("unused") IOException e) {
                 // no op. This happens if the socket gets closed by the destroy method.
             }
         }
     }
 
     @Override
-    protected NPDU handleIncomingDataImpl(final ByteQueue queue, final OctetString fromIpv6) throws Exception {
+    protected NPDU handleIncomingDataImpl(ByteQueue queue, OctetString fromIpv6) throws BACnetException {
         if (queue.size() < 4)
             throw new MessageValidationException("Message too short to be BACnet/IPv6: " + queue + " from " + fromIpv6);
 
@@ -308,14 +315,14 @@ public class Ipv6Network extends Network implements Runnable {
         if (queue.pop() != BVLC_TYPE)
             throw new MessageValidationException("Protocol id is not BACnet/IPv6 (0x82)");
 
-        final byte function = queue.pop();
+        byte function = queue.pop();
 
-        final int length = BACnetUtils.popShort(queue);
+        int length = BACnetUtils.popShort(queue);
         if (length != queue.size() + 4)
             throw new MessageValidationException(
                     "Length field does not match data: given=" + length + ", expected=" + (queue.size() + 4));
 
-        final OctetString sourceVMAC = BACnetUtils.popDeviceId(queue);
+        OctetString sourceVMAC = BACnetUtils.popDeviceId(queue);
 
         // Add the resolution to the table
         vmacTable.put(sourceVMAC, fromIpv6);
@@ -324,23 +331,21 @@ public class Ipv6Network extends Network implements Runnable {
 
         if (function == 0x0) {
             // BVLC-Result. Currently can only be the answer to the foreign device registration request.
-            final int result = BACnetUtils.popShort(queue);
+            int result = BACnetUtils.popShort(queue);
             if (result != 0)
                 // TODO need to do something better here.
-                System.out.println("Foreign device registration not successful! result: " + result);
+                LOG.warn("Foreign device registration not successful! result: {}", result);
         } else if (function == 0x1 || function == 0x2) {
             // Original-Unicast-NPDU or Original-Broadcast-NPDU
-            //OctetString destinationVMAC = null;
             if (function == 0x1) // Unicast only
-                //destinationVMAC = BACnetUtils.popDeviceId(queue);
                 BACnetUtils.popDeviceId(queue);
             npdu = parseNpduData(queue, sourceVMAC);
         } else if (function == 0x3 || function == 0x4) {
             // Address-Resolution or Forwarded-Address-Resolution
-            final OctetString targetVMAC = BACnetUtils.popDeviceId(queue);
+            OctetString targetVMAC = BACnetUtils.popDeviceId(queue);
 
             // How is this source address used?
-            byte[] sourceIpv6Address = null;
+            byte[] sourceIpv6Address;
             if (function == 0x4) {
                 sourceIpv6Address = new byte[18];
                 queue.pop(sourceIpv6Address);
@@ -348,7 +353,7 @@ public class Ipv6Network extends Network implements Runnable {
 
             if (thisVMAC.equals(targetVMAC)) {
                 // This is the device you are looking for. Reply with an Address-Resolution-Ack
-                final ByteQueue ack = new ByteQueue();
+                ByteQueue ack = new ByteQueue();
                 ack.push(BVLC_TYPE);
                 ack.push(0x5); // Function
                 ack.pushU2B(0xa); // Length
@@ -358,11 +363,10 @@ public class Ipv6Network extends Network implements Runnable {
             }
         } else if (function == 0x5) {
             // Address-Resolution-Ack. Check the pending list for matching requests.
-            //OctetString destinationVMAC = BACnetUtils.popDeviceId(queue);
             BACnetUtils.popDeviceId(queue);
 
             List<PendingAddressResolution> matched = null;
-            for (final PendingAddressResolution par : pendingAddressResolutions) {
+            for (PendingAddressResolution par : pendingAddressResolutions) {
                 if (par.destination.equals(sourceVMAC)) {
                     if (matched == null)
                         matched = new ArrayList<>();
@@ -374,7 +378,7 @@ public class Ipv6Network extends Network implements Runnable {
                 pendingAddressResolutions.removeAll(matched);
         } else if (function == 0x6) {
             // Virtual-Address-Resolution. Reply with a Virtual-Address-Resolution-Ack
-            final ByteQueue ack = new ByteQueue();
+            ByteQueue ack = new ByteQueue();
             ack.push(BVLC_TYPE);
             ack.push(0x7); // Function
             ack.pushU2B(0xa); // Length
@@ -383,11 +387,10 @@ public class Ipv6Network extends Network implements Runnable {
             sendPacket(Ipv6NetworkUtils.getInetSocketAddress(fromIpv6), queue.popAll());
         } else if (function == 0x7) {
             // Virtual-Address-Resolution-Ack.
-            //OctetString destinationVMAC = BACnetUtils.popDeviceId(queue);
             BACnetUtils.popDeviceId(queue);
         } else if (function == 0x8) {
             // Forwarded-NPDU. Use the address/port as the link service address.
-            final byte[] addr = new byte[18];
+            byte[] addr = new byte[18];
             queue.pop(addr);
             vmacTable.put(sourceVMAC, new OctetString(addr));
             npdu = parseNpduData(queue, sourceVMAC);
@@ -413,9 +416,9 @@ public class Ipv6Network extends Network implements Runnable {
     }
 
     private void purgePendingAddressResolutions() {
-        final long now = getTransport().getLocalDevice().getClock().millis();
+        long now = getTransport().getLocalDevice().getClock().millis();
         List<PendingAddressResolution> toRemove = null;
-        for (final PendingAddressResolution par : pendingAddressResolutions) {
+        for (PendingAddressResolution par : pendingAddressResolutions) {
             if (par.deadline < now) {
                 if (toRemove == null)
                     toRemove = new ArrayList<>();

--- a/src/main/java/com/serotonin/bacnet4j/npdu/mstp/ManagerNode.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/mstp/ManagerNode.java
@@ -35,6 +35,8 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.serotonin.bacnet4j.exception.BACnetException;
+import com.serotonin.bacnet4j.exception.BACnetRuntimeException;
 import com.serotonin.bacnet4j.transport.Transport;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
@@ -151,7 +153,7 @@ public class ManagerNode extends MstpNode {
     }
 
     @Override
-    public void initialize(Transport transport) throws Exception {
+    public void initialize(Transport transport) throws BACnetException {
         super.initialize(transport);
 
         transport.getLocalDevice().getDeviceObject().writePropertyInternal(PropertyIdentifier.maxManager,
@@ -163,7 +165,7 @@ public class ManagerNode extends MstpNode {
     public void queueFrame(FrameType type, byte destination, byte[] data) {
         if (!type.oneOf(FrameType.bacnetDataExpectingReply, FrameType.bacnetDataNotExpectingReply,
                 FrameType.testRequest))
-            throw new RuntimeException("Cannot send frame of type: " + type);
+            throw new BACnetRuntimeException("Cannot send frame of type: " + type);
 
         Frame frame = new Frame(type, destination, thisStation, data);
         synchronized (framesToSend) {
@@ -304,7 +306,7 @@ public class ManagerNode extends MstpNode {
                 LOG.debug("useToken:SendAndWait ({})", frameToSend.getDestinationAddress());
                 state = ManagerNodeState.waitForReply;
             } else {
-                throw new RuntimeException("Unhandled frame type: " + frameToSend.getFrameType());
+                throw new BACnetRuntimeException("Unhandled frame type: " + frameToSend.getFrameType());
             }
 
             sendFrame(frameToSend);

--- a/src/main/java/com/serotonin/bacnet4j/npdu/mstp/MstpNetwork.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/mstp/MstpNetwork.java
@@ -29,6 +29,7 @@ package com.serotonin.bacnet4j.npdu.mstp;
 
 import com.serotonin.bacnet4j.enums.MaxApduLength;
 import com.serotonin.bacnet4j.exception.BACnetException;
+import com.serotonin.bacnet4j.exception.BACnetRuntimeException;
 import com.serotonin.bacnet4j.npdu.MessageValidationException;
 import com.serotonin.bacnet4j.npdu.NPDU;
 import com.serotonin.bacnet4j.npdu.Network;
@@ -61,7 +62,7 @@ public class MstpNetwork extends Network {
     }
 
     @Override
-    public void initialize(Transport transport) throws Exception {
+    public void initialize(Transport transport) throws BACnetException {
         super.initialize(transport);
         node.initialize(transport);
     }
@@ -111,7 +112,7 @@ public class MstpNetwork extends Network {
 
         if (expectsReply) {
             if (node instanceof SubordinateNode)
-                throw new RuntimeException("Cannot originate a request from a subordinate node");
+                throw new BACnetRuntimeException("Cannot originate a request from a subordinate node");
 
             ((ManagerNode) node).queueFrame(FrameType.bacnetDataExpectingReply, mstpAddress, data);
         } else
@@ -119,9 +120,9 @@ public class MstpNetwork extends Network {
     }
 
     public void sendTestRequest(byte destination) {
-        if (!(node instanceof ManagerNode))
-            throw new RuntimeException("Only manager nodes can send test requests");
-        ((ManagerNode) node).queueFrame(FrameType.testRequest, destination, null);
+        if (!(node instanceof ManagerNode mNode))
+            throw new BACnetRuntimeException("Only manager nodes can send test requests");
+        mNode.queueFrame(FrameType.testRequest, destination, null);
     }
 
     //
@@ -144,30 +145,5 @@ public class MstpNetwork extends Network {
     //
     public Address getAddress(byte station) {
         return MstpNetworkUtils.toAddress(getLocalNetworkNumber(), station);
-    }
-
-    @Override
-    public int hashCode() {
-        int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + (node == null ? 0 : node.hashCode());
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (!super.equals(obj))
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        MstpNetwork other = (MstpNetwork) obj;
-        if (node == null) {
-            if (other.node != null)
-                return false;
-        } else if (!node.equals(other.node))
-            return false;
-        return true;
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/npdu/mstp/MstpNode.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/mstp/MstpNode.java
@@ -32,16 +32,18 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.time.Clock;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.serotonin.bacnet4j.exception.BACnetException;
+import com.serotonin.bacnet4j.exception.BACnetRuntimeException;
 import com.serotonin.bacnet4j.transport.Transport;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
 import com.serotonin.bacnet4j.util.sero.SerialPortWrapper;
 import com.serotonin.bacnet4j.util.sero.StreamUtils;
 
-abstract public class MstpNode implements Runnable {
+public abstract class MstpNode implements Runnable {
     private static final Logger LOG = LoggerFactory.getLogger(MstpNode.class);
 
     private static final byte PREAMBLE1 = 0x55;
@@ -92,17 +94,17 @@ abstract public class MstpNode implements Runnable {
     protected long bytesOut;
     protected long bytesIn;
 
-    public MstpNode(final SerialPortWrapper wrapper, final byte thisStation) {
+    protected MstpNode(SerialPortWrapper wrapper, byte thisStation) {
         this(wrapper.getCommPortId(), wrapper, thisStation);
     }
 
-    public MstpNode(final String portId, final SerialPortWrapper wrapper, final byte thisStation) {
+    protected MstpNode(String portId, SerialPortWrapper wrapper, byte thisStation) {
         this.portId = portId;
         this.wrapper = wrapper;
         this.thisStation = thisStation;
     }
 
-    public MstpNode(final String portId, final InputStream in, final OutputStream out, final byte thisStation) {
+    protected MstpNode(String portId, InputStream in, OutputStream out, byte thisStation) {
         this.portId = portId;
         this.in = in;
         this.out = out;
@@ -113,7 +115,7 @@ abstract public class MstpNode implements Runnable {
         return portId;
     }
 
-    public void initialize(final Transport transport) throws Exception {
+    public void initialize(Transport transport) throws BACnetException {
         this.clock = transport.getLocalDevice().getClock();
         initialize(true);
     }
@@ -126,10 +128,14 @@ abstract public class MstpNode implements Runnable {
         return bytesIn;
     }
 
-    public void initialize(final boolean runInThread) throws Exception {
+    public void initialize(boolean runInThread) throws BACnetException {
         if (!running) {
             if (wrapper != null) {
-                wrapper.open();
+                try {
+                    wrapper.open();
+                } catch (Exception e) {
+                    throw new BACnetException(e);
+                }
                 in = wrapper.getInputStream();
                 out = wrapper.getOutputStream();
             }
@@ -149,20 +155,20 @@ abstract public class MstpNode implements Runnable {
         if (thread != null) {
             try {
                 thread.join();
-            } catch (final InterruptedException e) {
-                throw new RuntimeException(e);
+            } catch (InterruptedException e) {
+                throw new BACnetRuntimeException(e);
             }
         }
 
         try {
             if (wrapper != null)
                 wrapper.close();
-        } catch (final Exception e) {
+        } catch (Exception e) {
             LOG.warn("", e);
         }
     }
 
-    public void setNetwork(final MstpNetwork network) {
+    public void setNetwork(MstpNetwork network) {
         this.network = network;
     }
 
@@ -254,22 +260,16 @@ abstract public class MstpNode implements Runnable {
             if (!activity && inactivityDelay > 0) {
                 try {
                     Thread.sleep(inactivityDelay);
-                } catch (final InterruptedException e) {
-                    throw new RuntimeException(e);
+                } catch (InterruptedException e) {
+                    throw new BACnetRuntimeException(e);
                 }
             }
         }
-        //
-        //        try {
-        //            wrapper.close();
-        //        } catch (final Exception e) {
-        //            LOG.warn("", e);
-        //        }
     }
 
-    abstract protected void doCycle();
+    protected abstract void doCycle();
 
-    abstract public void setReplyFrame(FrameType type, byte destination, byte[] data);
+    public abstract void setReplyFrame(FrameType type, byte destination, byte[] data);
 
     protected void readFrame() {
         readInputStream();
@@ -312,17 +312,17 @@ abstract public class MstpNode implements Runnable {
             if (in.available() > 0) {
                 readCount = in.read(readArray);
                 bytesIn += readCount;
-                if (LOG.isTraceEnabled())
-                    LOG.trace(tracePrefix() + "in: " + StreamUtils.dumpArrayHex(readArray, 0, readCount));
+                if (LOG.isTraceEnabled()) {
+                    LOG.trace("{} in: {}", tracePrefix(), StreamUtils.dumpArrayHex(readArray, 0, readCount));
+                }
                 inputBuffer.push(readArray, 0, readCount);
                 eventCount += readCount;
-                //noise();
             }
-        } catch (final IOException e) {
-            if (StringUtils.equals(e.getMessage(), "Stream closed."))
-                throw new RuntimeException(e);
-            if (LOG.isDebugEnabled())
-                LOG.debug(thisStation + " Input stream listener exception", e);
+        } catch (IOException e) {
+            if (Strings.CS.equals(e.getMessage(), "Stream closed.")) {
+                throw new BACnetRuntimeException(e);
+            }
+            LOG.debug("{} Input stream listener exception", thisStation, e);
             receiveError = true;
         }
     }
@@ -348,8 +348,7 @@ abstract public class MstpNode implements Runnable {
     private void preamble() {
         if (silence() > Constants.FRAME_ABORT) {
             // Timeout
-            if (LOG.isDebugEnabled())
-                LOG.debug(thisStation + " Frame abort due to timeout");
+            LOG.debug("{} Frame abort due to timeout", thisStation);
             state = ReadFrameState.idle;
             activity = true;
         } else {
@@ -382,8 +381,7 @@ abstract public class MstpNode implements Runnable {
         if (silence() > Constants.FRAME_ABORT) {
             // Timeout
             receivedInvalidFrame = "Timeout reading header";
-            if (LOG.isDebugEnabled())
-                LOG.debug(thisStation + " Timeout reading header: index=" + index + ", frame=" + frame);
+            LOG.debug("{} Timeout reading header: index={}, frame={}", thisStation, index, frame);
             state = ReadFrameState.idle;
             activity = true;
         } else {
@@ -397,7 +395,7 @@ abstract public class MstpNode implements Runnable {
                     headerCRC.accumulate(b);
                     frame.setFrameType(FrameType.forId(b));
                     if (LOG.isTraceEnabled() && frame.getFrameType() == null)
-                        LOG.trace(tracePrefix() + "Unknown frame type for value: " + b);
+                        LOG.trace("{} Unknown frame type for value: {}", tracePrefix(), b);
                     index = 1;
                 } else if (index == 1) {
                     // Destination
@@ -447,8 +445,9 @@ abstract public class MstpNode implements Runnable {
             } else if (frame.getLength() == 0) {
                 // NoData
                 receivedValidFrame = true;
-                if (frame.getFrameType() == null && LOG.isDebugEnabled())
-                    LOG.debug(thisStation + " Received valid frame with no type (1): " + frame);
+                if (frame.getFrameType() == null && LOG.isDebugEnabled()) {
+                    LOG.debug("{} Received valid frame with no type (1): {}", thisStation, frame);
+                }
                 state = ReadFrameState.idle;
             } else {
                 // Data
@@ -470,7 +469,7 @@ abstract public class MstpNode implements Runnable {
             while (inputBuffer.size() > 0) {
                 activity = true;
                 noise();
-                final byte b = inputBuffer.pop();
+                byte b = inputBuffer.pop();
 
                 if (index < frame.getLength()) {
                     // DataOctet
@@ -500,18 +499,19 @@ abstract public class MstpNode implements Runnable {
         else {
             // GoodCRC
             receivedValidFrame = true;
-            if (frame.getFrameType() == null && LOG.isDebugEnabled())
-                LOG.debug(thisStation + " Received valid frame with no type (2): " + frame);
+            if (frame.getFrameType() == null && LOG.isDebugEnabled()) {
+                LOG.debug("{} Received valid frame with no type (2): {}", thisStation, frame);
+            }
         }
 
         state = ReadFrameState.idle;
     }
 
-    protected void sendFrame(final FrameType type, final byte destinationAddress) {
+    protected void sendFrame(FrameType type, byte destinationAddress) {
         sendFrame(type, destinationAddress, null);
     }
 
-    protected void sendFrame(final FrameType type, final byte destinationAddress, final byte[] data) {
+    protected void sendFrame(FrameType type, byte destinationAddress, byte[] data) {
         sendFrame.reset();
         sendFrame.setFrameType(type);
         sendFrame.setDestinationAddress(destinationAddress);
@@ -520,29 +520,15 @@ abstract public class MstpNode implements Runnable {
         sendFrame(sendFrame);
     }
 
-    public void testSendFrame(final Frame frame) {
+    public void testSendFrame(Frame frame) {
         sendFrame(frame);
     }
 
-    protected void sendFrame(final Frame frame) {
-        //        long start = clock.millis();
-
-        // Turnaround. 40 bit times at 9600 baud is around 4ms.
-        //        long wait = 4 - silence();
-        //        if (wait > 0) {
-        //            debug("Turnaround wait time: " + wait);
-        //            try {
-        //                Thread.sleep(wait);
-        //            }
-        //            catch (InterruptedException e) {
-        //                // no op
-        //            }
-        //        }
-
+    protected void sendFrame(Frame frame) {
         try {
-            if (LOG.isTraceEnabled())
-                LOG.trace(tracePrefix() + "out: " + frame);
-            //LOG.fine("writing frame: " + frame);
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("{} out: {}", tracePrefix(), frame);
+            }
 
             // Preamble
             out.write(0x55);
@@ -560,17 +546,17 @@ abstract public class MstpNode implements Runnable {
             if (frame.getLength() > 0) {
                 // Data
                 out.write(frame.getData());
-                final int crc = sendDataCRC.getCrc(frame);
+                int crc = sendDataCRC.getCrc(frame);
                 out.write(crc & 0xff);
                 out.write(crc >> 8 & 0xff);
                 bytesOut += frame.getLength() + 2;
             }
 
             out.flush();
-        } catch (final IOException e) {
+        } catch (IOException e) {
             // Only write the same error message once. Prevents logs from getting filled up unnecessarily with repeated
             // error messages.
-            if (!StringUtils.equals(e.getMessage(), lastWriteError)) {
+            if (!Strings.CS.equals(e.getMessage(), lastWriteError)) {
                 // NOTE: should anything else be informed of this?
                 LOG.error("Error while sending frame", e);
                 lastWriteError = e.getMessage();
@@ -578,8 +564,6 @@ abstract public class MstpNode implements Runnable {
         }
 
         noise();
-
-        //        debug("Write took " + (clock.millis() - start) + " ms");
 
         // NOTE: ??
         // Wait until the final stop bit of the most significant CRC octet has been transmitted
@@ -598,47 +582,22 @@ abstract public class MstpNode implements Runnable {
     //
     // Incoming message handling
     //
-    protected void receivedDataNoReply(final Frame frame) {
+    protected void receivedDataNoReply(Frame frame) {
         if (frame.getFrameType() == FrameType.testResponse)
             LOG.info("Received test response frame");
         else if (network == null)
-            LOG.info("Received data no reply: " + frame);
+            LOG.info("Received data no reply: {}", frame);
         else
             network.receivedFrame(frame.copy());
     }
 
-    protected void receivedDataNeedingReply(final Frame frame) {
+    protected void receivedDataNeedingReply(Frame frame) {
         if (frame.getFrameType() == FrameType.testRequest)
             // Echo the data back.
             sendFrame(FrameType.testResponse, frame.getSourceAddress(), frame.getData());
         else if (network == null)
-            LOG.info("Received data needing reply: " + frame);
+            LOG.info("Received data needing reply: {}", frame);
         else
             network.receivedFrame(frame.copy());
-    }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + (portId == null ? 0 : portId.hashCode());
-        return result;
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        final MstpNode other = (MstpNode) obj;
-        if (portId == null) {
-            if (other.portId != null)
-                return false;
-        } else if (!portId.equals(other.portId))
-            return false;
-        return true;
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/npdu/mstp/RealtimeManagerNode.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/mstp/RealtimeManagerNode.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.serotonin.bacnet4j.exception.BACnetException;
 import com.serotonin.bacnet4j.npdu.mstp.realtime.RealtimeDriver;
 import com.serotonin.bacnet4j.transport.Transport;
 import com.serotonin.bacnet4j.util.sero.StreamUtils;
@@ -73,15 +74,19 @@ public class RealtimeManagerNode extends ManagerNode {
     }
 
     @Override
-    public void initialize(Transport transport) throws Exception {
-        //Setup I/O
-        File file = new File(portId);
-        in = new FileInputStream(file);
-        out = new FileOutputStream(file);
+    public void initialize(Transport transport) throws BACnetException {
+        try {
+            //Setup I/O
+            File file = new File(portId);
+            in = new FileInputStream(file);
+            out = new FileOutputStream(file);
 
-        //Configure Driver
-        this.driver.configure(portId, baud, thisStation, maxManager, maxInfoFrames, usageTimeout);
-        super.initialize(transport);
+            //Configure Driver
+            this.driver.configure(portId, baud, thisStation, maxManager, maxInfoFrames, usageTimeout);
+            super.initialize(transport);
+        } catch (Exception e) {
+            throw new BACnetException(e);
+        }
     }
 
     @Override

--- a/src/main/java/com/serotonin/bacnet4j/npdu/sc/SCNetwork.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/sc/SCNetwork.java
@@ -290,7 +290,7 @@ public class SCNetwork extends Network {
     }
 
     @Override
-    public void initialize(Transport transport) throws Exception {
+    public void initialize(Transport transport) throws BACnetException {
         super.initialize(transport);
 
         initializationError =
@@ -407,7 +407,7 @@ public class SCNetwork extends Network {
     }
 
     @Override
-    protected NPDU handleIncomingDataImpl(ByteQueue queue, OctetString linkService) throws Exception {
+    protected NPDU handleIncomingDataImpl(ByteQueue queue, OctetString linkService) throws BACnetException {
         return parseNpduData(queue, linkService);
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/npdu/test/TestNetwork.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/test/TestNetwork.java
@@ -49,7 +49,7 @@ import com.serotonin.bacnet4j.util.sero.ThreadUtils;
 
 /**
  * A network that is useful for unit tests as it simulates a BACnet network within
- * a single process. The static <code>instances</code> field keeps track of all of
+ * a single process. The static <code>instances</code> field keeps track of all
  * the currently available networks,
  */
 public class TestNetwork extends Network implements Runnable {
@@ -71,26 +71,24 @@ public class TestNetwork extends Network implements Runnable {
      * This is the list of outgoing messages queued up for sending.
      */
     private final Queue<SendData> queue = new ConcurrentLinkedQueue<>();
-    private long bytesOut;
-    private long bytesIn;
 
-    public TestNetwork(final TestNetworkMap map, final int address, final int sendDelay) {
+    public TestNetwork(TestNetworkMap map, int address, int sendDelay) {
         this(map, new NetworkSourceAddress(Address.LOCAL_NETWORK, new byte[] {(byte) address}), sendDelay);
     }
 
-    public TestNetwork(final TestNetworkMap map, final Address address, final int sendDelay) {
+    public TestNetwork(TestNetworkMap map, Address address, int sendDelay) {
         super(0);
         this.networkMap = map;
         this.address = address;
         this.sendDelay = sendDelay;
     }
 
-    public TestNetwork withTimeout(final int timeout) {
+    public TestNetwork withTimeout(int timeout) {
         this.timeout = timeout;
         return this;
     }
 
-    public TestNetwork withSegTimeout(final int segTimeout) {
+    public TestNetwork withSegTimeout(int segTimeout) {
         this.segTimeout = segTimeout;
         return this;
     }
@@ -107,16 +105,16 @@ public class TestNetwork extends Network implements Runnable {
 
     @Override
     public long getBytesOut() {
-        return bytesOut;
+        return 0;
     }
 
     @Override
     public long getBytesIn() {
-        return bytesIn;
+        return 0;
     }
 
     @Override
-    public void initialize(final Transport transport) throws Exception {
+    public void initialize(Transport transport) throws BACnetException {
         super.initialize(transport);
 
         running = true;
@@ -157,14 +155,14 @@ public class TestNetwork extends Network implements Runnable {
     }
 
     @Override
-    public Address getSourceAddress(final APDU apdu) {
+    public Address getSourceAddress(APDU apdu) {
         return address;
     }
 
     @Override
-    public void sendNPDU(final Address recipient, final OctetString router, final ByteQueue npdu,
-            final boolean broadcast, final boolean expectsReply) throws BACnetException {
-        final SendData d = new SendData();
+    public void sendNPDU(Address recipient, OctetString router, ByteQueue npdu, boolean broadcast, boolean expectsReply)
+            throws BACnetException {
+        SendData d = new SendData();
         d.recipient = recipient;
         d.data = npdu.popAll();
 
@@ -176,7 +174,7 @@ public class TestNetwork extends Network implements Runnable {
     public void run() {
         while (running) {
             // Check for a message to send.
-            final SendData d = queue.poll();
+            SendData d = queue.poll();
 
             if (d == null)
                 ThreadUtils.waitSync(queue, 2);
@@ -186,11 +184,11 @@ public class TestNetwork extends Network implements Runnable {
 
                 if (d.recipient.equals(getLocalBroadcastAddress()) || d.recipient.equals(Address.GLOBAL)) {
                     // A broadcast. Send to everyone.
-                    for (final TestNetwork network : networkMap)
+                    for (TestNetwork network : networkMap)
                         receive(network, d.data);
                 } else {
                     // A directed message. Find the network to pass it to.
-                    final TestNetwork network = networkMap.get(d.recipient);
+                    TestNetwork network = networkMap.get(d.recipient);
                     if (network != null)
                         receive(network, d.data);
                 }
@@ -200,17 +198,14 @@ public class TestNetwork extends Network implements Runnable {
 
     /**
      * Passes the the data over to the given network instance.
-     *
-     * @param recipient
-     * @param data
      */
-    private void receive(final TestNetwork recipient, final byte[] data) {
+    private void receive(TestNetwork recipient, byte[] data) {
         LOG.debug("Sending data from {} to {}", address, recipient.address);
         recipient.handleIncomingData(new ByteQueue(data), address.getMacAddress());
     }
 
     @Override
-    protected NPDU handleIncomingDataImpl(final ByteQueue queue, final OctetString linkService)
+    protected NPDU handleIncomingDataImpl(ByteQueue queue, OctetString linkService)
             throws MessageValidationException {
         return parseNpduData(queue, linkService);
     }

--- a/src/main/java/com/serotonin/bacnet4j/obj/AlertEnrollmentObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/AlertEnrollmentObject.java
@@ -41,16 +41,17 @@ import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
 import com.serotonin.bacnet4j.type.notificationParameters.ExtendedNotif.Parameter;
 import com.serotonin.bacnet4j.type.primitive.Boolean;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
+import com.serotonin.bacnet4j.type.primitive.Unsigned16;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
 public class AlertEnrollmentObject extends BACnetObject {
     static final Logger LOG = LoggerFactory.getLogger(AlertEnrollmentObject.class);
 
     private final AlertReportingMixin alertReporting;
-    private final UnsignedInteger defaultVendorId;
+    private final Unsigned16 defaultVendorId;
 
-    public AlertEnrollmentObject(final LocalDevice localDevice, final int instanceNumber, final String name,
-            final int notificationClass, final NotifyType notifyType) {
+    public AlertEnrollmentObject(LocalDevice localDevice, int instanceNumber, String name, int notificationClass,
+            NotifyType notifyType) {
         super(localDevice, ObjectType.alertEnrollment, instanceNumber, name);
 
         defaultVendorId = localDevice.get(PropertyIdentifier.vendorIdentifier);
@@ -69,13 +70,12 @@ public class AlertEnrollmentObject extends BACnetObject {
         addMixin(alertReporting);
     }
 
-    public void issueAlert(final ObjectIdentifier alertSource, final int extendedEventType,
-            final Parameter... parameters) {
+    public void issueAlert(ObjectIdentifier alertSource, int extendedEventType, Parameter... parameters) {
         issueAlert(alertSource, defaultVendorId, extendedEventType, parameters);
     }
 
-    public void issueAlert(final ObjectIdentifier alertSource, final UnsignedInteger vendorId,
-            final int extendedEventType, final Parameter... parameters) {
+    public void issueAlert(ObjectIdentifier alertSource, Unsigned16 vendorId, int extendedEventType,
+            Parameter... parameters) {
         // Delegate to the mixin
         alertReporting.issueAlert(alertSource, vendorId, new UnsignedInteger(extendedEventType), parameters);
     }

--- a/src/main/java/com/serotonin/bacnet4j/obj/DeviceObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/DeviceObject.java
@@ -86,7 +86,7 @@ public class DeviceObject extends BACnetObject {
 
         writePropertyInternal(PropertyIdentifier.maxApduLengthAccepted,
                 new UnsignedInteger(MaxApduLength.UP_TO_1476.getMaxLengthInt()));
-        writePropertyInternal(PropertyIdentifier.vendorIdentifier, new UnsignedInteger(VENDOR_ID));
+        writePropertyInternal(PropertyIdentifier.vendorIdentifier, new Unsigned16(VENDOR_ID));
         writePropertyInternal(PropertyIdentifier.vendorName, new CharacterString("Radix IoT LLC"));
         writePropertyInternal(PropertyIdentifier.segmentationSupported, Segmentation.segmentedBoth);
         writePropertyInternal(PropertyIdentifier.maxSegmentsAccepted, new UnsignedInteger(Integer.MAX_VALUE));
@@ -142,8 +142,8 @@ public class DeviceObject extends BACnetObject {
         //        servicesSupported.setConfirmedAuditNotification(true);
         //        servicesSupported.setAuditLogQuery(true);
         //        servicesSupported.setUnconfirmedAuditNotification(true);
-        //        servicesSupported.setWhoAmI(true);
-        //        servicesSupported.setYouAre(true);
+        servicesSupported.setWhoAmI(true);
+        servicesSupported.setYouAre(true);
         //        servicesSupported.setAuthRequest(true);
 
         writePropertyInternal(PropertyIdentifier.protocolServicesSupported, servicesSupported);
@@ -223,7 +223,7 @@ public class DeviceObject extends BACnetObject {
         writePropertyInternal(PropertyIdentifier.firmwareRevision, new CharacterString("not set"));
         writePropertyInternal(PropertyIdentifier.applicationSoftwareVersion, new CharacterString(LocalDevice.VERSION));
         writePropertyInternal(PropertyIdentifier.protocolVersion, new UnsignedInteger(1));
-        writePropertyInternal(PropertyIdentifier.protocolRevision, new UnsignedInteger(21));
+        writePropertyInternal(PropertyIdentifier.protocolRevision, new UnsignedInteger(22));
 
         UnsignedInteger databaseRevision = getLocalDevice().getPersistence()
                 .loadEncodable(getPersistenceKey(PropertyIdentifier.databaseRevision), UnsignedInteger.class);

--- a/src/main/java/com/serotonin/bacnet4j/obj/mixin/event/AlertReportingMixin.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/mixin/event/AlertReportingMixin.java
@@ -41,6 +41,7 @@ import com.serotonin.bacnet4j.type.notificationParameters.ExtendedNotif;
 import com.serotonin.bacnet4j.type.notificationParameters.ExtendedNotif.Parameter;
 import com.serotonin.bacnet4j.type.notificationParameters.NotificationParameters;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
+import com.serotonin.bacnet4j.type.primitive.Unsigned16;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
 /**
@@ -50,16 +51,16 @@ import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
  */
 public class AlertReportingMixin extends EventReportingMixin {
     private ObjectIdentifier alertSource;
-    private UnsignedInteger vendorId;
+    private Unsigned16 vendorId;
     private UnsignedInteger extendedEventType;
     private Parameter[] parameters;
 
-    public AlertReportingMixin(final BACnetObject bo) {
+    public AlertReportingMixin(BACnetObject bo) {
         super(bo, null, null);
     }
 
-    public void issueAlert(final ObjectIdentifier alertSource, final UnsignedInteger vendorId,
-            final UnsignedInteger extendedEventType, final Parameter[] parameters) {
+    public void issueAlert(ObjectIdentifier alertSource, Unsigned16 vendorId, UnsignedInteger extendedEventType,
+            Parameter[] parameters) {
         writePropertyInternal(PropertyIdentifier.presentValue, alertSource);
 
         this.alertSource = alertSource;
@@ -71,12 +72,12 @@ public class AlertReportingMixin extends EventReportingMixin {
     }
 
     @Override
-    protected StateTransition evaluateEventState(final BACnetObject bo, final EventAlgorithm eventAlgo) {
+    protected StateTransition evaluateEventState(BACnetObject bo, EventAlgorithm eventAlgo) {
         return null;
     }
 
     @Override
-    protected EventType getEventType(final EventAlgorithm eventAlgo) {
+    protected EventType getEventType(EventAlgorithm eventAlgo) {
         return EventType.extended;
     }
 
@@ -86,22 +87,22 @@ public class AlertReportingMixin extends EventReportingMixin {
     }
 
     @Override
-    protected NotificationParameters getNotificationParameters(final EventState fromState, final EventState toState,
-            final BACnetObject bo, final EventAlgorithm eventAlgo) {
-        final SequenceOf<Parameter> params = new SequenceOf<>(new Parameter(alertSource));
-        for (final Parameter p : parameters)
+    protected NotificationParameters getNotificationParameters(EventState fromState, EventState toState,
+            BACnetObject bo, EventAlgorithm eventAlgo) {
+        SequenceOf<Parameter> params = new SequenceOf<>(new Parameter(alertSource));
+        for (Parameter p : parameters)
             params.add(p);
         return new NotificationParameters(new ExtendedNotif(vendorId, extendedEventType, params));
     }
 
     @Override
-    protected Reliability evaluateFaultState(final Encodable oldMonitoredValue, final Encodable newMonitoredValue,
-            final BACnetObject bo, final FaultAlgorithm faultAlgo) {
+    protected Reliability evaluateFaultState(Encodable oldMonitoredValue, Encodable newMonitoredValue, BACnetObject bo,
+            FaultAlgorithm faultAlgo) {
         return null;
     }
 
     @Override
-    protected PropertyValue getEventEnrollmentMonitoredProperty(final PropertyIdentifier pid) {
+    protected PropertyValue getEventEnrollmentMonitoredProperty(PropertyIdentifier pid) {
         throw new RuntimeException("Should not be called because AlertEnrollment does not support intrinsic reporting");
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/service/unconfirmed/IAmRequest.java
+++ b/src/main/java/com/serotonin/bacnet4j/service/unconfirmed/IAmRequest.java
@@ -27,6 +27,8 @@
 
 package com.serotonin.bacnet4j.service.unconfirmed;
 
+import java.util.Objects;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,6 +40,7 @@ import com.serotonin.bacnet4j.type.enumerated.ObjectType;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
 import com.serotonin.bacnet4j.type.enumerated.Segmentation;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
+import com.serotonin.bacnet4j.type.primitive.Unsigned16;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
 
@@ -49,22 +52,22 @@ public class IAmRequest extends UnconfirmedRequestService {
     private final ObjectIdentifier iAmDeviceIdentifier;
     private final UnsignedInteger maxAPDULengthAccepted;
     private final Segmentation segmentationSupported;
-    private final UnsignedInteger vendorId;
+    private final Unsigned16 vendorId;
 
     /**
      * This field allows us to properly implement 16.1.2.
      */
     private boolean isResponseToWhoIs;
 
-    public IAmRequest(final ObjectIdentifier iamDeviceIdentifier, final UnsignedInteger maxAPDULengthAccepted,
-            final Segmentation segmentationSupported, final UnsignedInteger vendorId) {
+    public IAmRequest(ObjectIdentifier iamDeviceIdentifier, UnsignedInteger maxAPDULengthAccepted,
+            Segmentation segmentationSupported, Unsigned16 vendorId) {
         this.iAmDeviceIdentifier = iamDeviceIdentifier;
         this.maxAPDULengthAccepted = maxAPDULengthAccepted;
         this.segmentationSupported = segmentationSupported;
         this.vendorId = vendorId;
     }
 
-    public IAmRequest withIsResponseToWhoIs(final boolean isResponseToWhoIs) {
+    public IAmRequest withIsResponseToWhoIs(boolean isResponseToWhoIs) {
         this.isResponseToWhoIs = isResponseToWhoIs;
         return this;
     }
@@ -79,18 +82,18 @@ public class IAmRequest extends UnconfirmedRequestService {
     }
 
     @Override
-    public void handle(final LocalDevice localDevice, final Address from) {
+    public void handle(LocalDevice localDevice, Address from) {
         if (!ObjectType.device.equals(iAmDeviceIdentifier.getObjectType())) {
             LOG.warn("Received IAm from an object that is not a device from {}", from);
             return;
         }
 
         // Make sure we're not hearing from ourselves.
-        final int myDoi = localDevice.getInstanceNumber();
-        final int remoteDoi = iAmDeviceIdentifier.getInstanceNumber();
+        int myDoi = localDevice.getInstanceNumber();
+        int remoteDoi = iAmDeviceIdentifier.getInstanceNumber();
         if (remoteDoi == myDoi) {
             // Get my bacnet address and compare the addresses
-            for (final Address addr : localDevice.getAllLocalAddresses()) {
+            for (Address addr : localDevice.getAllLocalAddresses()) {
                 if (addr.getMacAddress().equals(from.getMacAddress()))
                     // This is a local address, so ignore.
                     return;
@@ -113,60 +116,34 @@ public class IAmRequest extends UnconfirmedRequestService {
     }
 
     @Override
-    public void write(final ByteQueue queue) {
+    public void write(ByteQueue queue) {
         write(queue, iAmDeviceIdentifier);
         write(queue, maxAPDULengthAccepted);
         write(queue, segmentationSupported);
         write(queue, vendorId);
     }
 
-    public IAmRequest(final ByteQueue queue) throws BACnetException {
+    public IAmRequest(ByteQueue queue) throws BACnetException {
         iAmDeviceIdentifier = read(queue, ObjectIdentifier.class);
         maxAPDULengthAccepted = read(queue, UnsignedInteger.class);
         segmentationSupported = read(queue, Segmentation.class);
-        vendorId = read(queue, UnsignedInteger.class);
+        vendorId = read(queue, Unsigned16.class);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass())
+            return false;
+        IAmRequest that = (IAmRequest) o;
+        return isResponseToWhoIs == that.isResponseToWhoIs && Objects.equals(iAmDeviceIdentifier,
+                that.iAmDeviceIdentifier) && Objects.equals(maxAPDULengthAccepted,
+                that.maxAPDULengthAccepted) && Objects.equals(segmentationSupported,
+                that.segmentationSupported) && Objects.equals(vendorId, that.vendorId);
     }
 
     @Override
     public int hashCode() {
-        final int PRIME = 31;
-        int result = 1;
-        result = PRIME * result + (iAmDeviceIdentifier == null ? 0 : iAmDeviceIdentifier.hashCode());
-        result = PRIME * result + (maxAPDULengthAccepted == null ? 0 : maxAPDULengthAccepted.hashCode());
-        result = PRIME * result + (segmentationSupported == null ? 0 : segmentationSupported.hashCode());
-        result = PRIME * result + (vendorId == null ? 0 : vendorId.hashCode());
-        return result;
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        final IAmRequest other = (IAmRequest) obj;
-        if (iAmDeviceIdentifier == null) {
-            if (other.iAmDeviceIdentifier != null)
-                return false;
-        } else if (!iAmDeviceIdentifier.equals(other.iAmDeviceIdentifier))
-            return false;
-        if (maxAPDULengthAccepted == null) {
-            if (other.maxAPDULengthAccepted != null)
-                return false;
-        } else if (!maxAPDULengthAccepted.equals(other.maxAPDULengthAccepted))
-            return false;
-        if (segmentationSupported == null) {
-            if (other.segmentationSupported != null)
-                return false;
-        } else if (!segmentationSupported.equals(other.segmentationSupported))
-            return false;
-        if (vendorId == null) {
-            if (other.vendorId != null)
-                return false;
-        } else if (!vendorId.equals(other.vendorId))
-            return false;
-        return true;
+        return Objects.hash(iAmDeviceIdentifier, maxAPDULengthAccepted, segmentationSupported, vendorId,
+                isResponseToWhoIs);
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/service/unconfirmed/WhoAmIRequest.java
+++ b/src/main/java/com/serotonin/bacnet4j/service/unconfirmed/WhoAmIRequest.java
@@ -31,7 +31,6 @@ import java.util.Objects;
 
 import com.serotonin.bacnet4j.LocalDevice;
 import com.serotonin.bacnet4j.exception.BACnetException;
-import com.serotonin.bacnet4j.exception.NotImplementedException;
 import com.serotonin.bacnet4j.type.constructed.Address;
 import com.serotonin.bacnet4j.type.primitive.CharacterString;
 import com.serotonin.bacnet4j.type.primitive.Unsigned16;
@@ -69,7 +68,7 @@ public class WhoAmIRequest extends UnconfirmedRequestService {
 
     @Override
     public void handle(LocalDevice localDevice, Address from) throws BACnetException {
-        throw new NotImplementedException();
+        localDevice.getEventHandler().fireWhoAmIReceived(from, vendorId, modelName, serialNumber);
     }
 
     @Override

--- a/src/main/java/com/serotonin/bacnet4j/service/unconfirmed/WhoIsRequest.java
+++ b/src/main/java/com/serotonin/bacnet4j/service/unconfirmed/WhoIsRequest.java
@@ -27,13 +27,23 @@
 
 package com.serotonin.bacnet4j.service.unconfirmed;
 
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.serotonin.bacnet4j.LocalDevice;
 import com.serotonin.bacnet4j.exception.BACnetException;
 import com.serotonin.bacnet4j.type.constructed.Address;
+import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
+import com.serotonin.bacnet4j.type.primitive.CharacterString;
+import com.serotonin.bacnet4j.type.primitive.Unsigned16;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
 
 public class WhoIsRequest extends UnconfirmedRequestService {
+    private static final Logger LOG = LoggerFactory.getLogger(WhoIsRequest.class);
+
     public static final byte TYPE_ID = 8;
 
     private UnsignedInteger deviceInstanceRangeLowLimit;
@@ -43,12 +53,11 @@ public class WhoIsRequest extends UnconfirmedRequestService {
         // no op
     }
 
-    public WhoIsRequest(final int deviceInstanceRangeLowLimit, final int deviceInstanceRangeHighLimit) {
+    public WhoIsRequest(int deviceInstanceRangeLowLimit, int deviceInstanceRangeHighLimit) {
         this(new UnsignedInteger(deviceInstanceRangeLowLimit), new UnsignedInteger(deviceInstanceRangeHighLimit));
     }
 
-    public WhoIsRequest(final UnsignedInteger deviceInstanceRangeLowLimit,
-            final UnsignedInteger deviceInstanceRangeHighLimit) {
+    public WhoIsRequest(UnsignedInteger deviceInstanceRangeLowLimit, UnsignedInteger deviceInstanceRangeHighLimit) {
         this.deviceInstanceRangeLowLimit = deviceInstanceRangeLowLimit;
         this.deviceInstanceRangeHighLimit = deviceInstanceRangeHighLimit;
     }
@@ -59,8 +68,8 @@ public class WhoIsRequest extends UnconfirmedRequestService {
     }
 
     @Override
-    public void handle(final LocalDevice localDevice, final Address from) throws BACnetException {
-        final int instanceId = localDevice.getInstanceNumber();
+    public void handle(LocalDevice localDevice, Address from) throws BACnetException {
+        int instanceId = localDevice.getInstanceNumber();
 
         // Check if we're in the device id range.
         if (deviceInstanceRangeLowLimit != null && instanceId < deviceInstanceRangeLowLimit.intValue())
@@ -69,50 +78,48 @@ public class WhoIsRequest extends UnconfirmedRequestService {
         if (deviceInstanceRangeHighLimit != null && instanceId > deviceInstanceRangeHighLimit.intValue())
             return;
 
-        // Return the result in a i am message.
-        final IAmRequest iam = localDevice.getIAm().withIsResponseToWhoIs(true);
-        localDevice.sendGlobalBroadcast(iam);
+        if (localDevice.isUnconfigured()) {
+            // All three properties must be defined to send WhoAmI.
+            Unsigned16 vendorId = localDevice.get(PropertyIdentifier.vendorIdentifier);
+            CharacterString modelName = localDevice.get(PropertyIdentifier.modelName);
+            CharacterString serialNumber = localDevice.get(PropertyIdentifier.serialNumber);
+            if (vendorId != null && modelName != null && serialNumber != null) {
+                var whoAmI = new WhoAmIRequest(vendorId, modelName, serialNumber);
+                localDevice.send(from, whoAmI);
+            } else {
+                LOG.warn("Not configured to send WhoAmI: vendorId={}, modelName={}, serialNumber={}",
+                        vendorId, modelName, serialNumber);
+            }
+        } else {
+            // Return the result in an iAm message.
+            IAmRequest iam = localDevice.getIAm().withIsResponseToWhoIs(true);
+            localDevice.sendGlobalBroadcast(iam);
+        }
     }
 
     @Override
-    public void write(final ByteQueue queue) {
+    public void write(ByteQueue queue) {
         writeOptional(queue, deviceInstanceRangeLowLimit, 0);
         writeOptional(queue, deviceInstanceRangeHighLimit, 1);
     }
 
-    WhoIsRequest(final ByteQueue queue) throws BACnetException {
+    WhoIsRequest(ByteQueue queue) throws BACnetException {
         deviceInstanceRangeLowLimit = readOptional(queue, UnsignedInteger.class, 0);
         deviceInstanceRangeHighLimit = readOptional(queue, UnsignedInteger.class, 1);
     }
 
     @Override
-    public int hashCode() {
-        final int PRIME = 31;
-        int result = 1;
-        result = PRIME * result + (deviceInstanceRangeHighLimit == null ? 0 : deviceInstanceRangeHighLimit.hashCode());
-        result = PRIME * result + (deviceInstanceRangeLowLimit == null ? 0 : deviceInstanceRangeLowLimit.hashCode());
-        return result;
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass())
+            return false;
+        WhoIsRequest that = (WhoIsRequest) o;
+        return Objects.equals(deviceInstanceRangeLowLimit,
+                that.deviceInstanceRangeLowLimit) && Objects.equals(deviceInstanceRangeHighLimit,
+                that.deviceInstanceRangeHighLimit);
     }
 
     @Override
-    public boolean equals(final Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        final WhoIsRequest other = (WhoIsRequest) obj;
-        if (deviceInstanceRangeHighLimit == null) {
-            if (other.deviceInstanceRangeHighLimit != null)
-                return false;
-        } else if (!deviceInstanceRangeHighLimit.equals(other.deviceInstanceRangeHighLimit))
-            return false;
-        if (deviceInstanceRangeLowLimit == null) {
-            if (other.deviceInstanceRangeLowLimit != null)
-                return false;
-        } else if (!deviceInstanceRangeLowLimit.equals(other.deviceInstanceRangeLowLimit))
-            return false;
-        return true;
+    public int hashCode() {
+        return Objects.hash(deviceInstanceRangeLowLimit, deviceInstanceRangeHighLimit);
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/service/unconfirmed/YouAreRequest.java
+++ b/src/main/java/com/serotonin/bacnet4j/service/unconfirmed/YouAreRequest.java
@@ -31,8 +31,8 @@ import java.util.Objects;
 
 import com.serotonin.bacnet4j.LocalDevice;
 import com.serotonin.bacnet4j.exception.BACnetException;
-import com.serotonin.bacnet4j.exception.NotImplementedException;
 import com.serotonin.bacnet4j.type.constructed.Address;
+import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
 import com.serotonin.bacnet4j.type.primitive.CharacterString;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
 import com.serotonin.bacnet4j.type.primitive.OctetString;
@@ -88,7 +88,11 @@ public class YouAreRequest extends UnconfirmedRequestService {
 
     @Override
     public void handle(LocalDevice localDevice, Address from) throws BACnetException {
-        throw new NotImplementedException();
+        if (vendorId.equals(localDevice.get(PropertyIdentifier.vendorIdentifier))
+                && modelName.equals(localDevice.get(PropertyIdentifier.modelName))
+                && serialNumber.equals(localDevice.get(PropertyIdentifier.serialNumber))) {
+            localDevice.getEventHandler().fireYouAreReceived(from, deviceIdentifier, deviceMacAddress);
+        }
     }
 
     @Override

--- a/src/main/java/com/serotonin/bacnet4j/transport/DefaultTransport.java
+++ b/src/main/java/com/serotonin/bacnet4j/transport/DefaultTransport.java
@@ -30,6 +30,7 @@ package com.serotonin.bacnet4j.transport;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -69,6 +70,8 @@ import com.serotonin.bacnet4j.service.confirmed.ConfirmedRequestService;
 import com.serotonin.bacnet4j.service.confirmed.DeviceCommunicationControlRequest.EnableDisable;
 import com.serotonin.bacnet4j.service.unconfirmed.IAmRequest;
 import com.serotonin.bacnet4j.service.unconfirmed.UnconfirmedRequestService;
+import com.serotonin.bacnet4j.service.unconfirmed.WhoIsRequest;
+import com.serotonin.bacnet4j.service.unconfirmed.YouAreRequest;
 import com.serotonin.bacnet4j.type.constructed.Address;
 import com.serotonin.bacnet4j.type.constructed.ServicesSupported;
 import com.serotonin.bacnet4j.type.enumerated.AbortReason;
@@ -180,7 +183,7 @@ public class DefaultTransport implements Transport, Runnable {
     }
 
     @Override
-    public void initialize() throws Exception {
+    public void initialize() throws BACnetException {
         servicesSupported = localDevice.getServicesSupported();
 
         synchronized (runLock) {
@@ -661,6 +664,18 @@ public class DefaultTransport implements Transport, Runnable {
         }
 
         if (apdu instanceof ConfirmedRequest confAPDU) {
+            if (localDevice.isUnconfigured()) {
+                // Per clause 19.7, no confirmed service is permitted while unconfigured. Reject with
+                // unrecognizedService so the sender learns the request can't be handled here (rather than timing out).
+                try {
+                    network.sendAPDU(from, linkService,
+                            new Reject(confAPDU.getInvokeId(), RejectReason.unrecognizedService), false);
+                } catch (final BACnetException e) {
+                    LOG.warn("Error sending reject from unconfigured device", e);
+                }
+                return;
+            }
+
             // Received a request that must be handled and responded to.
             final byte invokeId = confAPDU.getInvokeId();
 
@@ -690,7 +705,7 @@ public class DefaultTransport implements Transport, Runnable {
                 }
 
                 try {
-                    segmentedIncoming(key, confAPDU, ctx);
+                    segmentedIncoming(key, confAPDU, Objects.requireNonNull(ctx));
                 } catch (final BACnetException e) {
                     LOG.warn("Error handling incoming request", e);
                     final com.serotonin.bacnet4j.apdu.Error error = new com.serotonin.bacnet4j.apdu.Error(
@@ -710,8 +725,17 @@ public class DefaultTransport implements Transport, Runnable {
             // Received a request that must be handled with no response.
             try {
                 ur.parseServiceData();
-                localDevice.getEventHandler().requestReceived(from, ur.getService());
-                ur.getService().handle(localDevice, from);
+                var service = ur.getService();
+
+                if (localDevice.isUnconfigured()
+                        && !(service instanceof WhoIsRequest || service instanceof YouAreRequest)) {
+                    // Per clause 19.7, the only unconfirmed services permitted while unconfigured are WhoIs and YouAre.
+                    // Silently drop everything else. Unconfirmed services have no reply mechanism.
+                    LOG.debug("Unconfigured device dropping unconfirmed choice {}", service.getClass());
+                } else {
+                    localDevice.getEventHandler().requestReceived(from, service);
+                    ur.getService().handle(localDevice, from);
+                }
             } catch (@SuppressWarnings("unused") final BACnetRejectException e) {
                 // Ignore
             } catch (final BACnetException e) {
@@ -837,7 +861,7 @@ public class DefaultTransport implements Transport, Runnable {
     /**
      * The first part of the segmented message has already been sent. This is called each time a segment ack is
      * received.
-     *
+     * <p>
      * This method handles outgoing segmented requests and responses.
      */
     private void segmentedOutgoing(final UnackedMessageKey key, final UnackedMessageContext ctx, final SegmentACK ack) {
@@ -1044,30 +1068,5 @@ public class DefaultTransport implements Transport, Runnable {
             unackedMessages.remove(key);
             ctx.useConsumer(consumer -> consumer.ex(e));
         }
-    }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + (network == null ? 0 : network.hashCode());
-        return result;
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        final DefaultTransport other = (DefaultTransport) obj;
-        if (network == null) {
-            if (other.network != null)
-                return false;
-        } else if (!network.equals(other.network))
-            return false;
-        return true;
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/transport/Transport.java
+++ b/src/main/java/com/serotonin/bacnet4j/transport/Transport.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import com.serotonin.bacnet4j.LocalDevice;
 import com.serotonin.bacnet4j.ResponseConsumer;
 import com.serotonin.bacnet4j.ServiceFuture;
+import com.serotonin.bacnet4j.exception.BACnetException;
 import com.serotonin.bacnet4j.npdu.NPDU;
 import com.serotonin.bacnet4j.npdu.Network;
 import com.serotonin.bacnet4j.npdu.NetworkIdentifier;
@@ -43,14 +44,12 @@ import com.serotonin.bacnet4j.type.primitive.OctetString;
 
 /**
  * Provides segmentation support for all data link types.
- *
- * @author Matthew
  */
 public interface Transport {
-    public static final int DEFAULT_TIMEOUT = 6000;
-    public static final int DEFAULT_SEG_TIMEOUT = 5000;
-    public static final int DEFAULT_SEG_WINDOW = 5;
-    public static final int DEFAULT_RETRIES = 2;
+    int DEFAULT_TIMEOUT = 6000;
+    int DEFAULT_SEG_TIMEOUT = 5000;
+    int DEFAULT_SEG_WINDOW = 5;
+    int DEFAULT_RETRIES = 2;
 
     NetworkIdentifier getNetworkIdentifier();
 
@@ -60,23 +59,23 @@ public interface Transport {
 
     void setLocalDevice(LocalDevice localDevice);
 
-    public void setTimeout(int timeout);
+    void setTimeout(int timeout);
 
-    public int getTimeout();
+    int getTimeout();
 
-    public void setSegTimeout(int segTimeout);
+    void setSegTimeout(int segTimeout);
 
-    public int getSegTimeout();
+    int getSegTimeout();
 
-    public void setRetries(int retries);
+    void setRetries(int retries);
 
-    public int getRetries();
+    int getRetries();
 
-    public void setSegWindow(int segWindow);
+    void setSegWindow(int segWindow);
 
-    public int getSegWindow();
+    int getSegWindow();
 
-    void initialize() throws Exception;
+    void initialize() throws BACnetException;
 
     void terminate();
 

--- a/src/main/java/com/serotonin/bacnet4j/type/notificationParameters/ExtendedNotif.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/notificationParameters/ExtendedNotif.java
@@ -27,43 +27,45 @@
 
 package com.serotonin.bacnet4j.type.notificationParameters;
 
+import java.util.Objects;
+
 import com.serotonin.bacnet4j.exception.BACnetException;
 import com.serotonin.bacnet4j.type.constructed.BaseType;
 import com.serotonin.bacnet4j.type.constructed.DeviceObjectPropertyReference;
 import com.serotonin.bacnet4j.type.constructed.SequenceOf;
 import com.serotonin.bacnet4j.type.primitive.Null;
 import com.serotonin.bacnet4j.type.primitive.Primitive;
+import com.serotonin.bacnet4j.type.primitive.Unsigned16;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
 
 public class ExtendedNotif extends AbstractNotificationParameter {
     public static final byte TYPE_ID = 9;
 
-    private final UnsignedInteger vendorId;
+    private final Unsigned16 vendorId;
     private final UnsignedInteger extendedEventType;
     private final SequenceOf<Parameter> parameters;
 
-    public ExtendedNotif(final UnsignedInteger vendorId, final UnsignedInteger extendedEventType,
-            final SequenceOf<Parameter> parameters) {
+    public ExtendedNotif(Unsigned16 vendorId, UnsignedInteger extendedEventType, SequenceOf<Parameter> parameters) {
         this.vendorId = vendorId;
         this.extendedEventType = extendedEventType;
         this.parameters = parameters;
     }
 
     @Override
-    public void write(final ByteQueue queue) {
+    public void write(ByteQueue queue) {
         write(queue, vendorId, 0);
         write(queue, extendedEventType, 1);
         write(queue, parameters, 2);
     }
 
-    public ExtendedNotif(final ByteQueue queue) throws BACnetException {
-        vendorId = read(queue, UnsignedInteger.class, 0);
+    public ExtendedNotif(ByteQueue queue) throws BACnetException {
+        vendorId = read(queue, Unsigned16.class, 0);
         extendedEventType = read(queue, UnsignedInteger.class, 1);
         parameters = readSequenceOf(queue, Parameter.class, 2);
     }
 
-    public UnsignedInteger getVendorId() {
+    public Unsigned16 getVendorId() {
         return vendorId;
     }
 
@@ -85,23 +87,23 @@ public class ExtendedNotif extends AbstractNotificationParameter {
         private Primitive primitive;
         private DeviceObjectPropertyReference reference;
 
-        public Parameter(final Primitive primitive) {
+        public Parameter(Primitive primitive) {
             this.primitive = primitive;
         }
 
-        public Parameter(final DeviceObjectPropertyReference reference) {
+        public Parameter(DeviceObjectPropertyReference reference) {
             this.reference = reference;
         }
 
         @Override
-        public void write(final ByteQueue queue) {
+        public void write(ByteQueue queue) {
             if (primitive != null)
                 primitive.write(queue);
             else
                 reference.write(queue, 0);
         }
 
-        public Parameter(final ByteQueue queue) throws BACnetException {
+        public Parameter(ByteQueue queue) throws BACnetException {
             if (queue.peek(0) == 0) {
                 primitive = new Null(queue);
             } else {
@@ -118,71 +120,31 @@ public class ExtendedNotif extends AbstractNotificationParameter {
         }
 
         @Override
-        public int hashCode() {
-            final int prime = 31;
-            int result = 1;
-            result = prime * result + (primitive == null ? 0 : primitive.hashCode());
-            result = prime * result + (reference == null ? 0 : reference.hashCode());
-            return result;
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass())
+                return false;
+            Parameter parameter = (Parameter) o;
+            return Objects.equals(primitive, parameter.primitive) && Objects.equals(reference,
+                    parameter.reference);
         }
 
         @Override
-        public boolean equals(final Object obj) {
-            if (this == obj)
-                return true;
-            if (obj == null)
-                return false;
-            if (getClass() != obj.getClass())
-                return false;
-            final Parameter other = (Parameter) obj;
-            if (primitive == null) {
-                if (other.primitive != null)
-                    return false;
-            } else if (!primitive.equals(other.primitive))
-                return false;
-            if (reference == null) {
-                if (other.reference != null)
-                    return false;
-            } else if (!reference.equals(other.reference))
-                return false;
-            return true;
+        public int hashCode() {
+            return Objects.hash(primitive, reference);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass())
+            return false;
+        ExtendedNotif that = (ExtendedNotif) o;
+        return Objects.equals(vendorId, that.vendorId) && Objects.equals(extendedEventType,
+                that.extendedEventType) && Objects.equals(parameters, that.parameters);
     }
 
     @Override
     public int hashCode() {
-        final int PRIME = 31;
-        int result = 1;
-        result = PRIME * result + (extendedEventType == null ? 0 : extendedEventType.hashCode());
-        result = PRIME * result + (parameters == null ? 0 : parameters.hashCode());
-        result = PRIME * result + (vendorId == null ? 0 : vendorId.hashCode());
-        return result;
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        final ExtendedNotif other = (ExtendedNotif) obj;
-        if (extendedEventType == null) {
-            if (other.extendedEventType != null)
-                return false;
-        } else if (!extendedEventType.equals(other.extendedEventType))
-            return false;
-        if (parameters == null) {
-            if (other.parameters != null)
-                return false;
-        } else if (!parameters.equals(other.parameters))
-            return false;
-        if (vendorId == null) {
-            if (other.vendorId != null)
-                return false;
-        } else if (!vendorId.equals(other.vendorId))
-            return false;
-        return true;
+        return Objects.hash(vendorId, extendedEventType, parameters);
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/ObjectIdentifier.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/ObjectIdentifier.java
@@ -77,11 +77,11 @@ public class ObjectIdentifier extends Primitive {
     public ObjectIdentifier(ByteQueue queue) throws BACnetErrorException {
         readTag(queue, TYPE_ID);
 
-        int objectType = queue.popU1B() << 2;
+        int type = queue.popU1B() << 2;
         int i = queue.popU1B();
-        objectType |= i >> 6;
+        type |= i >> 6;
 
-        this.objectType = ObjectType.forId(objectType);
+        this.objectType = ObjectType.forId(type);
 
         instanceNumber = (i & 0x3f) << 16;
         instanceNumber |= queue.popU1B() << 8;

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/ObjectIdentifier.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/ObjectIdentifier.java
@@ -40,14 +40,14 @@ public class ObjectIdentifier extends Primitive {
     private final ObjectType objectType;
     private int instanceNumber;
 
-    public ObjectIdentifier(final int objectType, final int instanceNumber) {
+    public ObjectIdentifier(int objectType, int instanceNumber) {
         this(ObjectType.forId(objectType), instanceNumber);
     }
 
-    public ObjectIdentifier(final ObjectType objectType, final int instanceNumber) {
+    public ObjectIdentifier(ObjectType objectType, int instanceNumber) {
         Objects.requireNonNull(objectType);
 
-        if (instanceNumber < 0 || instanceNumber > 0x3FFFFF)
+        if (instanceNumber < 0 || instanceNumber > UNINITIALIZED)
             throw new IllegalArgumentException("Illegal instance number: " + instanceNumber);
 
         this.objectType = objectType;
@@ -74,11 +74,11 @@ public class ObjectIdentifier extends Primitive {
     //
     // Reading and writing
     //
-    public ObjectIdentifier(final ByteQueue queue) throws BACnetErrorException {
+    public ObjectIdentifier(ByteQueue queue) throws BACnetErrorException {
         readTag(queue, TYPE_ID);
 
         int objectType = queue.popU1B() << 2;
-        final int i = queue.popU1B();
+        int i = queue.popU1B();
         objectType |= i >> 6;
 
         this.objectType = ObjectType.forId(objectType);
@@ -89,8 +89,8 @@ public class ObjectIdentifier extends Primitive {
     }
 
     @Override
-    public void writeImpl(final ByteQueue queue) {
-        final int objectType = this.objectType.intValue();
+    public void writeImpl(ByteQueue queue) {
+        int objectType = this.objectType.intValue();
         queue.push(objectType >> 2);
         queue.push((objectType & 3) << 6 | instanceNumber >> 16);
         queue.push(instanceNumber >> 8);
@@ -108,30 +108,15 @@ public class ObjectIdentifier extends Primitive {
     }
 
     @Override
-    public int hashCode() {
-        final int PRIME = 31;
-        int result = 1;
-        result = PRIME * result + instanceNumber;
-        result = PRIME * result + (objectType == null ? 0 : objectType.hashCode());
-        return result;
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass())
+            return false;
+        ObjectIdentifier that = (ObjectIdentifier) o;
+        return instanceNumber == that.instanceNumber && Objects.equals(objectType, that.objectType);
     }
 
     @Override
-    public boolean equals(final Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        final ObjectIdentifier other = (ObjectIdentifier) obj;
-        if (instanceNumber != other.instanceNumber)
-            return false;
-        if (objectType == null) {
-            if (other.objectType != null)
-                return false;
-        } else if (!objectType.equals(other.objectType))
-            return false;
-        return true;
+    public int hashCode() {
+        return Objects.hash(objectType, instanceNumber);
     }
 }

--- a/src/test/java/com/serotonin/bacnet4j/AnnexFEncodingTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/AnnexFEncodingTest.java
@@ -1148,7 +1148,7 @@ public class AnnexFEncodingTest {
     @Test
     public void e4_9b_and_e4_9fTest() {
         UnconfirmedRequestService service = new IAmRequest(new ObjectIdentifier(ObjectType.device, 3),
-                new UnsignedInteger(1024), Segmentation.noSegmentation, new UnsignedInteger(99));
+                new UnsignedInteger(1024), Segmentation.noSegmentation, new Unsigned16(99));
         APDU pdu = new UnconfirmedRequest(service);
         compare(pdu, "1000C40200000322040091032163");
     }
@@ -1163,7 +1163,7 @@ public class AnnexFEncodingTest {
     @Test
     public void e4_9dTest() {
         UnconfirmedRequestService service = new IAmRequest(new ObjectIdentifier(ObjectType.device, 1),
-                new UnsignedInteger(480), Segmentation.segmentedTransmit, new UnsignedInteger(99));
+                new UnsignedInteger(480), Segmentation.segmentedTransmit, new Unsigned16(99));
         APDU pdu = new UnconfirmedRequest(service);
         compare(pdu, "1000C4020000012201E091012163");
     }
@@ -1171,7 +1171,7 @@ public class AnnexFEncodingTest {
     @Test
     public void e4_9eTest() {
         UnconfirmedRequestService service = new IAmRequest(new ObjectIdentifier(ObjectType.device, 2),
-                new UnsignedInteger(206), Segmentation.segmentedReceive, new UnsignedInteger(33));
+                new UnsignedInteger(206), Segmentation.segmentedReceive, new Unsigned16(33));
         APDU pdu = new UnconfirmedRequest(service);
         compare(pdu, "1000C40200000221CE91022121");
     }
@@ -1179,7 +1179,7 @@ public class AnnexFEncodingTest {
     @Test
     public void e4_9gTest() {
         UnconfirmedRequestService service = new IAmRequest(new ObjectIdentifier(ObjectType.device, 4),
-                new UnsignedInteger(128), Segmentation.segmentedBoth, new UnsignedInteger(66));
+                new UnsignedInteger(128), Segmentation.segmentedBoth, new Unsigned16(66));
         APDU pdu = new UnconfirmedRequest(service);
         compare(pdu, "1000C402000004218091002142");
     }

--- a/src/test/java/com/serotonin/bacnet4j/LocalDeviceTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/LocalDeviceTest.java
@@ -28,9 +28,7 @@
 package com.serotonin.bacnet4j;
 
 import static com.serotonin.bacnet4j.TestUtils.awaitTrue;
-import static com.serotonin.bacnet4j.TestUtils.quiesce;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -67,7 +65,6 @@ import com.serotonin.bacnet4j.obj.DeviceObject;
 import com.serotonin.bacnet4j.transport.DefaultTransport;
 import com.serotonin.bacnet4j.type.enumerated.EngineeringUnits;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
-import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
 import com.serotonin.bacnet4j.util.DiscoveryUtils;
 import com.serotonin.bacnet4j.util.RemoteDeviceDiscoverer;
 import com.serotonin.bacnet4j.util.RemoteDeviceFinder.RemoteDeviceFuture;
@@ -105,20 +102,20 @@ public class LocalDeviceTest {
         DiscoveryUtils.getExtendedDeviceInformation(d1, rd2);
 
         // Ask for device 2 in two different threads.
-        final MutableObject<RemoteDevice> rd21 = new MutableObject<>();
-        final MutableObject<RemoteDevice> rd22 = new MutableObject<>();
-        final Future<?> future1 = d1.submit(() -> {
+        MutableObject<RemoteDevice> rd21 = new MutableObject<>();
+        MutableObject<RemoteDevice> rd22 = new MutableObject<>();
+        Future<?> future1 = d1.submit(() -> {
             try {
                 rd21.setValue(d1.getRemoteDevice(2).get());
-            } catch (final BACnetException e) {
+            } catch (BACnetException e) {
                 fail(e.getMessage());
                 LOG.error("Should not have happened", e);
             }
         });
-        final Future<?> future2 = d1.submit(() -> {
+        Future<?> future2 = d1.submit(() -> {
             try {
                 rd22.setValue(d1.getRemoteDevice(2).get());
-            } catch (final BACnetException e) {
+            } catch (BACnetException e) {
                 LOG.error("Should not have happened", e);
             }
         });
@@ -134,7 +131,7 @@ public class LocalDeviceTest {
         assertNotNull(rd21.get().getDeviceProperty(PropertyIdentifier.modelName));
 
         // Ask for it again. Should be the same instance.
-        final RemoteDevice rd23 = d1.getRemoteDevice(2).get();
+        RemoteDevice rd23 = d1.getRemoteDevice(2).get();
 
         // Device is cached, so it will still be the same instance.
         assertSame(rd21.get(), rd23);
@@ -147,26 +144,9 @@ public class LocalDeviceTest {
 
     @Test(expected = CancellationException.class)
     public void cancelGetRemoteDevice() throws CancellationException, BACnetException {
-        final RemoteDeviceFuture future = d1.getRemoteDevice(3);
+        RemoteDeviceFuture future = d1.getRemoteDevice(3);
         future.cancel();
         future.get();
-    }
-
-    @Test
-    public void undefinedDeviceId() throws Exception {
-        try (final LocalDevice ld = new LocalDevice(ObjectIdentifier.UNINITIALIZED,
-                new DefaultTransport(new TestNetwork(map, 3, 10)))) {
-            ld.setClock(clock);
-            new Thread(() -> {
-                // After a quiet period advance the clock to allow the local device initialization to complete.
-                quiesce();
-                clock.plusSeconds(200);
-            }).start();
-            ld.initialize();
-
-            LOG.info("Local device initialized with device id {}", ld.getInstanceNumber());
-            assertNotEquals(ObjectIdentifier.UNINITIALIZED, ld.getInstanceNumber());
-        }
     }
 
     @Test
@@ -174,7 +154,7 @@ public class LocalDeviceTest {
         assertNull(d1.getCachedRemoteDevice(2));
 
         // Ask for device 2 in a different thread.
-        final MutableObject<RemoteDevice> rd21 = new MutableObject<>();
+        MutableObject<RemoteDevice> rd21 = new MutableObject<>();
         d1.getRemoteDevice(2, rd21::setValue, null, null, 1, TimeUnit.SECONDS);
 
         awaitTrue(() -> rd21.get() != null);
@@ -183,8 +163,8 @@ public class LocalDeviceTest {
 
     @Test
     public void createSecondDevice() {
-        final LocalDevice ld = new LocalDevice(1, new DefaultTransport(new TestNetwork(map, 1, 0)));
-        final DeviceObject o = new DeviceObject(ld, 2);
+        LocalDevice ld = new LocalDevice(1, new DefaultTransport(new TestNetwork(map, 1, 0)));
+        DeviceObject o = new DeviceObject(ld, 2);
 
         // Ensure the device object was not automatically added to the local device.
         assertEquals(1, ld.getLocalObjects().size());
@@ -206,14 +186,14 @@ public class LocalDeviceTest {
     @SuppressWarnings("unused")
     @Test
     public void getDeviceBlockingTimeout() throws Exception {
-        try (final LocalDevice d3 = new LocalDevice(3, new DefaultTransport(new TestNetwork(map, 3, 0))).withClock(
+        try (LocalDevice d3 = new LocalDevice(3, new DefaultTransport(new TestNetwork(map, 3, 0))).withClock(
                 clock).initialize()) {
-            final long start = Clock.systemUTC().millis();
+            long start = Clock.systemUTC().millis();
 
             try {
                 d3.getRemoteDeviceBlocking(4, 100);
                 fail();
-            } catch (final BACnetTimeoutException e) {
+            } catch (BACnetTimeoutException e) {
                 // Expected after 100ms.
                 assertTrue(Clock.systemUTC().millis() - start >= 100);
             }
@@ -221,7 +201,7 @@ public class LocalDeviceTest {
             try {
                 d3.getRemoteDeviceBlocking(4, 1000);
                 fail();
-            } catch (final BACnetTimeoutException e) {
+            } catch (BACnetTimeoutException e) {
                 // Expected immediately.
                 assertTrue(Clock.systemUTC().millis() - start < 1000);
             }
@@ -231,7 +211,7 @@ public class LocalDeviceTest {
             try {
                 d3.getRemoteDeviceBlocking(4, 100);
                 fail();
-            } catch (final BACnetTimeoutException e) {
+            } catch (BACnetTimeoutException e) {
                 // Expected after 100ms.
                 assertTrue(Clock.systemUTC().millis() - start >= 100);
             }

--- a/src/test/java/com/serotonin/bacnet4j/npdu/NetworkPriorityTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/npdu/NetworkPriorityTest.java
@@ -35,7 +35,7 @@ import com.serotonin.bacnet4j.apdu.ConfirmedRequest;
 import com.serotonin.bacnet4j.apdu.UnconfirmedRequest;
 import com.serotonin.bacnet4j.enums.MaxApduLength;
 import com.serotonin.bacnet4j.enums.MaxSegments;
-import com.serotonin.bacnet4j.exception.BACnetException;
+import com.serotonin.bacnet4j.exception.BACnetRuntimeException;
 import com.serotonin.bacnet4j.service.confirmed.ConfirmedEventNotificationRequest;
 import com.serotonin.bacnet4j.service.confirmed.ConfirmedTextMessageRequest;
 import com.serotonin.bacnet4j.service.unconfirmed.UnconfirmedEventNotificationRequest;
@@ -89,8 +89,8 @@ public class NetworkPriorityTest {
         Assert.assertEquals(0, getNetworkPriorityOther());
     }
 
-    private static int getNetworkPriorityCEN(final int eventPriority) throws Exception {
-        final ConfirmedEventNotificationRequest req = new ConfirmedEventNotificationRequest(new UnsignedInteger(2),
+    private static int getNetworkPriorityCEN(int eventPriority) throws Exception {
+        ConfirmedEventNotificationRequest req = new ConfirmedEventNotificationRequest(new UnsignedInteger(2),
                 new ObjectIdentifier(ObjectType.device, 8), new ObjectIdentifier(ObjectType.analogInput, 9),
                 new TimeStamp(new DateTime(123456789)), new UnsignedInteger(3), new UnsignedInteger(eventPriority),
                 EventType.changeOfBitstring, new CharacterString("hi"), NotifyType.event, Boolean.FALSE,
@@ -98,13 +98,13 @@ public class NetworkPriorityTest {
                 new NotificationParameters(
                         new ChangeOfBitStringNotif(new BitString(new boolean[] {false, true, false, true}),
                                 new StatusFlags(true, false, false, false))));
-        final ConfirmedRequest apdu = new ConfirmedRequest(false, false, true, MaxSegments.MORE_THAN_64,
+        ConfirmedRequest apdu = new ConfirmedRequest(false, false, true, MaxSegments.MORE_THAN_64,
                 MaxApduLength.UP_TO_1476, (byte) 45, 0, 5, req);
         return getNetworkPriority(apdu);
     }
 
-    private static int getNetworkPriorityUEN(final int eventPriority) throws Exception {
-        final UnconfirmedEventNotificationRequest req = new UnconfirmedEventNotificationRequest(new UnsignedInteger(2),
+    private static int getNetworkPriorityUEN(int eventPriority) throws Exception {
+        UnconfirmedEventNotificationRequest req = new UnconfirmedEventNotificationRequest(new UnsignedInteger(2),
                 new ObjectIdentifier(ObjectType.device, 8), new ObjectIdentifier(ObjectType.analogInput, 9),
                 new TimeStamp(new DateTime(123456789)), new UnsignedInteger(3), new UnsignedInteger(eventPriority),
                 EventType.changeOfBitstring, new CharacterString("hi"), NotifyType.event, Boolean.FALSE,
@@ -113,50 +113,49 @@ public class NetworkPriorityTest {
                         new ChangeOfBitStringNotif(new BitString(new boolean[] {false, true, false, true}),
                                 new StatusFlags(true, false, false, false))));
 
-        final UnconfirmedRequest apdu = new UnconfirmedRequest(req);
+        UnconfirmedRequest apdu = new UnconfirmedRequest(req);
 
         return getNetworkPriority(apdu);
     }
 
-    private static int getNetworkPriorityCTM(final MessagePriority priority) throws Exception {
-        final ConfirmedTextMessageRequest req = new ConfirmedTextMessageRequest(
+    private static int getNetworkPriorityCTM(MessagePriority priority) throws Exception {
+        ConfirmedTextMessageRequest req = new ConfirmedTextMessageRequest(
                 new ObjectIdentifier(ObjectType.device, 8), priority, new CharacterString("hi"));
-        final ConfirmedRequest apdu = new ConfirmedRequest(false, false, true, MaxSegments.MORE_THAN_64,
+        ConfirmedRequest apdu = new ConfirmedRequest(false, false, true, MaxSegments.MORE_THAN_64,
                 MaxApduLength.UP_TO_1476, (byte) 45, 0, 5, req);
         return getNetworkPriority(apdu);
     }
 
-    private static int getNetworkPriorityUTM(final MessagePriority priority) throws Exception {
-        final UnconfirmedTextMessageRequest req = new UnconfirmedTextMessageRequest(
+    private static int getNetworkPriorityUTM(MessagePriority priority) throws Exception {
+        UnconfirmedTextMessageRequest req = new UnconfirmedTextMessageRequest(
                 new ObjectIdentifier(ObjectType.device, 8), priority, new CharacterString("hi"));
-        final UnconfirmedRequest apdu = new UnconfirmedRequest(req);
+        UnconfirmedRequest apdu = new UnconfirmedRequest(req);
         return getNetworkPriority(apdu);
     }
 
     private static int getNetworkPriorityOther() throws Exception {
-        final UnconfirmedPrivateTransferRequest req = new UnconfirmedPrivateTransferRequest(11, 12, new Real(3.14F));
-        final UnconfirmedRequest apdu = new UnconfirmedRequest(req);
+        UnconfirmedPrivateTransferRequest req = new UnconfirmedPrivateTransferRequest(11, 12, new Real(3.14F));
+        UnconfirmedRequest apdu = new UnconfirmedRequest(req);
         return getNetworkPriority(apdu);
     }
 
-    private static int getNetworkPriority(final APDU apdu) throws Exception {
-        final ByteQueue queue = new ByteQueue();
-        final Network network = new Network() {
+    private static int getNetworkPriority(APDU apdu) throws Exception {
+        ByteQueue queue = new ByteQueue();
+        Network network = new Network() {
             @Override
             public void terminate() {
                 throw new RuntimeException();
             }
 
             @Override
-            public void sendNPDU(final Address recipient, final OctetString router, final ByteQueue npdu,
-                    final boolean broadcast, final boolean expectsReply) throws BACnetException {
+            public void sendNPDU(Address recipient, OctetString router, ByteQueue npdu, boolean broadcast,
+                    boolean expectsReply) {
                 queue.push(npdu);
             }
 
             @Override
-            protected NPDU handleIncomingDataImpl(final ByteQueue queue, final OctetString linkService)
-                    throws Exception {
-                throw new RuntimeException();
+            protected NPDU handleIncomingDataImpl(ByteQueue queue, OctetString linkService) {
+                throw new BACnetRuntimeException();
             }
 
             @Override
@@ -199,7 +198,7 @@ public class NetworkPriorityTest {
         network.sendAPDU(new Address(2, new byte[] {2}), new OctetString(new byte[] {5}), apdu, false);
 
         queue.pop();
-        final byte control = queue.pop();
+        byte control = queue.pop();
 
         return control & 0x3;
     }

--- a/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadPropertyMultipleRequestTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadPropertyMultipleRequestTest.java
@@ -186,7 +186,8 @@ public class ReadPropertyMultipleRequestTest {
         ReadPropertyMultipleAck ack = (ReadPropertyMultipleAck) new ReadPropertyMultipleRequest(listOfReadAccessSpecs)
                 .handle(localDevice, addr);
 
-        //The instance number of the localdevice must be sent if a request is made to the instance 0x3FFFFF (unitialized).
+        // The instance number of the local device must be sent if a request is made to the
+        // instance 0x3FFFFF (uninitialized).
         for (ReadAccessResult listOfReadAccessResult : ack.getListOfReadAccessResults()) {
             assertEquals(new ObjectIdentifier(ObjectType.device, localDevice.getInstanceNumber()),
                     listOfReadAccessResult.getObjectIdentifier());

--- a/src/test/java/com/serotonin/bacnet4j/service/unconfirmed/UnconfiguredDeviceRestrictionTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/service/unconfirmed/UnconfiguredDeviceRestrictionTest.java
@@ -1,0 +1,479 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2026 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
+package com.serotonin.bacnet4j.service.unconfirmed;
+
+import static com.serotonin.bacnet4j.TestUtils.awaitEquals;
+import static com.serotonin.bacnet4j.TestUtils.quiesce;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.serotonin.bacnet4j.LocalDevice;
+import com.serotonin.bacnet4j.RemoteDevice;
+import com.serotonin.bacnet4j.event.DeviceEventAdapter;
+import com.serotonin.bacnet4j.exception.BACnetRuntimeException;
+import com.serotonin.bacnet4j.exception.RejectAPDUException;
+import com.serotonin.bacnet4j.npdu.test.TestNetwork;
+import com.serotonin.bacnet4j.npdu.test.TestNetworkMap;
+import com.serotonin.bacnet4j.npdu.test.TestNetworkUtils;
+import com.serotonin.bacnet4j.service.confirmed.ReadPropertyRequest;
+import com.serotonin.bacnet4j.transport.DefaultTransport;
+import com.serotonin.bacnet4j.type.constructed.Address;
+import com.serotonin.bacnet4j.type.enumerated.ObjectType;
+import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
+import com.serotonin.bacnet4j.type.enumerated.RejectReason;
+import com.serotonin.bacnet4j.type.primitive.CharacterString;
+import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
+import com.serotonin.bacnet4j.type.primitive.OctetString;
+import com.serotonin.bacnet4j.type.primitive.Unsigned16;
+
+/**
+ * Tests the runtime restrictions on a BACnet4J device with Device Identifier 4194303 (the
+ * "unconfigured" state defined by addendum 135-2016bz-1 Clause 19.X): outbound sends are limited
+ * to Who-Am-I, and inbound execution is limited to Who-Is and You-Are.
+ */
+public class UnconfiguredDeviceRestrictionTest {
+    private final TestNetworkMap map = new TestNetworkMap();
+    private final Address unconfiguredAddr = TestNetworkUtils.toAddress(50);
+    private final Address peerAddr = TestNetworkUtils.toAddress(51);
+
+    /** The device under test — starts life with Device Identifier 4194303. */
+    private LocalDevice unconfigured;
+
+    /** A configured peer used to send stimulus to the unconfigured device. */
+    private LocalDevice peer;
+
+    @Before
+    public void before() throws Exception {
+        unconfigured = new LocalDevice(ObjectIdentifier.UNINITIALIZED,
+                new DefaultTransport(new TestNetwork(map, 50, 0)));
+        unconfigured.getDeviceObject().writePropertyInternal(
+                PropertyIdentifier.serialNumber, new CharacterString("SN-under-test"));
+        unconfigured.initialize();
+
+        peer = new LocalDevice(51, new DefaultTransport(new TestNetwork(map, 51, 0)));
+        peer.initialize();
+    }
+
+    @After
+    public void after() {
+        unconfigured.terminate();
+        peer.terminate();
+    }
+
+    // ------------------------- Outbound restriction -------------------------
+
+    /**
+     * Per Clause 19.X, an unconfigured device shall not initiate any service other than Who-Am-I.
+     * The library's send guard should reject an attempt to broadcast I-Am.
+     */
+    @Test
+    public void outboundRestriction_iAmBroadcast_throws() {
+        var iAm = unconfigured.getIAm();
+        BACnetRuntimeException e = assertThrows(BACnetRuntimeException.class,
+                () -> unconfigured.sendGlobalBroadcast(iAm));
+        // Message should mention what was attempted.
+        assertThrowsForNonWhoAmI(e, "IAmRequest");
+    }
+
+    /**
+     * Same guard, confirmed-request send path.
+     */
+    @Test
+    public void outboundRestriction_confirmedRequest_throws() {
+        var rpr = new ReadPropertyRequest(new ObjectIdentifier(ObjectType.device, 51), PropertyIdentifier.objectName);
+        BACnetRuntimeException e = assertThrows(BACnetRuntimeException.class,
+                () -> unconfigured.send(peerAddr, rpr));
+        assertThrowsForNonWhoAmI(e, "ReadPropertyRequest");
+    }
+
+    /**
+     * Who-Am-I is the one service an unconfigured device is permitted to initiate.
+     */
+    @Test
+    public void outboundRestriction_whoAmI_succeeds() {
+        WhoAmIRequest whoAmI = new WhoAmIRequest(
+                new Unsigned16(865),
+                new CharacterString("BACnet4J"),
+                new CharacterString("SN-under-test"));
+        // Should not throw.
+        unconfigured.sendGlobalBroadcast(whoAmI);
+        assertFalse(false); // Have at least one assertion.
+    }
+
+    private static void assertThrowsForNonWhoAmI(BACnetRuntimeException e, String requestName) {
+        // The library's guard message names the class it refused.
+        if (!e.getMessage().contains(requestName)) {
+            fail("Expected guard message to mention " + requestName + ", got: " + e.getMessage());
+        }
+    }
+
+    // ------------------------- Inbound restriction -------------------------
+
+    /**
+     * Per Clause 19.X, an unconfigured device shall not execute any confirmed service. A peer
+     * sending ReadProperty should receive a Reject(unrecognizedService) rather than a timeout.
+     */
+    @Test
+    public void inboundRestriction_confirmedRequest_rejected() {
+        // Address the unconfigured device by its MAC (instance is 4194303 and can't be used to
+        // route). Use a made-up device object identifier — the reject fires before any object
+        // lookup happens.
+        var rpr = new ReadPropertyRequest(new ObjectIdentifier(ObjectType.device, ObjectIdentifier.UNINITIALIZED),
+                PropertyIdentifier.objectName);
+        var ex = assertThrows(RejectAPDUException.class, () -> peer.send(unconfiguredAddr, rpr).get());
+        assertEquals(RejectReason.unrecognizedService, ex.getApdu().getRejectReason());
+    }
+
+    /**
+     * Non-Who-Is / non-You-Are unconfirmed services shall be silently dropped by an unconfigured
+     * device. We verify by asserting that the device's iAmReceived listener never fires.
+     */
+    @Test
+    public void inboundRestriction_iAm_droppedSilently() {
+        AtomicInteger iamReceived = new AtomicInteger(0);
+        unconfigured.getEventHandler().addListener(new DeviceEventAdapter() {
+            @Override
+            public void iAmReceived(RemoteDevice d) {
+                iamReceived.incrementAndGet();
+            }
+        });
+
+        peer.send(unconfiguredAddr, peer.getIAm());
+        quiesce();
+
+        assertEquals(0, iamReceived.get());
+    }
+
+    /**
+     * Who-Is is one of the two services an unconfigured device is required to execute. A peer
+     * sending Who-Is with a range that includes 4194303 shall receive a Who-Am-I reply unicast
+     * back per Clause 16.X.2.
+     */
+    @Test
+    public void inboundRestriction_whoIs_repliesWithWhoAmI() throws Exception {
+        AtomicReference<WhoAmIRequest> received = new AtomicReference<>();
+        peer.getEventHandler().addListener(new DeviceEventAdapter() {
+            @Override
+            public void whoAmIReceived(Address from, Unsigned16 vendorId, CharacterString modelName,
+                    CharacterString serialNumber) {
+                received.set(new WhoAmIRequest(vendorId, modelName, serialNumber));
+            }
+        });
+
+        peer.sendGlobalBroadcast(new WhoIsRequest(0, ObjectIdentifier.UNINITIALIZED));
+
+        awaitEquals(1, () -> received.get() == null ? 0 : 1);
+        WhoAmIRequest w = received.get();
+        assertEquals(new Unsigned16(865), w.getVendorId());
+        assertEquals(new CharacterString("BACnet4J"), w.getModelName());
+        assertEquals(new CharacterString("SN-under-test"), w.getSerialNumber());
+    }
+
+    /**
+     * You-Are is the other required-execution service. A peer sending You-Are with matching
+     * vendor / model / serial shall cause the unconfigured device to fire youAreReceived. The
+     * library does not itself apply the identifier — that's application-listener policy.
+     */
+    @Test
+    public void inboundRestriction_youAre_matchingIdentity_firesListener() throws Exception {
+        AtomicReference<ObjectIdentifier> assignedId = new AtomicReference<>();
+        unconfigured.getEventHandler().addListener(new DeviceEventAdapter() {
+            @Override
+            public void youAreReceived(Address from, ObjectIdentifier deviceIdentifier,
+                    OctetString deviceMacAddress) {
+                assignedId.set(deviceIdentifier);
+            }
+        });
+
+        peer.send(unconfiguredAddr, new YouAreRequest(
+                new Unsigned16(865),                       // matches
+                new CharacterString("BACnet4J"),           // matches
+                new CharacterString("SN-under-test"),      // matches
+                new ObjectIdentifier(com.serotonin.bacnet4j.type.enumerated.ObjectType.device, 42),
+                null));
+
+        awaitEquals(1, () -> assignedId.get() == null ? 0 : 1);
+        assertEquals(42, assignedId.get().getInstanceNumber());
+    }
+
+    /**
+     * A You-Are whose vendor / model / serial doesn't match the local device shall be ignored,
+     * even though the service was executable.
+     */
+    @Test
+    public void inboundRestriction_youAre_nonMatchingIdentity_ignored() {
+        AtomicInteger fired = new AtomicInteger(0);
+        unconfigured.getEventHandler().addListener(new DeviceEventAdapter() {
+            @Override
+            public void youAreReceived(Address from, ObjectIdentifier deviceIdentifier,
+                    OctetString deviceMacAddress) {
+                fired.incrementAndGet();
+            }
+        });
+
+        peer.send(unconfiguredAddr, new YouAreRequest(
+                new Unsigned16(999),                       // wrong vendor
+                new CharacterString("BACnet4J"),
+                new CharacterString("SN-under-test"),
+                new ObjectIdentifier(com.serotonin.bacnet4j.type.enumerated.ObjectType.device, 42),
+                null));
+
+        quiesce();
+        assertEquals(0, fired.get());
+    }
+
+    // ------------------------- Regression: configured device -------------------------
+
+    /**
+     * Once the device is assigned a real instance number, both the outbound and inbound gates
+     * lift and normal service execution resumes.
+     */
+    @Test
+    public void configuredDevice_normalReadPropertySucceeds() throws Exception {
+        // Simulate a successful You-Are: write a real Device Identifier.
+        unconfigured.getDeviceObject().writePropertyInternal(
+                PropertyIdentifier.objectIdentifier,
+                new ObjectIdentifier(ObjectType.device, 42));
+
+        // Peer can now read the newly-configured device.
+        assertNull(unconfigured.getDeviceObject().get(PropertyIdentifier.description));
+        // A trivial round-trip: read the objectName. Should succeed with no reject.
+        peer.send(unconfiguredAddr, new ReadPropertyRequest(
+                new ObjectIdentifier(ObjectType.device, 42),
+                PropertyIdentifier.objectName)).get();
+    }
+
+    // ------------------------- Additional outbound cases -------------------------
+
+    /**
+     * The outbound guard covers every send entry point, not only sendGlobalBroadcast.
+     */
+    @Test
+    public void outboundRestriction_sendLocalBroadcast_iAm_throws() {
+        var iAm = unconfigured.getIAm();
+        BACnetRuntimeException e = assertThrows(BACnetRuntimeException.class,
+                () -> unconfigured.sendLocalBroadcast(iAm));
+        assertThrowsForNonWhoAmI(e, "IAmRequest");
+    }
+
+    /**
+     * A Who-Am-I local broadcast is the natural corollary — permitted while unconfigured.
+     */
+    @Test
+    public void outboundRestriction_sendLocalBroadcast_whoAmI_succeeds() {
+        var whoAmI = new WhoAmIRequest(
+                new Unsigned16(865),
+                new CharacterString("BACnet4J"),
+                new CharacterString("SN-under-test"));
+        unconfigured.sendLocalBroadcast(whoAmI);
+        assertFalse(false); // Have at least one assertion.
+    }
+
+    /**
+     * Unicast unconfirmed sends are also gated.
+     */
+    @Test
+    public void outboundRestriction_sendUnicastUnconfirmed_iAm_throws() {
+        var iAm = unconfigured.getIAm();
+        BACnetRuntimeException e = assertThrows(BACnetRuntimeException.class,
+                () -> unconfigured.send(peerAddr, iAm));
+        assertThrowsForNonWhoAmI(e, "IAmRequest");
+    }
+
+    // ------------------------- Additional inbound cases -------------------------
+
+    /**
+     * Per Clause 16.X.2, an unconfigured device treats its own instance as 4194303 when
+     * checking Who-Is range inclusion. A Who-Is whose range excludes 4194303 shall get no
+     * reply.
+     */
+    @Test
+    public void inboundRestriction_whoIs_rangeExcludesUnconfigured_noReply() {
+        AtomicInteger received = new AtomicInteger(0);
+        peer.getEventHandler().addListener(new DeviceEventAdapter() {
+            @Override
+            public void whoAmIReceived(Address from, Unsigned16 vendorId, CharacterString modelName,
+                    CharacterString serialNumber) {
+                received.incrementAndGet();
+            }
+        });
+
+        peer.sendGlobalBroadcast(new WhoIsRequest(0, 100));
+        quiesce();
+
+        assertEquals(0, received.get());
+    }
+
+    /**
+     * An unbounded Who-Is (no range limits) covers instance 4194303 by definition. The
+     * unconfigured device shall reply with Who-Am-I.
+     */
+    @Test
+    public void inboundRestriction_whoIs_unboundedRange_repliesWithWhoAmI() throws Exception {
+        AtomicInteger received = new AtomicInteger(0);
+        peer.getEventHandler().addListener(new DeviceEventAdapter() {
+            @Override
+            public void whoAmIReceived(Address from, Unsigned16 vendorId, CharacterString modelName,
+                    CharacterString serialNumber) {
+                received.incrementAndGet();
+            }
+        });
+
+        peer.sendGlobalBroadcast(new WhoIsRequest());   // no range limits
+        awaitEquals(1, received::get);
+        assertFalse(false); // Have at least one assertion.
+    }
+
+    /**
+     * Per Clause 19.X, only Who-Is and You-Are are executable while unconfigured. Who-Am-I is
+     * initiation-only; receiving one shall be silently dropped.
+     */
+    @Test
+    public void inboundRestriction_whoAmI_droppedSilently() {
+        AtomicInteger received = new AtomicInteger(0);
+        unconfigured.getEventHandler().addListener(new DeviceEventAdapter() {
+            @Override
+            public void whoAmIReceived(Address from, Unsigned16 vendorId, CharacterString modelName,
+                    CharacterString serialNumber) {
+                received.incrementAndGet();
+            }
+        });
+
+        peer.send(unconfiguredAddr, new WhoAmIRequest(
+                new Unsigned16(100),
+                new CharacterString("PeerModel"),
+                new CharacterString("peer-serial")));
+        quiesce();
+
+        assertEquals(0, received.get());
+    }
+
+    /**
+     * Per Clause 16.X.3.1.4/5, either Device Identifier or MAC Address (or both) may be
+     * provided in a You-Are. The library shall pass through a MAC-only You-Are the same way
+     * it does for a Device-Identifier-only or both-fields You-Are.
+     */
+    @Test
+    public void inboundRestriction_youAre_macOnly_firesListener() throws Exception {
+        AtomicReference<OctetString> assignedMac = new AtomicReference<>();
+        unconfigured.getEventHandler().addListener(new DeviceEventAdapter() {
+            @Override
+            public void youAreReceived(Address from, ObjectIdentifier deviceIdentifier,
+                    OctetString deviceMacAddress) {
+                assignedMac.set(deviceMacAddress);
+            }
+        });
+
+        OctetString newMac = new OctetString(new byte[] {(byte) 0xAB});
+        peer.send(unconfiguredAddr, new YouAreRequest(
+                new Unsigned16(865),
+                new CharacterString("BACnet4J"),
+                new CharacterString("SN-under-test"),
+                null,
+                newMac));
+
+        awaitEquals(1, () -> assignedMac.get() == null ? 0 : 1);
+        assertEquals(newMac, assignedMac.get());
+    }
+
+    // ------------------------- Regression: initialize on unconfigured device -------------------------
+
+    /**
+     * Regression for the bug where {@code initialize()} unconditionally sent a restart
+     * notification, which the outbound guard now blocks. On an unconfigured device the
+     * notification loop must be skipped so that {@code initialize()} completes cleanly.
+     * The {@code @Before} setup would have thrown before reaching the test if this were broken.
+     */
+    @Test
+    public void initialize_unconfigured_completesWithoutError() {
+        assertEquals(ObjectIdentifier.UNINITIALIZED, unconfigured.getInstanceNumber());
+    }
+
+    // ------------------------- End-to-end listener plumbing -------------------------
+
+    /**
+     * The unconfigured device broadcasts a Who-Am-I; the peer's listener plumbing observes it
+     * end-to-end.
+     */
+    @Test
+    public void unconfiguredDevice_broadcastsWhoAmI_peerListenerFires() throws Exception {
+        AtomicReference<CharacterString> received = new AtomicReference<>();
+        peer.getEventHandler().addListener(new DeviceEventAdapter() {
+            @Override
+            public void whoAmIReceived(Address from, Unsigned16 vendorId, CharacterString modelName,
+                    CharacterString serialNumber) {
+                received.set(serialNumber);
+            }
+        });
+
+        unconfigured.sendGlobalBroadcast(new WhoAmIRequest(
+                new Unsigned16(865),
+                new CharacterString("BACnet4J"),
+                new CharacterString("SN-under-test")));
+
+        awaitEquals(1, () -> received.get() == null ? 0 : 1);
+        assertEquals(new CharacterString("SN-under-test"), received.get());
+    }
+
+    // ------------------------- Transition: configured → unconfigured -------------------------
+
+    /**
+     * Writing 4194303 back to the Device Identifier returns the device to the unconfigured
+     * state; the guards re-engage. This proves the gate reads the current instance dynamically
+     * rather than caching an initial value.
+     */
+    @Test
+    public void configuredToUnconfiguredTransition_gatesReEngage() {
+        // Step 1: promote the device to configured and confirm the outbound gate is lifted.
+        unconfigured.getDeviceObject().writePropertyInternal(
+                PropertyIdentifier.objectIdentifier,
+                new ObjectIdentifier(ObjectType.device, 42));
+        unconfigured.sendGlobalBroadcast(unconfigured.getIAm());   // must not throw
+
+        // Step 2: return the device to unconfigured.
+        unconfigured.getDeviceObject().writePropertyInternal(
+                PropertyIdentifier.objectIdentifier,
+                new ObjectIdentifier(ObjectType.device, ObjectIdentifier.UNINITIALIZED));
+
+        // Step 3: outbound guard is back in effect.
+        var iAm = unconfigured.getIAm();
+        BACnetRuntimeException e = assertThrows(BACnetRuntimeException.class,
+                () -> unconfigured.sendGlobalBroadcast(iAm));
+        assertThrowsForNonWhoAmI(e, "IAmRequest");
+    }
+}

--- a/src/test/java/com/serotonin/bacnet4j/type/constructed/DeviceAddressProxyTableEntryTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/type/constructed/DeviceAddressProxyTableEntryTest.java
@@ -41,6 +41,7 @@ import com.serotonin.bacnet4j.type.primitive.Date;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
 import com.serotonin.bacnet4j.type.primitive.OctetString;
 import com.serotonin.bacnet4j.type.primitive.Time;
+import com.serotonin.bacnet4j.type.primitive.Unsigned16;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
 
@@ -53,16 +54,16 @@ import com.serotonin.bacnet4j.util.sero.ByteQueue;
 public class DeviceAddressProxyTableEntryTest {
     @Test
     public void roundTrip() throws BACnetException {
-        final DeviceAddressProxyTableEntry entry = new DeviceAddressProxyTableEntry(
+        DeviceAddressProxyTableEntry entry = new DeviceAddressProxyTableEntry(
                 new Address(123, new OctetString(new byte[] {10, 0, 0, 1, (byte) 0xba, (byte) 0xc0})),
                 new IAmRequest(
                         new ObjectIdentifier(ObjectType.device, 555),
                         new UnsignedInteger(1476),
                         Segmentation.segmentedBoth,
-                        new UnsignedInteger(42)),
+                        new Unsigned16(42)),
                 new DateTime(new Date(2026, Month.JUNE, 12, DayOfWeek.FRIDAY), new Time(13, 0, 0, 0)));
 
-        final ByteQueue queue = new ByteQueue();
+        ByteQueue queue = new ByteQueue();
         entry.write(queue);
 
         assertEquals(entry, new DeviceAddressProxyTableEntry(queue));

--- a/src/test/java/com/serotonin/bacnet4j/util/DiscoveryUtilsTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/util/DiscoveryUtilsTest.java
@@ -48,6 +48,7 @@ import com.serotonin.bacnet4j.type.constructed.ServicesSupported;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
 import com.serotonin.bacnet4j.type.enumerated.Segmentation;
 import com.serotonin.bacnet4j.type.primitive.CharacterString;
+import com.serotonin.bacnet4j.type.primitive.Unsigned16;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
 public class DiscoveryUtilsTest {
@@ -66,7 +67,7 @@ public class DiscoveryUtilsTest {
         remoteDevice.setDeviceProperty(PropertyIdentifier.protocolServicesSupported, new ServicesSupported());
         remoteDevice.setDeviceProperty(PropertyIdentifier.objectName, new CharacterString("name"));
         remoteDevice.setDeviceProperty(PropertyIdentifier.protocolVersion, new UnsignedInteger(1));
-        remoteDevice.setDeviceProperty(PropertyIdentifier.vendorIdentifier, new UnsignedInteger(165));
+        remoteDevice.setDeviceProperty(PropertyIdentifier.vendorIdentifier, new Unsigned16(165));
         remoteDevice.setDeviceProperty(PropertyIdentifier.modelName, new CharacterString("model"));
         remoteDevice.setDeviceProperty(PropertyIdentifier.maxSegmentsAccepted, new UnsignedInteger(500));
 


### PR DESCRIPTION
https://radixiot.atlassian.net/browse/MANGO-3010

Implement basic Who-Am-I / You-Are support (135-2016bz-1)

Adds receiver-side implementation of the two new unconfirmed services introduced by ANSI/ASHRAE 135-2016 addendum bz-1 (Who-Am-I, unconfirmed choice 13; You-Are, unconfirmed choice 14), plus the runtime restrictions from Clause 19.X that govern how an unconfigured device (Device Identifier 4194303) may participate on the network.

Summary

Service handlers
- WhoIsRequest.handle returns Who-Am-I (unicast to sender) when the local instance is 4194303, I-Am (broadcast) otherwise. The range check treats 4194303 as the self-instance per Clause 16.X.2, so a Who-Is[low, 4194303] or unbounded Who-Is correctly discovers unconfigured devices.
- WhoAmIRequest.handle fires DeviceEventListener.whoAmIReceived(from, vendorId, modelName, serialNumber).
- YouAreRequest.handle matches vendor / model / serial against the local Device object and, on match, fires DeviceEventListener.youAreReceived(from, deviceIdentifier, deviceMacAddress). The application is responsible for persisting the assignment and emitting I-Am; MAC validation is deferred to the listener.

Listener plumbing
- DeviceEventListener gains whoAmIReceived and youAreReceived.
- DefaultDeviceEventListener provides default no-op implementations so existing single-method listeners (e.g. IAmListener) retain @FunctionalInterface.
- DeviceEventHandler gains fireWhoAmIReceived and fireYouAreReceived with per-listener exception isolation.

Other
- increases supported protocol revision to 22
- fixes vendor id previously declared as `UnsignedInteger` to `Unsigned16`
- fixes init methods that previous threw `Exception` to throw `BACnetException`
- removes non-spec functionality that found an unused device id since it is now in violation of the spec
