### PR TITLE
MANGO-2968 multiple protocol revision 26 compliance fixes

### DIFF
--- a/src/main/java/com/serotonin/bacnet4j/obj/DeviceObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/DeviceObject.java
@@ -223,7 +223,7 @@ public class DeviceObject extends BACnetObject {
         writePropertyInternal(PropertyIdentifier.firmwareRevision, new CharacterString("not set"));
         writePropertyInternal(PropertyIdentifier.applicationSoftwareVersion, new CharacterString(LocalDevice.VERSION));
         writePropertyInternal(PropertyIdentifier.protocolVersion, new UnsignedInteger(1));
-        writePropertyInternal(PropertyIdentifier.protocolRevision, new UnsignedInteger(25));
+        writePropertyInternal(PropertyIdentifier.protocolRevision, new UnsignedInteger(26));
 
         UnsignedInteger databaseRevision = getLocalDevice().getPersistence()
                 .loadEncodable(getPersistenceKey(PropertyIdentifier.databaseRevision), UnsignedInteger.class);

--- a/src/main/java/com/serotonin/bacnet4j/obj/NetworkPortObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/NetworkPortObject.java
@@ -226,6 +226,16 @@ public class NetworkPortObject extends BACnetObject {
                 throw new BACnetServiceException(ErrorClass.property, ErrorCode.optionalFunctionalityNotSupported);
             }
         }
