### PR TITLE
MANGO-2964 Ensure cipher suite compatibility

### DIFF
--- a/src/main/java/com/serotonin/bacnet4j/npdu/sc/SCTLSManager.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/sc/SCTLSManager.java
@@ -60,11 +60,7 @@ public class SCTLSManager {
     private static final Logger LOG = LoggerFactory.getLogger(SCTLSManager.class);
     private static final String TLS_VERSION = "TLSv1.3";
 
-    // Clause AB.7.4 — TLS V1.3 Cipher Suite Application Profile for BACnet/SC (135-2020cd-1).
-    // The profile mandates support of TLS_AES_128_GCM_SHA256 with ecdsa_secp256r1_sha256 signatures
-    // and secp256r1 key exchange. The named group and signature scheme are enabled by default in
-    // Java's TLS 1.3 provider whenever the cipher suite is present, so verifying cipher-suite
-    // availability at startup is sufficient to detect a JVM whose crypto has been restricted.
+    // AB.7.4
     static final String REQUIRED_CIPHER_SUITE = "TLS_AES_128_GCM_SHA256";
 
     protected final PrivateKey privateKey;

--- a/src/main/java/com/serotonin/bacnet4j/npdu/sc/SCTLSManager.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/sc/SCTLSManager.java
@@ -39,6 +39,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -58,6 +59,13 @@ import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
 public class SCTLSManager {
     private static final Logger LOG = LoggerFactory.getLogger(SCTLSManager.class);
     private static final String TLS_VERSION = "TLSv1.3";
+
+    // Clause AB.7.4 — TLS V1.3 Cipher Suite Application Profile for BACnet/SC (135-2020cd-1).
+    // The profile mandates support of TLS_AES_128_GCM_SHA256 with ecdsa_secp256r1_sha256 signatures
+    // and secp256r1 key exchange. The named group and signature scheme are enabled by default in
+    // Java's TLS 1.3 provider whenever the cipher suite is present, so verifying cipher-suite
+    // availability at startup is sufficient to detect a JVM whose crypto has been restricted.
+    static final String REQUIRED_CIPHER_SUITE = "TLS_AES_128_GCM_SHA256";
 
     protected final PrivateKey privateKey;
     protected final byte[] operationalCertificateBytes;
@@ -114,6 +122,7 @@ public class SCTLSManager {
 
             SSLContext ctx = SSLContext.getInstance(TLS_VERSION);
             ctx.init(keyManagers, trustManagers, null);
+            assertProfileSupported(ctx);
             return ctx;
         } catch (KeyStoreException e) {
             throw new TLSException(ErrorClass.device, ErrorCode.internalError, "Keystore error: %s", e);
@@ -126,6 +135,15 @@ public class SCTLSManager {
                     e);
         } catch (NoSuchAlgorithmException e) {
             throw new TLSException(ErrorClass.device, ErrorCode.internalError, "Algorithm not available: %s", e);
+        }
+    }
+
+    static void assertProfileSupported(SSLContext ctx) throws TLSException {
+        String[] supported = ctx.getSupportedSSLParameters().getCipherSuites();
+        if (Arrays.stream(supported).noneMatch(REQUIRED_CIPHER_SUITE::equals)) {
+            throw new TLSException(ErrorClass.device, ErrorCode.internalError,
+                    "Required BACnet/SC TLS 1.3 cipher suite " + REQUIRED_CIPHER_SUITE
+                            + " is not available in this JVM. Check jdk.tls.disabledAlgorithms.", null);
         }
     }
 
@@ -174,7 +192,7 @@ public class SCTLSManager {
         private final transient ErrorCode errorCode;
 
         public TLSException(ErrorClass errorClass, ErrorCode errorCode, String message, Exception cause) {
-            super(message.formatted(cause.getMessage()), cause);
+            super(cause == null ? message : message.formatted(cause.getMessage()), cause);
             this.errorClass = errorClass;
             this.errorCode = errorCode;
         }

--- a/src/main/java/com/serotonin/bacnet4j/obj/DeviceObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/DeviceObject.java
@@ -223,7 +223,7 @@ public class DeviceObject extends BACnetObject {
         writePropertyInternal(PropertyIdentifier.firmwareRevision, new CharacterString("not set"));
         writePropertyInternal(PropertyIdentifier.applicationSoftwareVersion, new CharacterString(LocalDevice.VERSION));
         writePropertyInternal(PropertyIdentifier.protocolVersion, new UnsignedInteger(1));
-        writePropertyInternal(PropertyIdentifier.protocolRevision, new UnsignedInteger(22));
+        writePropertyInternal(PropertyIdentifier.protocolRevision, new UnsignedInteger(23));
 
         UnsignedInteger databaseRevision = getLocalDevice().getPersistence()
                 .loadEncodable(getPersistenceKey(PropertyIdentifier.databaseRevision), UnsignedInteger.class);

--- a/src/test/java/com/serotonin/bacnet4j/npdu/sc/SCTLSManagerTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/npdu/sc/SCTLSManagerTest.java
@@ -1,0 +1,152 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2026 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
+package com.serotonin.bacnet4j.npdu.sc;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+import java.security.spec.ECGenParameterSpec;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Date;
+
+import javax.net.ssl.SSLContext;
+
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.serotonin.bacnet4j.npdu.sc.SCTLSManager.TLSException;
+
+/**
+ * Verifies compliance with 135-2020cd-1 Clause AB.7.4, the TLS V1.3 Cipher Suite Application
+ * Profile for BACnet/SC. The profile mandates support for:
+ * <ul>
+ *   <li>TLS 1.3</li>
+ *   <li>Cipher suite TLS_AES_128_GCM_SHA256</li>
+ *   <li>Signature algorithm ecdsa_secp256r1_sha256</li>
+ *   <li>Key exchange group secp256r1</li>
+ * </ul>
+ */
+public class SCTLSManagerTest {
+    @BeforeClass
+    public static void addBouncyCastleProvider() {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
+
+    @Test
+    public void tls13IsAvailableInJvm() throws Exception {
+        SSLContext ctx = SSLContext.getInstance("TLSv1.3");
+        assertNotNull(ctx);
+        assertEquals("TLSv1.3", ctx.getProtocol());
+    }
+
+    @Test
+    public void requiredCipherSuiteIsAvailableInJvm() throws Exception {
+        SSLContext ctx = SSLContext.getInstance("TLSv1.3");
+        ctx.init(null, null, null);
+        String[] supported = ctx.getSupportedSSLParameters().getCipherSuites();
+        assertTrue("JVM must support the BACnet/SC required cipher suite "
+                        + SCTLSManager.REQUIRED_CIPHER_SUITE + " but supports " + Arrays.toString(supported),
+                Arrays.asList(supported).contains(SCTLSManager.REQUIRED_CIPHER_SUITE));
+    }
+
+    @Test
+    public void assertProfileSupported_passesWhenCipherAvailable() throws Exception {
+        SSLContext ctx = SSLContext.getInstance("TLSv1.3");
+        ctx.init(null, null, null);
+        SCTLSManager.assertProfileSupported(ctx);
+    }
+
+    @Test
+    public void constructingSCTLSManager_exposesTls13ContextWithRequiredCipher() throws Exception {
+        KeyPair deviceKey = generateEcKeyPair();
+        KeyPair issuerKey = generateEcKeyPair();
+        Instant now = Instant.now();
+        X509Certificate opCert = makeCert(deviceKey, issuerKey, "device",
+                now.minusSeconds(3600), now.plusSeconds(365 * 24 * 3600L));
+        X509Certificate issuerCert = makeCert(issuerKey, issuerKey, "issuer",
+                now.minusSeconds(3600), now.plusSeconds(365 * 24 * 3600L));
+
+        SCTLSManager tls = new SCTLSManager(deviceKey.getPrivate(), opCert.getEncoded(),
+                issuerCert.getEncoded(), new byte[0]);
+
+        SSLContext ctx = tls.getSSLContext();
+        assertEquals("TLSv1.3", ctx.getProtocol());
+        String[] supported = ctx.getSupportedSSLParameters().getCipherSuites();
+        assertTrue(Arrays.asList(supported).contains(SCTLSManager.REQUIRED_CIPHER_SUITE));
+        assertArrayEquals(opCert.getEncoded(), tls.getOperationalCertificate().getEncoded());
+    }
+
+    @Test
+    public void tlsExceptionWithNullCausePreservesMessage() {
+        TLSException ex = assertThrows(TLSException.class, () -> {
+            throw new TLSException(
+                    com.serotonin.bacnet4j.type.enumerated.ErrorClass.device,
+                    com.serotonin.bacnet4j.type.enumerated.ErrorCode.internalError,
+                    "test message", null);
+        });
+        assertEquals("test message", ex.getMessage());
+        assertEquals(com.serotonin.bacnet4j.type.enumerated.ErrorClass.device, ex.getErrorClass());
+        assertEquals(com.serotonin.bacnet4j.type.enumerated.ErrorCode.internalError, ex.getErrorCode());
+    }
+
+    private static KeyPair generateEcKeyPair() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
+        kpg.initialize(new ECGenParameterSpec("secp256r1"));
+        return kpg.generateKeyPair();
+    }
+
+    private static X509Certificate makeCert(KeyPair subject, KeyPair issuer, String cn, Instant notBefore,
+            Instant notAfter) throws Exception {
+        X500Name issuerName = new X500Name("CN=" + (issuer == subject ? cn : cn + "-signer"));
+        X500Name subjectName = new X500Name("CN=" + cn);
+        BigInteger serial = new BigInteger(64, new SecureRandom());
+        var signer = new JcaContentSignerBuilder("SHA256withECDSA").build(issuer.getPrivate());
+        var builder = new JcaX509v3CertificateBuilder(issuerName, serial, Date.from(notBefore), Date.from(notAfter),
+                subjectName, subject.getPublic());
+        return new JcaX509CertificateConverter()
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME)
+                .getCertificate(builder.build(signer));
+    }
+}


### PR DESCRIPTION
https://radixiot.atlassian.net/browse/MANGO-2964

Despite the ticket description this PR has to do with verifying that the cipher suites available include those mandated in the BACnet spec. The actual ticket description had no required code changes, so this change (bj-5) is just piggybacking on this ticket.