+        if (command == NetworkPortCommand.restartSubordinateDiscovery) {
+            // Per 12.56.14, writing this value to a non-MS/TP port returns VALUE_OUT_OF_RANGE, while an
+            // MS/TP port without subordinate proxy support returns OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED.
+            // Subclasses that support subordinate proxying override this method. The non-MS/TP case falls
+            // through to the VALUE_OUT_OF_RANGE below.
+            NetworkType networkType = get(PropertyIdentifier.networkType);
+            if (networkType == NetworkType.mstp) {
+                throw new BACnetServiceException(ErrorClass.property, ErrorCode.optionalFunctionalityNotSupported);
+            }
+        }
         if (command.isOneOf(NetworkPortCommand.restartAutonegotiation, NetworkPortCommand.restartPort,
                 NetworkPortCommand.restartDeviceDiscovery, NetworkPortCommand.generateCsrFile)) {
             throw new BACnetServiceException(ErrorClass.property, ErrorCode.optionalFunctionalityNotSupported);

--- a/src/main/java/com/serotonin/bacnet4j/service/confirmed/ReadRangeRequest.java
+++ b/src/main/java/com/serotonin/bacnet4j/service/confirmed/ReadRangeRequest.java
@@ -51,7 +51,7 @@ import com.serotonin.bacnet4j.type.enumerated.ErrorClass;
 import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
-import com.serotonin.bacnet4j.type.primitive.SignedInteger;
+import com.serotonin.bacnet4j.type.primitive.SignedInteger16;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
 
@@ -501,9 +501,9 @@ public class ReadRangeRequest extends ConfirmedRequestService {
     }
 
     public abstract static class Range extends BaseType {
-        protected SignedInteger count;
+        protected SignedInteger16 count;
 
-        protected Range(SignedInteger count) {
+        protected Range(SignedInteger16 count) {
             this.count = count;
         }
 
@@ -511,7 +511,7 @@ public class ReadRangeRequest extends ConfirmedRequestService {
             // no op
         }
 
-        public SignedInteger getCount() {
+        public SignedInteger16 getCount() {
             return count;
         }
 
@@ -534,10 +534,10 @@ public class ReadRangeRequest extends ConfirmedRequestService {
         private final UnsignedInteger referenceIndex;
 
         public ByPosition(int referenceIndex, int count) {
-            this(new UnsignedInteger(referenceIndex), new SignedInteger(count));
+            this(new UnsignedInteger(referenceIndex), new SignedInteger16(count));
         }
 
-        public ByPosition(UnsignedInteger referenceIndex, SignedInteger count) {
+        public ByPosition(UnsignedInteger referenceIndex, SignedInteger16 count) {
             super(count);
             this.referenceIndex = referenceIndex;
         }
@@ -550,7 +550,7 @@ public class ReadRangeRequest extends ConfirmedRequestService {
 
         public ByPosition(ByteQueue queue) throws BACnetException {
             referenceIndex = read(queue, UnsignedInteger.class);
-            count = read(queue, SignedInteger.class);
+            count = read(queue, SignedInteger16.class);
         }
 
         public UnsignedInteger getReferenceIndex() {
@@ -577,10 +577,10 @@ public class ReadRangeRequest extends ConfirmedRequestService {
         private final UnsignedInteger referenceIndex;
 
         public BySequenceNumber(long referenceIndex, int count) {
-            this(new UnsignedInteger(referenceIndex), new SignedInteger(count));
+            this(new UnsignedInteger(referenceIndex), new SignedInteger16(count));
         }
 
-        public BySequenceNumber(UnsignedInteger referenceIndex, SignedInteger count) {
+        public BySequenceNumber(UnsignedInteger referenceIndex, SignedInteger16 count) {
             super(count);
             this.referenceIndex = referenceIndex;
         }
@@ -593,7 +593,7 @@ public class ReadRangeRequest extends ConfirmedRequestService {
 
         public BySequenceNumber(ByteQueue queue) throws BACnetException {
             referenceIndex = read(queue, UnsignedInteger.class);
-            count = read(queue, SignedInteger.class);
+            count = read(queue, SignedInteger16.class);
         }
 
         public UnsignedInteger getReferenceIndex() {
@@ -620,10 +620,10 @@ public class ReadRangeRequest extends ConfirmedRequestService {
         private final DateTime referenceTime;
 
         public ByTime(DateTime referenceTime, int count) {
-            this(referenceTime, new SignedInteger(count));
+            this(referenceTime, new SignedInteger16(count));
         }
 
-        public ByTime(DateTime referenceTime, SignedInteger count) {
+        public ByTime(DateTime referenceTime, SignedInteger16 count) {
             super(count);
             this.referenceTime = referenceTime;
         }
@@ -636,7 +636,7 @@ public class ReadRangeRequest extends ConfirmedRequestService {
 
         public ByTime(ByteQueue queue) throws BACnetException {
             referenceTime = read(queue, DateTime.class);
-            count = read(queue, SignedInteger.class);
+            count = read(queue, SignedInteger16.class);
         }
 
         public DateTime getReferenceTime() {

--- a/src/main/java/com/serotonin/bacnet4j/type/enumerated/EngineeringUnits.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/enumerated/EngineeringUnits.java
@@ -107,9 +107,9 @@ public class EngineeringUnits extends Enumerated {
     public static final EngineeringUnits voltAmpereHours = new EngineeringUnits(239);
     public static final EngineeringUnits kilovoltAmpereHours = new EngineeringUnits(240);
     public static final EngineeringUnits megavoltAmpereHours = new EngineeringUnits(241);
-    public static final EngineeringUnits voltAmpereHoursReactive = new EngineeringUnits(242);
-    public static final EngineeringUnits kilovoltAmpereHoursReactive = new EngineeringUnits(243);
-    public static final EngineeringUnits megavoltAmpereHoursReactive = new EngineeringUnits(244);
+    public static final EngineeringUnits voltAmpereReactiveHours = new EngineeringUnits(242);
+    public static final EngineeringUnits kilovoltAmpereReactiveHours = new EngineeringUnits(243);
+    public static final EngineeringUnits megavoltAmpereReactiveHours = new EngineeringUnits(244);
     public static final EngineeringUnits voltSquareHours = new EngineeringUnits(245);
     public static final EngineeringUnits ampereSquareHours = new EngineeringUnits(246);
     public static final EngineeringUnits joules = new EngineeringUnits(16);
@@ -119,9 +119,9 @@ public class EngineeringUnits extends Enumerated {
     public static final EngineeringUnits wattHours = new EngineeringUnits(18);
     public static final EngineeringUnits kilowattHours = new EngineeringUnits(19);
     public static final EngineeringUnits megawattHours = new EngineeringUnits(146);
-    public static final EngineeringUnits wattHoursReactive = new EngineeringUnits(203);
-    public static final EngineeringUnits kilowattHoursReactive = new EngineeringUnits(204);
-    public static final EngineeringUnits megawattHoursReactive = new EngineeringUnits(205);
+    public static final EngineeringUnits wattReactiveHours = new EngineeringUnits(203);
+    public static final EngineeringUnits kilowattReactiveHours = new EngineeringUnits(204);
+    public static final EngineeringUnits megawattReactiveHours = new EngineeringUnits(205);
     public static final EngineeringUnits btus = new EngineeringUnits(20);
     public static final EngineeringUnits kiloBtus = new EngineeringUnits(147);
     public static final EngineeringUnits megaBtus = new EngineeringUnits(148);

--- a/src/main/java/com/serotonin/bacnet4j/type/primitive/SignedInteger16.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/primitive/SignedInteger16.java
@@ -1,0 +1,67 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2026 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
+package com.serotonin.bacnet4j.type.primitive;
+
+import java.math.BigInteger;
+
+import com.serotonin.bacnet4j.exception.BACnetErrorException;
+import com.serotonin.bacnet4j.exception.BACnetServiceException;
+import com.serotonin.bacnet4j.type.enumerated.ErrorClass;
+import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
+import com.serotonin.bacnet4j.util.sero.ByteQueue;
+
+/**
+ * Represents the Integer16 type — an Integer constrained to the range -32768..32767 per
+ * 135-2020ck-1 Clause 21.5.
+ */
+public class SignedInteger16 extends SignedInteger {
+    private static final int MIN = Short.MIN_VALUE;
+    private static final int MAX = Short.MAX_VALUE;
+    private static final BigInteger BIGMIN = BigInteger.valueOf(MIN);
+    private static final BigInteger BIGMAX = BigInteger.valueOf(MAX);
+
+    public SignedInteger16(int value) {
+        super(value);
+        if (value < MIN || value > MAX) {
+            throw new IllegalArgumentException("Value out of range for Integer16: " + value);
+        }
+    }
+
+    public SignedInteger16(ByteQueue queue) throws BACnetErrorException {
+        super(queue);
+    }
+
+    @Override
+    public void validate() throws BACnetServiceException {
+        super.validate();
+        BigInteger value = bigIntegerValue();
+        if (value.compareTo(BIGMIN) < 0 || value.compareTo(BIGMAX) > 0) {
+            throw new BACnetServiceException(ErrorClass.property, ErrorCode.valueOutOfRange);
+        }
+    }
+}

--- a/src/test/java/com/serotonin/bacnet4j/AnnexFEncodingTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/AnnexFEncodingTest.java
@@ -158,6 +158,7 @@ import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
 import com.serotonin.bacnet4j.type.primitive.OctetString;
 import com.serotonin.bacnet4j.type.primitive.Real;
 import com.serotonin.bacnet4j.type.primitive.SignedInteger;
+import com.serotonin.bacnet4j.type.primitive.SignedInteger16;
 import com.serotonin.bacnet4j.type.primitive.Time;
 import com.serotonin.bacnet4j.type.primitive.Unsigned16;
 import com.serotonin.bacnet4j.type.primitive.Unsigned32;
@@ -913,7 +914,7 @@ public class AnnexFEncodingTest {
         ReadRangeRequest req = new ReadRangeRequest(new ObjectIdentifier(ObjectType.trendLog, 1),
                 PropertyIdentifier.logBuffer, null,
                 new ByTime(new DateTime(new Date(1998, Month.MARCH, 23, DayOfWeek.MONDAY), new Time(19, 52, 34, 0)),
-                        new SignedInteger(4)));
+                        new SignedInteger16(4)));
         APDU pdu = new ConfirmedRequest(false, false, true, MaxSegments.UNSPECIFIED, MaxApduLength.UP_TO_206,
                 (byte) 1, (byte) 0, 0, req);
         compare(pdu, "0202011a0c0500000119837ea462031701b41334220031047f");

--- a/src/test/java/com/serotonin/bacnet4j/obj/NetworkPortObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/NetworkPortObjectTest.java
@@ -302,6 +302,41 @@ public class NetworkPortObjectTest {
     }
 
     @Test
+    public void commands_restartSubordinateDiscovery() throws Exception {
+        withLocalDevice(localDevice -> {
+            // A non-MS/TP port rejects the command as out of range.
+            var npo = localDevice.addObject(new NetworkPortObject(localDevice, 12, "NetworkPort",
+                    false, NetworkType.virtual, ProtocolLevel.bacnetApplication, Set.of()));
+            var thrown = assertThrows(BACnetServiceException.class, () -> npo.writeProperty(
+                    new ValueSource(), PropertyIdentifier.command, NetworkPortCommand.restartSubordinateDiscovery));
+            assertEquals(ErrorClass.property, thrown.getErrorClass());
+            assertEquals(ErrorCode.valueOutOfRange, thrown.getErrorCode());
+
+            // An MS/TP port without subordinate proxy support rejects it as unsupported functionality.
+            var mstp = localDevice.addObject(new NetworkPortObject(localDevice, 13, "NetworkPortMstp",
+                    false, NetworkType.mstp, ProtocolLevel.bacnetApplication, Set.of()));
+            thrown = assertThrows(BACnetServiceException.class, () -> mstp.writeProperty(
+                    new ValueSource(), PropertyIdentifier.command, NetworkPortCommand.restartSubordinateDiscovery));
+            assertEquals(ErrorClass.property, thrown.getErrorClass());
+            assertEquals(ErrorCode.optionalFunctionalityNotSupported, thrown.getErrorCode());
+        });
+    }
+
+    @Test
+    public void commands_restartDeviceDiscovery() throws Exception {
+        withLocalDevice(localDevice -> {
+            // A port that does not support device address proxying rejects the command as unsupported
+            // functionality per 12.56.14.
+            var npo = localDevice.addObject(new NetworkPortObject(localDevice, 12, "NetworkPort",
+                    false, NetworkType.virtual, ProtocolLevel.bacnetApplication, Set.of()));
+            var thrown = assertThrows(BACnetServiceException.class, () -> npo.writeProperty(
+                    new ValueSource(), PropertyIdentifier.command, NetworkPortCommand.restartDeviceDiscovery));
+            assertEquals(ErrorClass.property, thrown.getErrorClass());
+            assertEquals(ErrorCode.optionalFunctionalityNotSupported, thrown.getErrorCode());
+        });
+    }
+
+    @Test
     public void commands() throws Exception {
         withLocalDevice(localDevice -> {
             var npo = localDevice.addObject(new NetworkPortObject(localDevice, 12, "NetworkPort",

--- a/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadRangeRequestTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadRangeRequestTest.java
@@ -75,7 +75,7 @@ import com.serotonin.bacnet4j.type.primitive.Date;
 import com.serotonin.bacnet4j.type.primitive.Null;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
 import com.serotonin.bacnet4j.type.primitive.Real;
-import com.serotonin.bacnet4j.type.primitive.SignedInteger;
+import com.serotonin.bacnet4j.type.primitive.SignedInteger16;
 import com.serotonin.bacnet4j.type.primitive.Time;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
@@ -86,7 +86,7 @@ public class ReadRangeRequestTest {
     private final TestNetworkMap map = new TestNetworkMap();
     final PropertyIdentifier pid = PropertyIdentifier.forId(9999);
     private final LocalDevice d1 = new LocalDevice(1, new DefaultTransport(new TestNetwork(map, 1, 0)));
-    final DateTime localNow = new DateTime(d1);
+    final DateTime now = new DateTime(d1);
 
     @Before
     public void before() throws Exception {
@@ -250,7 +250,7 @@ public class ReadRangeRequestTest {
     public void sequencePositiveCount() throws BACnetException {
         SequenceOf<LogRecord> data = new SequenceOf<>(1000);
         for (int i = 0; i < 1000; i++)
-            data.add(createLogRecord(localNow, 2001 + i));
+            data.add(createLogRecord(now, 2001 + i));
         d1.getObject(d1.getId()).writePropertyInternal(pid, data);
 
         ReadRangeAck ack =
@@ -259,7 +259,7 @@ public class ReadRangeRequestTest {
 
         data = new SequenceOf<>(200);
         for (int i = 0; i < 200; i++)
-            data.add(createLogRecord(localNow, i + 2800));
+            data.add(createLogRecord(now, i + 2800));
 
         assertEquals(d1.getId(), ack.getObjectIdentifier());
         assertEquals(pid, ack.getPropertyIdentifier());
@@ -277,7 +277,7 @@ public class ReadRangeRequestTest {
     public void sequenceNegativeCount() throws BACnetException {
         SequenceOf<LogRecord> data = new SequenceOf<>(1000);
         for (int i = 0; i < 1000; i++)
-            data.add(createLogRecord(localNow, 2001 + i));
+            data.add(createLogRecord(now, 2001 + i));
         d1.getObject(d1.getId()).writePropertyInternal(pid, data);
 
         ReadRangeAck ack =
@@ -286,7 +286,7 @@ public class ReadRangeRequestTest {
 
         data = new SequenceOf<>(200);
         for (int i = 0; i < 200; i++)
-            data.add(createLogRecord(localNow, i + 2801));
+            data.add(createLogRecord(now, i + 2801));
 
         assertEquals(d1.getId(), ack.getObjectIdentifier());
         assertEquals(pid, ack.getPropertyIdentifier());
@@ -597,7 +597,7 @@ public class ReadRangeRequestTest {
     public void sequenceOutOfRange() throws BACnetException {
         SequenceOf<LogRecord> data = new SequenceOf<>(1000);
         for (int i = 0; i < 1000; i++)
-            data.add(createLogRecord(localNow, 2001 + i));
+            data.add(createLogRecord(now, 2001 + i));
         d1.getObject(d1.getId()).writePropertyInternal(pid, data);
 
         // Too low
@@ -756,7 +756,7 @@ public class ReadRangeRequestTest {
     public void bi3_byPosition_referenceIndexOverUnsigned32_roundTrip() throws Exception {
         UnsignedInteger big = new UnsignedInteger(0x100000000L);
         ReadRangeRequest req = new ReadRangeRequest(
-                d1.getId(), pid, null, new ByPosition(big, new SignedInteger(1)));
+                d1.getId(), pid, null, new ByPosition(big, new SignedInteger16(1)));
 
         ByteQueue queue = new ByteQueue();
         req.write(queue);
@@ -772,7 +772,7 @@ public class ReadRangeRequestTest {
     public void bi3_bySequenceNumber_referenceIndexOverUnsigned32_roundTrip() throws Exception {
         UnsignedInteger big = new UnsignedInteger(0x123456789L);
         ReadRangeRequest req = new ReadRangeRequest(
-                d1.getId(), pid, null, new BySequenceNumber(big, new SignedInteger(-5)));
+                d1.getId(), pid, null, new BySequenceNumber(big, new SignedInteger16(-5)));
 
         ByteQueue queue = new ByteQueue();
         req.write(queue);

--- a/src/test/java/com/serotonin/bacnet4j/type/enumerated/EngineeringUnitsCnComplianceTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/type/enumerated/EngineeringUnitsCnComplianceTest.java
@@ -1,0 +1,111 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2026 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
+package com.serotonin.bacnet4j.type.enumerated;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+
+/**
+ * Verifies that the BACnetEngineeringUnits enumeration is compliant with Addendum 135-2020cn
+ * "Clarify Engineering Units".
+ *
+ * cn assigns enumerated values across two ranges: the traditional 0..254 block and the new
+ * ASHRAE-reserved block 47808..47967. Within the reserved block, cn does not assign 47813 or 47957.
+ */
+public class EngineeringUnitsCnComplianceTest {
+    // Reserved-range slots that cn leaves unassigned.
+    private static final int RESERVED_MIN = 47808;
+    private static final int RESERVED_MAX = 47967;
+    private static final int[] RESERVED_GAPS = {47813, 47957};
+
+    @Test
+    public void allTraditionalRangeUnitsDefined() {
+        for (int id = 0; id <= 254; id++) {
+            assertNotNull("Missing engineering unit for id " + id, EngineeringUnits.nameForId(id));
+        }
+    }
+
+    @Test
+    public void allReservedRangeUnitsDefined() {
+        for (int id = RESERVED_MIN; id <= RESERVED_MAX; id++) {
+            if (isReservedGap(id))
+                continue;
+            assertNotNull("Missing engineering unit for id " + id, EngineeringUnits.nameForId(id));
+        }
+    }
+
+    @Test
+    public void reactiveHoursUnitsUseCnTerminology() {
+        // cn reorders the reactive-energy units from "...-hours-reactive" to "...-reactive-hours".
+        assertUnit(203, "watt-reactive-hours", EngineeringUnits.wattReactiveHours);
+        assertUnit(204, "kilowatt-reactive-hours", EngineeringUnits.kilowattReactiveHours);
+        assertUnit(205, "megawatt-reactive-hours", EngineeringUnits.megawattReactiveHours);
+        assertUnit(242, "volt-ampere-reactive-hours", EngineeringUnits.voltAmpereReactiveHours);
+        assertUnit(243, "kilovolt-ampere-reactive-hours", EngineeringUnits.kilovoltAmpereReactiveHours);
+        assertUnit(244, "megavolt-ampere-reactive-hours", EngineeringUnits.megavoltAmpereReactiveHours);
+    }
+
+    @Test
+    public void kelvinUnitsDropDegreePrefix() {
+        // cn removes the word "degree" from all Kelvin units.
+        assertUnit(63, "kelvin", EngineeringUnits.kelvin);
+        assertUnit(121, "delta-kelvin", EngineeringUnits.deltaKelvin);
+        assertUnit(127, "joules-per-kelvin", EngineeringUnits.joulesPerKelvin);
+        assertUnit(128, "joules-per-kilogram-kelvin", EngineeringUnits.joulesPerKilogramKelvin);
+        assertUnit(141, "watts-per-square-meter-per-kelvin", EngineeringUnits.wattsPerSquareMeterPerKelvin);
+        assertUnit(151, "kilojoules-per-kelvin", EngineeringUnits.kilojoulesPerKelvin);
+        assertUnit(152, "megajoules-per-kelvin", EngineeringUnits.megajoulesPerKelvin);
+        assertUnit(176, "volts-per-kelvin", EngineeringUnits.voltsPerKelvin);
+        assertUnit(181, "kelvin-per-hour", EngineeringUnits.kelvinPerHour);
+        assertUnit(182, "kelvin-per-minute", EngineeringUnits.kelvinPerMinute);
+        assertUnit(189, "watts-per-meter-per-kelvin", EngineeringUnits.wattsPerMeterPerKelvin);
+        assertUnit(236, "minutes-per-kelvin", EngineeringUnits.minutesPerKelvin);
+    }
+
+    @Test
+    public void joulesPerHourErratumApplied() {
+        // cn corrects the "joule-per-hour" erratum to "joules-per-hour".
+        assertUnit(247, "joules-per-hour", EngineeringUnits.joulesPerHour);
+    }
+
+    private static void assertUnit(int id, String name, EngineeringUnits expected) {
+        assertEquals("Wrong id for " + name, expected, EngineeringUnits.forId(id));
+        assertEquals("Wrong name for id " + id, name, EngineeringUnits.nameForId(id));
+        assertEquals("forName mismatch for " + name, expected, EngineeringUnits.forName(name));
+    }
+
+    private static boolean isReservedGap(int id) {
+        for (int gap : RESERVED_GAPS) {
+            if (gap == id)
+                return true;
+        }
+        return false;
+    }
+}

--- a/src/test/java/com/serotonin/bacnet4j/type/primitive/SignedInteger16Test.java
+++ b/src/test/java/com/serotonin/bacnet4j/type/primitive/SignedInteger16Test.java
@@ -1,0 +1,106 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2026 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
+package com.serotonin.bacnet4j.type.primitive;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import org.junit.Test;
+
+import com.serotonin.bacnet4j.exception.BACnetServiceException;
+import com.serotonin.bacnet4j.type.enumerated.ErrorClass;
+import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
+import com.serotonin.bacnet4j.util.sero.ByteQueue;
+
+public class SignedInteger16Test {
+    @Test
+    public void constructorAcceptsInRangeValues() {
+        assertEquals(0, new SignedInteger16(0).intValue());
+        assertEquals(1, new SignedInteger16(1).intValue());
+        assertEquals(-1, new SignedInteger16(-1).intValue());
+        assertEquals(Short.MAX_VALUE, new SignedInteger16(Short.MAX_VALUE).intValue());
+        assertEquals(Short.MIN_VALUE, new SignedInteger16(Short.MIN_VALUE).intValue());
+    }
+
+    @Test
+    public void constructorRejectsAboveMax() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new SignedInteger16(Short.MAX_VALUE + 1));
+    }
+
+    @Test
+    public void constructorRejectsBelowMin() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new SignedInteger16(Short.MIN_VALUE - 1));
+    }
+
+    @Test
+    public void wireEncodingMatchesSignedInteger() {
+        // The wire encoding for SignedInteger16 must be identical to SignedInteger — ck-1 defines
+        // Integer16 as an ASN.1 subtype of Integer with no encoding difference.
+        ByteQueue a = new ByteQueue();
+        new SignedInteger16(12345).write(a);
+        ByteQueue b = new ByteQueue();
+        new SignedInteger(12345).write(b);
+        assertEquals(b, a);
+    }
+
+    @Test
+    public void validateAcceptsDecodedInRangeValue() throws Exception {
+        // Encode via the base class then decode as SignedInteger16 and validate.
+        SignedInteger source = new SignedInteger(100);
+        ByteQueue queue = new ByteQueue();
+        source.write(queue);
+        SignedInteger16 decoded = new SignedInteger16(queue);
+        decoded.validate();
+        assertEquals(100, decoded.intValue());
+    }
+
+    @Test
+    public void validateRejectsDecodedAboveMax() throws Exception {
+        // A wire value that fits SignedInteger but exceeds Integer16 must fail validate().
+        SignedInteger source = new SignedInteger(Short.MAX_VALUE + 1);
+        ByteQueue queue = new ByteQueue();
+        source.write(queue);
+        SignedInteger16 decoded = new SignedInteger16(queue);
+        BACnetServiceException ex = assertThrows(BACnetServiceException.class, decoded::validate);
+        assertEquals(ErrorClass.property, ex.getErrorClass());
+        assertEquals(ErrorCode.valueOutOfRange, ex.getErrorCode());
+    }
+
+    @Test
+    public void validateRejectsDecodedBelowMin() throws Exception {
+        SignedInteger source = new SignedInteger(Short.MIN_VALUE - 1);
+        ByteQueue queue = new ByteQueue();
+        source.write(queue);
+        SignedInteger16 decoded = new SignedInteger16(queue);
+        BACnetServiceException ex = assertThrows(BACnetServiceException.class, decoded::validate);
+        assertEquals(ErrorClass.property, ex.getErrorClass());
+        assertEquals(ErrorCode.valueOutOfRange, ex.getErrorCode());
+    }
+}


### PR DESCRIPTION
https://radixiot.atlassian.net/browse/MANGO-2968

- ReadRange count changed from Integer32 to Integer16 (addendum ck-1, Clause 21.5) — acf3be5f
- Engineering unit name corrections (addendum cn-1) — 276a4af3
- Network Port command error-code correction (addendum bx) — a97c0621
- Claim Protocol_Revision 26 — 1a3e37b5
