### PR TITLE
MANGO-2969 Verify rev 27 compliance

### DIFF
--- a/src/main/java/com/serotonin/bacnet4j/npdu/sc/SCConnection.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/sc/SCConnection.java
@@ -214,6 +214,10 @@ public class SCConnection {
                 // Centralize the parsing of payload here so that parsing issues can be handled.
                 try {
                     payload = parsePayload(message);
+                } catch (UnexpectedDataException e) {
+                    // AB.3.1.5 "If a BVLC message is received that is longer than expected..."
+                    protocolViolationLogAndSend(message, ErrorCode.unexpectedData, e.getMessage());
+                    return;
                 } catch (ArrayIndexOutOfBoundsException | IllegalArgumentException e) {
                     // AB.3.1.5 "If a BVLC message is received that is truncated..."
                     protocolViolationLogAndSend(message, ErrorCode.messageIncomplete,
@@ -615,6 +619,14 @@ public class SCConnection {
     }
 
     private SCBVLC parseMessage(ByteQueue queue) {
+        if (queue.size() < 4) {
+            // AB.3.1.5 (addendum 135-2020ci-9a): a BVLC message that does not contain a Message ID is
+            // discarded without returning a BVLC-Result NAK. The header is 4 octets: function, control,
+            // and the 2-octet Message ID.
+            LOG.error("{} protocol violation: BVLC message too short to contain a Message ID ({} octets); discarded",
+                    name, queue.size());
+            return null;
+        }
         if (queue.size() > network.getMaxBvlcLengthAccepted().intValue()) {
             // AB.7.5.3 discard
             LOG.error("{} protocol violation: length of BVLC message ({}) exceeds max accepted size ({})",
@@ -741,11 +753,35 @@ public class SCConnection {
 
     private SCPayload parsePayload(SCBVLC message) {
         return switch (message.getFunction()) {
-            case SCBVLC.CONNECT_ACCEPT -> new SCPayloadConnectAccept(message.getPayload());
+            case SCBVLC.CONNECT_ACCEPT -> {
+                checkFixedPayloadLength(message, SCPayloadConnectAccept.FIXED_LENGTH);
+                yield new SCPayloadConnectAccept(message.getPayload());
+            }
             case SCBVLC.BVLC_RESULT -> new SCPayloadBVLCResult(message.getPayload());
-            case SCBVLC.ADVERTISEMENT -> new SCPayloadAdvertisement(message.getPayload());
+            case SCBVLC.ADVERTISEMENT -> {
+                checkFixedPayloadLength(message, SCPayloadAdvertisement.FIXED_LENGTH);
+                yield new SCPayloadAdvertisement(message.getPayload());
+            }
             default -> null;
         };
+    }
+
+    /**
+     * Per AB.3.1.5 (addendum 135-2020ci-9a), a BVLC message that is longer than expected is discarded,
+     * with a NAK of COMMUNICATION/UNEXPECTED_DATA if it was a unicast request. A payload that is too
+     * short throws from the payload parser and is handled as MESSAGE_INCOMPLETE.
+     */
+    private static void checkFixedPayloadLength(SCBVLC message, int fixedLength) {
+        if (message.getPayload() != null && message.getPayload().length > fixedLength) {
+            throw new UnexpectedDataException(
+                    "payload is longer than expected: " + message.getPayload().length + " > " + fixedLength);
+        }
+    }
+
+    private static class UnexpectedDataException extends RuntimeException {
+        public UnexpectedDataException(String message) {
+            super(message);
+        }
     }
 
     private void protocolViolationLogOnly(ErrorCode errorCode, String errorDetails) {

--- a/src/main/java/com/serotonin/bacnet4j/npdu/sc/msg/SCPayloadAdvertisement.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/sc/msg/SCPayloadAdvertisement.java
@@ -34,6 +34,9 @@ import com.serotonin.bacnet4j.util.sero.ByteQueue;
  * This includes methods to parse from, and generate to, byte buffers.
  */
 public class SCPayloadAdvertisement implements SCPayload {
+    // Connection Status (1) + Accept Connections (1) + Maximum BVLC Length (2) + Maximum NPDU Length (2)
+    public static final int FIXED_LENGTH = 6;
+
     public static final int CONN_STAT_NONE = 0;
     public static final int CONN_STAT_PRIMARY = 1;
     public static final int CONN_STAT_FAILOVER = 2;

--- a/src/main/java/com/serotonin/bacnet4j/npdu/sc/msg/SCPayloadConnectAccept.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/sc/msg/SCPayloadConnectAccept.java
@@ -36,6 +36,9 @@ import com.serotonin.bacnet4j.util.sero.ByteQueue;
  * This includes methods to parse from, and generate to, byte buffers.
  */
 public class SCPayloadConnectAccept implements SCPayload {
+    // VMAC (6) + UUID (16) + Maximum BVLC Length (2) + Maximum NPDU Length (2)
+    public static final int FIXED_LENGTH = 26;
+
     public final SCUuid uuid;
     public final SCVmac vmac;
     public final int maximumBVLCLength;

--- a/src/main/java/com/serotonin/bacnet4j/obj/BACnetObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/BACnetObject.java
@@ -74,9 +74,6 @@ import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
 import com.serotonin.bacnet4j.type.primitive.Real;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
-/**
- * @author Matthew
- */
 public class BACnetObject {
     static final Logger LOG = LoggerFactory.getLogger(BACnetObject.class);
 

--- a/src/main/java/com/serotonin/bacnet4j/obj/BACnetObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/BACnetObject.java
@@ -554,10 +554,11 @@ public class BACnetObject {
 
                 if (pin.intValue() == 0) {
                     if (value.getValue() instanceof UnsignedInteger) {
-                        // Writing the size of the array is not allowed here because specific cases need to define what
-                        // value to use as a default when an array is being expanded. This condition therefore needs to
-                        // be handled in mixins or objects.
-                        throw new BACnetServiceException(ErrorClass.property, ErrorCode.writeAccessDenied);
+                        // Resizing the array is not handled here because specific cases need to define what value to
+                        // use as a default when an array is being expanded. Objects or mixins that support resizing
+                        // handle the write before this. Per 15.9.1.3.1 (addendum 135-2020ci-6), a write that would
+                        // resize the array to a size that is not supported returns INVALID_ARRAY_SIZE.
+                        throw new BACnetServiceException(ErrorClass.property, ErrorCode.invalidArraySize);
                     }
                     // Can only write an unsigned integer to the zero-index.
                     throw new BACnetServiceException(ErrorClass.property, ErrorCode.invalidArrayIndex);
@@ -666,29 +667,15 @@ public class BACnetObject {
     //
 
     @Override
-    public int hashCode() {
-        ObjectIdentifier id = getId();
-        int PRIME = 31;
-        int result = 1;
-        result = PRIME * result + (id == null ? 0 : id.hashCode());
-        return result;
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass())
+            return false;
+        BACnetObject that = (BACnetObject) o;
+        return Objects.equals(getId(), that.getId());
     }
 
     @Override
-    public boolean equals(Object obj) {
-        ObjectIdentifier id = getId();
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        BACnetObject other = (BACnetObject) obj;
-        if (id == null) {
-            if (other.getId() != null)
-                return false;
-        } else if (!id.equals(other.getId()))
-            return false;
-        return true;
+    public int hashCode() {
+        return Objects.hash(getId());
     }
 }

--- a/src/main/java/com/serotonin/bacnet4j/obj/DeviceObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/DeviceObject.java
@@ -223,7 +223,7 @@ public class DeviceObject extends BACnetObject {
         writePropertyInternal(PropertyIdentifier.firmwareRevision, new CharacterString("not set"));
         writePropertyInternal(PropertyIdentifier.applicationSoftwareVersion, new CharacterString(LocalDevice.VERSION));
         writePropertyInternal(PropertyIdentifier.protocolVersion, new UnsignedInteger(1));
-        writePropertyInternal(PropertyIdentifier.protocolRevision, new UnsignedInteger(26));
+        writePropertyInternal(PropertyIdentifier.protocolRevision, new UnsignedInteger(27));
 
         UnsignedInteger databaseRevision = getLocalDevice().getPersistence()
                 .loadEncodable(getPersistenceKey(PropertyIdentifier.databaseRevision), UnsignedInteger.class);

--- a/src/main/java/com/serotonin/bacnet4j/obj/EventEnrollmentObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/EventEnrollmentObject.java
@@ -55,7 +55,11 @@ import com.serotonin.bacnet4j.type.constructed.FaultParameter;
 import com.serotonin.bacnet4j.type.constructed.FaultParameter.AbstractFaultParameter;
 import com.serotonin.bacnet4j.type.constructed.ObjectPropertyReference;
 import com.serotonin.bacnet4j.type.constructed.PropertyReference;
+import com.serotonin.bacnet4j.type.constructed.PropertyValue;
 import com.serotonin.bacnet4j.type.constructed.StatusFlags;
+import com.serotonin.bacnet4j.type.constructed.ValueSource;
+import com.serotonin.bacnet4j.type.enumerated.ErrorClass;
+import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
 import com.serotonin.bacnet4j.type.enumerated.EventState;
 import com.serotonin.bacnet4j.type.enumerated.FaultType;
 import com.serotonin.bacnet4j.type.enumerated.NotifyType;
@@ -209,6 +213,31 @@ public class EventEnrollmentObject extends BACnetObject {
         // Start polling
         pollingFuture = localDevice.scheduleWithFixedDelay(this::doPoll, pollDelayMillis, pollDelayMillis,
                 TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    protected boolean validateProperty(ValueSource valueSource, PropertyValue value) throws BACnetServiceException {
+        if (PropertyIdentifier.eventParameters.equals(value.getPropertyIdentifier())
+                && value.getValue() instanceof EventParameter eventParameter) {
+            // Per 12.12.7 (addendum 135-2020ci-1), an attempt to write parameters for an unsupported
+            // event algorithm returns OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED.
+            AbstractEventParameter aep = eventParameter.getChoice().getDatum();
+            if (aep.createEventAlgorithm() == null) {
+                throw new BACnetServiceException(ErrorClass.property, ErrorCode.optionalFunctionalityNotSupported);
+            }
+        } else if (PropertyIdentifier.faultParameters.equals(value.getPropertyIdentifier())
+                && value.getValue() instanceof FaultParameter faultParameter) {
+            // Per 12.12.23 (addendum 135-2020ci-1), an attempt to write parameters for an unsupported
+            // fault algorithm returns OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED. The Null choice is valid
+            // and means that no fault algorithm is in use.
+            if (!faultParameter.isNull()) {
+                AbstractFaultParameter afp = faultParameter.getEntry().getDatum();
+                if (afp.createFaultAlgorithm() == null) {
+                    throw new BACnetServiceException(ErrorClass.property, ErrorCode.optionalFunctionalityNotSupported);
+                }
+            }
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/com/serotonin/bacnet4j/obj/NetworkPortObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/NetworkPortObject.java
@@ -244,9 +244,6 @@ public class NetworkPortObject extends BACnetObject {
             }
             // Only an MS/TP port can perform subordinate proxying.
             throw new BACnetServiceException(ErrorClass.property, ErrorCode.valueOutOfRange);
-        } else if (command.isOneOf(NetworkPortCommand.restartAutonegotiation, NetworkPortCommand.restartPort,
-                NetworkPortCommand.restartDeviceDiscovery, NetworkPortCommand.generateCsrFile)) {
-            throw new BACnetServiceException(ErrorClass.property, ErrorCode.optionalFunctionalityNotSupported);
         } else if (command == NetworkPortCommand.renewDhcp) {
             // Only an IPv4/IPv6 port can renew a DHCP lease.
             if (!networkType.isOneOf(NetworkType.ipv4, NetworkType.ipv6)) {

--- a/src/main/java/com/serotonin/bacnet4j/obj/NetworkPortObject.java
+++ b/src/main/java/com/serotonin/bacnet4j/obj/NetworkPortObject.java
@@ -46,6 +46,7 @@ import com.serotonin.bacnet4j.type.constructed.StatusFlags;
 import com.serotonin.bacnet4j.type.constructed.ValueSource;
 import com.serotonin.bacnet4j.type.enumerated.ErrorClass;
 import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
+import com.serotonin.bacnet4j.type.enumerated.IPMode;
 import com.serotonin.bacnet4j.type.enumerated.NetworkNumberQuality;
 import com.serotonin.bacnet4j.type.enumerated.NetworkPortCommand;
 import com.serotonin.bacnet4j.type.enumerated.NetworkType;
@@ -215,35 +216,62 @@ public class NetworkPortObject extends BACnetObject {
     }
 
     /**
-     * Subclasses should implement as required.
+     * Validates a command against the functionality this object supports. Per 12.56.14 (addendum
+     * 135-2020ci-3), writing a command that the object does not support returns
+     * OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED, except where the command's own clause specifies
+     * VALUE_OUT_OF_RANGE for ports of an inapplicable type or configuration. Subclasses that implement
+     * a command's functionality override this method, returning normally to accept the command, or
+     * throwing NOT_ENABLED when the functionality is supported but currently disabled.
      *
      * @param command the given command.
      */
     protected void validateCommandInternal(NetworkPortCommand command) throws BACnetServiceException {
-        if (command == NetworkPortCommand.renewDhcp) {
-            NetworkType networkType = get(PropertyIdentifier.networkType);
-            if (networkType == NetworkType.ipv4 || networkType == NetworkType.ipv6) {
-                throw new BACnetServiceException(ErrorClass.property, ErrorCode.optionalFunctionalityNotSupported);
+        NetworkType networkType = get(PropertyIdentifier.networkType);
+        if (command == NetworkPortCommand.renewFdRegistration) {
+            // Only an IPv4/IPv6 port in foreign mode can renew a foreign device registration.
+            IPMode ipMode = get(PropertyIdentifier.bacnetIpMode);
+            if (!networkType.isOneOf(NetworkType.ipv4, NetworkType.ipv6) || ipMode != IPMode.foreign) {
+                throw new BACnetServiceException(ErrorClass.property, ErrorCode.valueOutOfRange);
             }
-        }
-        if (command == NetworkPortCommand.restartSubordinateDiscovery) {
+            throw new BACnetServiceException(ErrorClass.property, ErrorCode.optionalFunctionalityNotSupported);
+        } else if (command == NetworkPortCommand.restartSubordinateDiscovery) {
             // Per 12.56.14, writing this value to a non-MS/TP port returns VALUE_OUT_OF_RANGE, while an
             // MS/TP port without subordinate proxy support returns OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED.
             // Subclasses that support subordinate proxying override this method. The non-MS/TP case falls
             // through to the VALUE_OUT_OF_RANGE below.
-            NetworkType networkType = get(PropertyIdentifier.networkType);
             if (networkType == NetworkType.mstp) {
                 throw new BACnetServiceException(ErrorClass.property, ErrorCode.optionalFunctionalityNotSupported);
             }
-        }
-        if (command.isOneOf(NetworkPortCommand.restartAutonegotiation, NetworkPortCommand.restartPort,
+            // Only an MS/TP port can perform subordinate proxying.
+            throw new BACnetServiceException(ErrorClass.property, ErrorCode.valueOutOfRange);
+        } else if (command.isOneOf(NetworkPortCommand.restartAutonegotiation, NetworkPortCommand.restartPort,
                 NetworkPortCommand.restartDeviceDiscovery, NetworkPortCommand.generateCsrFile)) {
             throw new BACnetServiceException(ErrorClass.property, ErrorCode.optionalFunctionalityNotSupported);
-        }
-        if (command.isOneOf(NetworkPortCommand.discardChanges, NetworkPortCommand.validateChanges)) {
+        } else if (command == NetworkPortCommand.renewDhcp) {
+            // Only an IPv4/IPv6 port can renew a DHCP lease.
+            if (!networkType.isOneOf(NetworkType.ipv4, NetworkType.ipv6)) {
+                throw new BACnetServiceException(ErrorClass.property, ErrorCode.valueOutOfRange);
+            }
+            throw new BACnetServiceException(ErrorClass.property, ErrorCode.optionalFunctionalityNotSupported);
+        } else if (command == NetworkPortCommand.disconnect) {
+            // Only a PTP port can disconnect.
+            if (networkType != NetworkType.ptp) {
+                throw new BACnetServiceException(ErrorClass.property, ErrorCode.valueOutOfRange);
+            }
+            throw new BACnetServiceException(ErrorClass.property, ErrorCode.optionalFunctionalityNotSupported);
+        } else if (command == NetworkPortCommand.restartAutonegotiation) {
+            // A port with autonegotiation disabled returns VALUE_OUT_OF_RANGE.
+            Boolean autonegotiate = get(PropertyIdentifier.linkSpeedAutonegotiate);
+            if (autonegotiate != null && !autonegotiate.booleanValue()) {
+                throw new BACnetServiceException(ErrorClass.property, ErrorCode.valueOutOfRange);
+            }
+            throw new BACnetServiceException(ErrorClass.property, ErrorCode.optionalFunctionalityNotSupported);
+        } else if (command.isOneOf(NetworkPortCommand.discardChanges, NetworkPortCommand.validateChanges)) {
             return;
         }
-        throw new BACnetServiceException(ErrorClass.property, ErrorCode.valueOutOfRange);
+        // All other commands this object does not support, including proprietary values, return
+        // OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED.
+        throw new BACnetServiceException(ErrorClass.property, ErrorCode.optionalFunctionalityNotSupported);
     }
 
     /**

--- a/src/main/java/com/serotonin/bacnet4j/service/confirmed/ReadRangeRequest.java
+++ b/src/main/java/com/serotonin/bacnet4j/service/confirmed/ReadRangeRequest.java
@@ -165,9 +165,11 @@ public class ReadRangeRequest extends ConfirmedRequestService {
             if (propertyIdentifier.isOneOf(PropertyIdentifier.all, PropertyIdentifier.required,
                     PropertyIdentifier.optional))
                 throw new BACnetServiceException(ErrorClass.services, ErrorCode.parameterOutOfRange);
-            // Property array index, if provided, cannot be 0.
+            // Per 15.8.1.3.1 (addendum 135-2020ci-6), an array index that is 0 or greater than the
+            // current length of the array returns INVALID_ARRAY_INDEX. The greater-than case is
+            // handled by the indexed property read below.
             if (propertyArrayIndex != null && propertyArrayIndex.intValue() == 0)
-                throw new BACnetServiceException(ErrorClass.services, ErrorCode.parameterOutOfRange);
+                throw new BACnetServiceException(ErrorClass.property, ErrorCode.invalidArrayIndex);
             // Count, if provided, cannot be zero.
             if (range != null && ((Range) range.getDatum()).getCount().intValue() == 0)
                 throw new BACnetServiceException(ErrorClass.services, ErrorCode.parameterOutOfRange);

--- a/src/test/java/com/serotonin/bacnet4j/npdu/sc/SCConnectionTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/npdu/sc/SCConnectionTest.java
@@ -1575,6 +1575,60 @@ public class SCConnectionTest {
     }
 
     /**
+     * Per AB.3.1.5 (addendum 135-2020ci-9a): a BVLC message that does not contain a Message ID (fewer
+     * than the 4 header octets) is discarded without a NAK. The 3-octet message here starts with the
+     * ENCAPSULATED_NPDU function, which would be NAK-eligible if the truncation were handled as
+     * MESSAGE_INCOMPLETE.
+     */
+    @Test
+    public void connected_messageWithoutMessageId_isDiscardedWithoutNak() {
+        enterConnected();
+        clearInvocations(client);
+
+        connection.onWebsocketMessage(new ByteQueue(new byte[] {SCBVLC.ENCAPSULATED_NPDU, 0x00, 0x00}));
+
+        assertEquals(SCConnection.State.CONNECTED, connection.getState());
+        verify(client, never()).send(any(byte[].class));
+    }
+
+    /**
+     * Per AB.3.1.5 (addendum 135-2020ci-9a): a BVLC message that is longer than expected is discarded
+     * and not processed. The oversized CONNECT_ACCEPT would otherwise parse successfully and move the
+     * state machine to CONNECTED. No NAK because CONNECT_ACCEPT is not a unicast request.
+     */
+    @Test
+    public void awaitingAccept_oversizedConnectAcceptPayload_isDiscarded() {
+        int connectId = enterAwaitingAccept();
+        clearInvocations(client);
+
+        // A valid, otherwise accepted, CONNECT_ACCEPT payload (fixed 26 bytes) with one trailing byte.
+        byte[] valid = new SCPayloadConnectAccept(new SCVmac(PEER_VMAC), new SCUuid(PEER_UUID), 1500, 1497).write();
+        byte[] oversized = new byte[valid.length + 1];
+        System.arraycopy(valid, 0, oversized, 0, valid.length);
+        feedMessage(new SCBVLC(null, null, SCBVLC.CONNECT_ACCEPT, oversized, connectId));
+
+        assertEquals(SCConnection.State.AWAITING_ACCEPT, connection.getState());
+        verify(client, never()).send(any(byte[].class));
+    }
+
+    /**
+     * Per AB.3.1.5 (addendum 135-2020ci-9a): an oversized ADVERTISEMENT is discarded and not
+     * processed. No NAK because ADVERTISEMENT is not a unicast request.
+     */
+    @Test
+    public void connected_oversizedAdvertisementPayload_isDiscarded() {
+        enterConnected();
+        clearInvocations(client);
+
+        // ADVERTISEMENT payload is fixed 6 bytes. Send 7.
+        var oversized = new SCBVLC(PEER_ORIGIN, null, SCBVLC.ADVERTISEMENT, new byte[7], 0);
+        feedMessage(oversized);
+
+        assertEquals(SCConnection.State.CONNECTED, connection.getState());
+        verify(client, never()).send(any(byte[].class));
+    }
+
+    /**
      * A CONNECTED-state peer BVLC-Result with truncated payload must not throw. BVLC_RESULT
      * is a response so no NAK is emitted; the state stays CONNECTED.
      */

--- a/src/test/java/com/serotonin/bacnet4j/obj/BACnetObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/BACnetObjectTest.java
@@ -79,9 +79,9 @@ public class BACnetObjectTest extends AbstractTest {
 
     @Test
     public void definedScalarWithIncorrectType() {
-        TestUtils.assertErrorAPDUException(() -> {
-            RequestUtils.writeProperty(d1, rd2, d2.getId(), PropertyIdentifier.description, new Real(0));
-        }, ErrorClass.property, ErrorCode.invalidDataType);
+        TestUtils.assertErrorAPDUException(() ->
+                        RequestUtils.writeProperty(d1, rd2, d2.getId(), PropertyIdentifier.description, new Real(0))
+                , ErrorClass.property, ErrorCode.invalidDataType);
     }
 
     @Test
@@ -102,10 +102,10 @@ public class BACnetObjectTest extends AbstractTest {
     @Test
     public void definedArrayWriteElementIncorrectType() {
         // Write a primitive type instead of a NameValue
-        TestUtils.assertErrorAPDUException(() -> {
-            RequestUtils.writeProperty(d1, rd2, d2.getId(), PropertyIdentifier.tags, 3,
-                    new BitString(new boolean[] {false}));
-        }, ErrorClass.property, ErrorCode.missingRequiredParameter);
+        TestUtils.assertErrorAPDUException(() ->
+                        RequestUtils.writeProperty(d1, rd2, d2.getId(), PropertyIdentifier.tags, 3,
+                                new BitString(new boolean[] {false}))
+                , ErrorClass.property, ErrorCode.missingRequiredParameter);
     }
 
     @Test
@@ -120,17 +120,17 @@ public class BACnetObjectTest extends AbstractTest {
 
     @Test
     public void definedArrayWriteIncorrectInnerType() {
-        TestUtils.assertErrorAPDUException(() -> {
-            RequestUtils.writeProperty(d1, rd2, d2.getId(), PropertyIdentifier.tags,
-                    new SequenceOf<>(new Real(-1), new Real(0), new Real(1)));
-        }, ErrorClass.property, ErrorCode.missingRequiredParameter);
+        TestUtils.assertErrorAPDUException(() ->
+                        RequestUtils.writeProperty(d1, rd2, d2.getId(), PropertyIdentifier.tags,
+                                new SequenceOf<>(new Real(-1), new Real(0), new Real(1)))
+                , ErrorClass.property, ErrorCode.missingRequiredParameter);
     }
 
     @Test
     public void definedArrayWriteIncorrectType() {
-        TestUtils.assertErrorAPDUException(() -> {
-            RequestUtils.writeProperty(d1, rd2, d2.getId(), PropertyIdentifier.tags, new Real(1));
-        }, ErrorClass.property, ErrorCode.missingRequiredParameter);
+        TestUtils.assertErrorAPDUException(() ->
+                        RequestUtils.writeProperty(d1, rd2, d2.getId(), PropertyIdentifier.tags, new Real(1))
+                , ErrorClass.property, ErrorCode.missingRequiredParameter);
     }
 
     @Test
@@ -147,27 +147,37 @@ public class BACnetObjectTest extends AbstractTest {
     @Test
     public void undefinedArrayWrite() {
         // Fails because the property isn't parsable.
-        TestUtils.assertErrorAPDUException(() -> {
-            RequestUtils.writeProperty(d1, rd2, d2.getId(), PropertyIdentifier.forId(5678),
-                    new SequenceOf<>(new Real(-0.1f), new Real(0), new Real(0.1f)));
-        }, ErrorClass.property, ErrorCode.datatypeNotSupported);
+        TestUtils.assertErrorAPDUException(() ->
+                        RequestUtils.writeProperty(d1, rd2, d2.getId(), PropertyIdentifier.forId(5678),
+                                new SequenceOf<>(new Real(-0.1f), new Real(0), new Real(0.1f)))
+                , ErrorClass.property, ErrorCode.datatypeNotSupported);
     }
 
     @Test
     public void undefinedArrayWriteElementLowIndexDirect() {
-        TestUtils.assertBACnetServiceException(() -> {
-            d2.getObject(d2.getId()).writeProperty(null,
-                    new PropertyValue(PropertyIdentifier.forId(6789), UnsignedInteger.ZERO, new Real(10), null));
-        }, ErrorClass.property, ErrorCode.invalidArrayIndex);
+        TestUtils.assertBACnetServiceException(() ->
+                        d2.getObject(d2.getId()).writeProperty(null,
+                                new PropertyValue(PropertyIdentifier.forId(6789), UnsignedInteger.ZERO, new Real(10), null))
+                , ErrorClass.property, ErrorCode.invalidArrayIndex);
     }
 
     @Test
     public void undefinedArrayWriteDataToArraySize() {
-        TestUtils.assertBACnetServiceException(() -> {
-            d2.getObject(d2.getId()).writeProperty(null,
-                    new PropertyValue(PropertyIdentifier.forId(6789), UnsignedInteger.ZERO, new UnsignedInteger(10),
-                            null));
-        }, ErrorClass.property, ErrorCode.writeAccessDenied);
+        // Per 15.9.1.3.1 (addendum 135-2020ci-6), a write that would resize the array to a size that
+        // is not supported returns INVALID_ARRAY_SIZE.
+        TestUtils.assertBACnetServiceException(() ->
+                        d2.getObject(d2.getId()).writeProperty(null,
+                                new PropertyValue(PropertyIdentifier.forId(6789), UnsignedInteger.ZERO, new UnsignedInteger(10),
+                                        null))
+                , ErrorClass.property, ErrorCode.invalidArraySize);
+    }
+
+    @Test
+    public void definedArrayWriteDataToArraySize() {
+        // Same as above, for a standard array property, written over the network.
+        TestUtils.assertErrorAPDUException(() ->
+                        RequestUtils.writeProperty(d1, rd2, d2.getId(), PropertyIdentifier.tags, 0, new UnsignedInteger(10))
+                , ErrorClass.property, ErrorCode.invalidArraySize);
     }
 
     @Test
@@ -184,9 +194,9 @@ public class BACnetObjectTest extends AbstractTest {
 
     @Test
     public void undefinedArrayWriteElementHighIndex() {
-        TestUtils.assertErrorAPDUException(() -> {
-            RequestUtils.writeProperty(d1, rd2, d2.getId(), PropertyIdentifier.forId(6789), 4, new Real(10));
-        }, ErrorClass.property, ErrorCode.invalidArrayIndex);
+        TestUtils.assertErrorAPDUException(() ->
+                        RequestUtils.writeProperty(d1, rd2, d2.getId(), PropertyIdentifier.forId(6789), 4, new Real(10))
+                , ErrorClass.property, ErrorCode.invalidArrayIndex);
     }
 
     @Test
@@ -225,19 +235,19 @@ public class BACnetObjectTest extends AbstractTest {
     @Test
     public void definedListWriteIncorrectType() {
         //Standard test 135.1-2013, 9.22.2.3
-        TestUtils.assertErrorAPDUException(() -> {
-            RequestUtils.writeProperty(d1, rd2, d2.getId(), PropertyIdentifier.utcTimeSynchronizationRecipients,
-                    new ObjectIdentifier(ObjectType.analogOutput, 1));
-        }, ErrorClass.property, ErrorCode.invalidDataType);
+        TestUtils.assertErrorAPDUException(() ->
+                        RequestUtils.writeProperty(d1, rd2, d2.getId(), PropertyIdentifier.utcTimeSynchronizationRecipients,
+                                new ObjectIdentifier(ObjectType.analogOutput, 1))
+                , ErrorClass.property, ErrorCode.invalidDataType);
     }
 
     @Test
     public void primitiveWriteIncorrectType() {
         //Standard test 135.1-2013, 9.22.2.3
-        TestUtils.assertErrorAPDUException(() -> {
-            RequestUtils.writeProperty(d1, rd2, d2.getId(), PropertyIdentifier.backupFailureTimeout,
-                    new CharacterString("This is the wrong type"));
-        }, ErrorClass.property, ErrorCode.invalidDataType);
+        TestUtils.assertErrorAPDUException(() ->
+                        RequestUtils.writeProperty(d1, rd2, d2.getId(), PropertyIdentifier.backupFailureTimeout,
+                                new CharacterString("This is the wrong type"))
+                , ErrorClass.property, ErrorCode.invalidDataType);
     }
 
     @Test
@@ -256,9 +266,9 @@ public class BACnetObjectTest extends AbstractTest {
     @Test
     public void writeOutOfRange() {
         //Standard test 135.1-2013, 9.22.2.4 - write a Unsigned16 with a value out of range.
-        TestUtils.assertErrorAPDUException(() -> {
-            RequestUtils.writeProperty(d1, rd2, d2.getId(), PropertyIdentifier.backupFailureTimeout,
-                    new Unsigned32(new BigInteger("4294967295")));
-        }, ErrorClass.property, ErrorCode.valueOutOfRange);
+        TestUtils.assertErrorAPDUException(() ->
+                        RequestUtils.writeProperty(d1, rd2, d2.getId(), PropertyIdentifier.backupFailureTimeout,
+                                new Unsigned32(new BigInteger("4294967295")))
+                , ErrorClass.property, ErrorCode.valueOutOfRange);
     }
 }

--- a/src/test/java/com/serotonin/bacnet4j/obj/EventEnrollmentObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/EventEnrollmentObjectTest.java
@@ -27,10 +27,12 @@
 
 package com.serotonin.bacnet4j.obj;
 
+import static com.serotonin.bacnet4j.TestUtils.assertErrorAPDUException;
 import static com.serotonin.bacnet4j.TestUtils.awaitEquals;
 import static com.serotonin.bacnet4j.TestUtils.quiesce;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -46,6 +48,7 @@ import com.serotonin.bacnet4j.type.constructed.EventTransitionBits;
 import com.serotonin.bacnet4j.type.constructed.FaultParameter;
 import com.serotonin.bacnet4j.type.constructed.FaultParameter.FaultOutOfRange;
 import com.serotonin.bacnet4j.type.constructed.FaultParameter.FaultOutOfRange.FaultNormalValue;
+import com.serotonin.bacnet4j.type.constructed.FaultParameter.FaultStatusFlags;
 import com.serotonin.bacnet4j.type.constructed.PropertyStates;
 import com.serotonin.bacnet4j.type.constructed.PropertyValue;
 import com.serotonin.bacnet4j.type.constructed.Recipient;
@@ -53,6 +56,8 @@ import com.serotonin.bacnet4j.type.constructed.SequenceOf;
 import com.serotonin.bacnet4j.type.constructed.StatusFlags;
 import com.serotonin.bacnet4j.type.constructed.TimeStamp;
 import com.serotonin.bacnet4j.type.enumerated.EngineeringUnits;
+import com.serotonin.bacnet4j.type.enumerated.ErrorClass;
+import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
 import com.serotonin.bacnet4j.type.enumerated.EventState;
 import com.serotonin.bacnet4j.type.enumerated.EventType;
 import com.serotonin.bacnet4j.type.enumerated.NotifyType;
@@ -60,6 +65,7 @@ import com.serotonin.bacnet4j.type.enumerated.ObjectType;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
 import com.serotonin.bacnet4j.type.enumerated.Reliability;
 import com.serotonin.bacnet4j.type.eventParameter.ChangeOfState;
+import com.serotonin.bacnet4j.type.eventParameter.ChangeOfValue;
 import com.serotonin.bacnet4j.type.eventParameter.EventParameter;
 import com.serotonin.bacnet4j.type.eventParameter.OutOfRange;
 import com.serotonin.bacnet4j.type.notificationParameters.ChangeOfReliabilityNotif;
@@ -67,6 +73,7 @@ import com.serotonin.bacnet4j.type.notificationParameters.ChangeOfStateNotif;
 import com.serotonin.bacnet4j.type.notificationParameters.NotificationParameters;
 import com.serotonin.bacnet4j.type.primitive.Boolean;
 import com.serotonin.bacnet4j.type.primitive.CharacterString;
+import com.serotonin.bacnet4j.type.primitive.Null;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
 import com.serotonin.bacnet4j.type.primitive.Real;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
@@ -462,6 +469,64 @@ public class EventEnrollmentObjectTest extends AbstractTest {
         assertEquals(new Real(300), newOor.getLowLimit());
         assertEquals(new Real(700), newOor.getHighLimit());
         assertEquals(new Real(10), newOor.getDeadband());
+    }
+
+    /**
+     * Per addendum 135-2020ci-1 (Clauses 12.12.7 and 12.12.23): an attempt to write parameters for an
+     * unsupported event or fault algorithm returns a Result(-) with an error class of PROPERTY and an
+     * error code of OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED.
+     */
+    @Test
+    public void unsupportedAlgorithmWrites() throws Exception {
+        DeviceObjectPropertyReference ref =
+                new DeviceObjectPropertyReference(new ObjectIdentifier(ObjectType.analogValue, 1),
+                        PropertyIdentifier.minPresValue, null, new ObjectIdentifier(ObjectType.device, 3));
+        EventEnrollmentObject ee = d1.addObject(new EventEnrollmentObject(
+                d1, 0, "ee0", ref, NotifyType.alarm,
+                new EventParameter(new OutOfRange(new UnsignedInteger(1), new Real(30), new Real(70), new Real(0))),
+                new EventTransitionBits(true, true, true), 5, 100, null, new FaultParameter(
+                new FaultOutOfRange(new FaultNormalValue(new Real(10)), new FaultNormalValue(new Real(90))))));
+
+        // The change-of-value event algorithm is not implemented.
+        assertErrorAPDUException(() -> d2.send(rd1, new WritePropertyRequest(
+                        ee.getId(), PropertyIdentifier.eventParameters, null,
+                        new EventParameter(new ChangeOfValue(new UnsignedInteger(1), new Real(10))), null)).get(),
+                ErrorClass.property, ErrorCode.optionalFunctionalityNotSupported);
+
+        // The fault-status-flags fault algorithm is not implemented.
+        assertErrorAPDUException(() -> d2.send(rd1, new WritePropertyRequest(
+                        ee.getId(), PropertyIdentifier.faultParameters, null,
+                        new FaultParameter(new FaultStatusFlags(ref)), null)).get(),
+                ErrorClass.property, ErrorCode.optionalFunctionalityNotSupported);
+
+        // The properties are unchanged.
+        EventParameter eventParams = ee.get(PropertyIdentifier.eventParameters);
+        assertEquals(EventType.outOfRange, eventParams.getEventType());
+        FaultParameter faultParams = ee.get(PropertyIdentifier.faultParameters);
+        assertTrue(faultParams.getEntry().getDatum() instanceof FaultOutOfRange);
+    }
+
+    /**
+     * The Null choice of Fault_Parameters means that no fault algorithm is in use, and so is not an
+     * unsupported algorithm. A write of it succeeds.
+     */
+    @Test
+    public void nullFaultParametersWrite() throws Exception {
+        DeviceObjectPropertyReference ref =
+                new DeviceObjectPropertyReference(new ObjectIdentifier(ObjectType.analogValue, 1),
+                        PropertyIdentifier.minPresValue, null, new ObjectIdentifier(ObjectType.device, 3));
+        EventEnrollmentObject ee = d1.addObject(new EventEnrollmentObject(
+                d1, 0, "ee0", ref, NotifyType.alarm,
+                new EventParameter(new OutOfRange(new UnsignedInteger(1), new Real(30), new Real(70), new Real(0))),
+                new EventTransitionBits(true, true, true), 5, 100, null, new FaultParameter(
+                new FaultOutOfRange(new FaultNormalValue(new Real(10)), new FaultNormalValue(new Real(90))))));
+
+        var response = d2.send(rd1, new WritePropertyRequest(ee.getId(), PropertyIdentifier.faultParameters, null,
+                new FaultParameter(Null.instance), null)).get();
+        assertNull(response);
+
+        FaultParameter faultParams = ee.get(PropertyIdentifier.faultParameters);
+        assertTrue(faultParams.isNull());
     }
 
     /**

--- a/src/test/java/com/serotonin/bacnet4j/obj/NetworkPortObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/NetworkPortObjectTest.java
@@ -54,6 +54,7 @@ import com.serotonin.bacnet4j.type.constructed.BACnetArray;
 import com.serotonin.bacnet4j.type.constructed.ValueSource;
 import com.serotonin.bacnet4j.type.enumerated.ErrorClass;
 import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
+import com.serotonin.bacnet4j.type.enumerated.IPMode;
 import com.serotonin.bacnet4j.type.enumerated.NetworkNumberQuality;
 import com.serotonin.bacnet4j.type.enumerated.NetworkPortCommand;
 import com.serotonin.bacnet4j.type.enumerated.NetworkType;
@@ -296,6 +297,132 @@ public class NetworkPortObjectTest {
             npo.writeProperty(new ValueSource(), PropertyIdentifier.networkType, NetworkType.ipv6);
             thrown = assertThrows(BACnetServiceException.class, () -> npo.writeProperty(
                     new ValueSource(), PropertyIdentifier.command, NetworkPortCommand.renewDhcp));
+            assertEquals(ErrorClass.property, thrown.getErrorClass());
+            assertEquals(ErrorCode.optionalFunctionalityNotSupported, thrown.getErrorCode());
+        });
+    }
+
+    /**
+     * Per 12.56.14 as revised by addendum 135-2020ci-3, a command that the object does not support,
+     * including proprietary values, returns OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED.
+     */
+    @Test
+    public void commands_unsupported() throws Exception {
+        withLocalDevice(localDevice -> {
+            var npo = localDevice.addObject(new NetworkPortObject(localDevice, 12, "NetworkPort",
+                    false, NetworkType.virtual, ProtocolLevel.bacnetApplication, Set.of()));
+
+            for (NetworkPortCommand command : new NetworkPortCommand[] {
+                    NetworkPortCommand.restartPort,
+                    NetworkPortCommand.restartDeviceDiscovery,
+                    NetworkPortCommand.generateCsrFile,
+                    NetworkPortCommand.forId(200)}) {
+                var thrown = assertThrows(BACnetServiceException.class, () -> npo.writeProperty(
+                        new ValueSource(), PropertyIdentifier.command, command));
+                assertEquals(ErrorClass.property, thrown.getErrorClass());
+                assertEquals(ErrorCode.optionalFunctionalityNotSupported, thrown.getErrorCode());
+            }
+        });
+    }
+
+    @Test
+    public void commands_renewFdRegistration() throws Exception {
+        withLocalDevice(localDevice -> {
+            // A non-IP port rejects the command as out of range.
+            var virtual = localDevice.addObject(new NetworkPortObject(localDevice, 12, "NetworkPort",
+                    false, NetworkType.virtual, ProtocolLevel.bacnetApplication, Set.of()));
+            var thrown = assertThrows(BACnetServiceException.class, () -> virtual.writeProperty(
+                    new ValueSource(), PropertyIdentifier.command, NetworkPortCommand.renewFdRegistration));
+            assertEquals(ErrorClass.property, thrown.getErrorClass());
+            assertEquals(ErrorCode.valueOutOfRange, thrown.getErrorCode());
+
+            // An IPv4 port not in foreign mode rejects the command as out of range. Note that
+            // bacnetIpMode is a changes-pending property, and so must be set before the object is
+            // added, or the command write is rejected with INVALID_VALUE_IN_THIS_STATE instead.
+            var normal = new NetworkPortObject(localDevice, 13, "NetworkPortNormal",
+                    false, NetworkType.ipv4, ProtocolLevel.bacnetApplication, Set.of());
+            normal.writePropertyInternal(PropertyIdentifier.bacnetIpMode, IPMode.normal);
+            localDevice.addObject(normal);
+            thrown = assertThrows(BACnetServiceException.class, () -> normal.writeProperty(
+                    new ValueSource(), PropertyIdentifier.command, NetworkPortCommand.renewFdRegistration));
+            assertEquals(ErrorClass.property, thrown.getErrorClass());
+            assertEquals(ErrorCode.valueOutOfRange, thrown.getErrorCode());
+
+            // An IPv4 port in foreign mode without renewal support rejects it as unsupported functionality.
+            var foreign = new NetworkPortObject(localDevice, 14, "NetworkPortForeign",
+                    false, NetworkType.ipv4, ProtocolLevel.bacnetApplication, Set.of());
+            foreign.writePropertyInternal(PropertyIdentifier.bacnetIpMode, IPMode.foreign);
+            localDevice.addObject(foreign);
+            thrown = assertThrows(BACnetServiceException.class, () -> foreign.writeProperty(
+                    new ValueSource(), PropertyIdentifier.command, NetworkPortCommand.renewFdRegistration));
+            assertEquals(ErrorClass.property, thrown.getErrorClass());
+            assertEquals(ErrorCode.optionalFunctionalityNotSupported, thrown.getErrorCode());
+        });
+    }
+
+    @Test
+    public void commands_restartSubordinateDiscovery() throws Exception {
+        withLocalDevice(localDevice -> {
+            // A non-MS/TP port rejects the command as out of range.
+            var virtual = localDevice.addObject(new NetworkPortObject(localDevice, 12, "NetworkPort",
+                    false, NetworkType.virtual, ProtocolLevel.bacnetApplication, Set.of()));
+            var thrown = assertThrows(BACnetServiceException.class, () -> virtual.writeProperty(
+                    new ValueSource(), PropertyIdentifier.command, NetworkPortCommand.restartSubordinateDiscovery));
+            assertEquals(ErrorClass.property, thrown.getErrorClass());
+            assertEquals(ErrorCode.valueOutOfRange, thrown.getErrorCode());
+
+            // An MS/TP port without subordinate proxy support rejects it as unsupported functionality.
+            var mstp = localDevice.addObject(new NetworkPortObject(localDevice, 13, "NetworkPortMstp",
+                    false, NetworkType.mstp, ProtocolLevel.bacnetApplication, Set.of()));
+            thrown = assertThrows(BACnetServiceException.class, () -> mstp.writeProperty(
+                    new ValueSource(), PropertyIdentifier.command, NetworkPortCommand.restartSubordinateDiscovery));
+            assertEquals(ErrorClass.property, thrown.getErrorClass());
+            assertEquals(ErrorCode.optionalFunctionalityNotSupported, thrown.getErrorCode());
+        });
+    }
+
+    @Test
+    public void commands_restartAutonegotiation() throws Exception {
+        withLocalDevice(localDevice -> {
+            // A port without autonegotiation support rejects the command as unsupported functionality.
+            var npo = localDevice.addObject(new NetworkPortObject(localDevice, 12, "NetworkPort",
+                    false, NetworkType.virtual, ProtocolLevel.bacnetApplication, Set.of()));
+            var thrown = assertThrows(BACnetServiceException.class, () -> npo.writeProperty(
+                    new ValueSource(), PropertyIdentifier.command, NetworkPortCommand.restartAutonegotiation));
+            assertEquals(ErrorClass.property, thrown.getErrorClass());
+            assertEquals(ErrorCode.optionalFunctionalityNotSupported, thrown.getErrorCode());
+
+            // A port with autonegotiation disabled rejects it as out of range. Note that
+            // linkSpeedAutonegotiate is a changes-pending property, and so must be set before the
+            // object is added, or the command write is rejected with INVALID_VALUE_IN_THIS_STATE
+            // instead.
+            var noAutonegotiate = new NetworkPortObject(localDevice, 13, "NetworkPortNoAuto",
+                    false, NetworkType.virtual, ProtocolLevel.bacnetApplication, Set.of());
+            noAutonegotiate.writePropertyInternal(PropertyIdentifier.linkSpeedAutonegotiate, Boolean.FALSE);
+            localDevice.addObject(noAutonegotiate);
+            thrown = assertThrows(BACnetServiceException.class, () -> noAutonegotiate.writeProperty(
+                    new ValueSource(), PropertyIdentifier.command, NetworkPortCommand.restartAutonegotiation));
+            assertEquals(ErrorClass.property, thrown.getErrorClass());
+            assertEquals(ErrorCode.valueOutOfRange, thrown.getErrorCode());
+        });
+    }
+
+    @Test
+    public void commands_disconnect() throws Exception {
+        withLocalDevice(localDevice -> {
+            // A non-PTP port rejects the command as out of range.
+            var virtual = localDevice.addObject(new NetworkPortObject(localDevice, 12, "NetworkPort",
+                    false, NetworkType.virtual, ProtocolLevel.bacnetApplication, Set.of()));
+            var thrown = assertThrows(BACnetServiceException.class, () -> virtual.writeProperty(
+                    new ValueSource(), PropertyIdentifier.command, NetworkPortCommand.disconnect));
+            assertEquals(ErrorClass.property, thrown.getErrorClass());
+            assertEquals(ErrorCode.valueOutOfRange, thrown.getErrorCode());
+
+            // A PTP port without disconnect support rejects it as unsupported functionality.
+            var ptp = localDevice.addObject(new NetworkPortObject(localDevice, 13, "NetworkPortPtp",
+                    false, NetworkType.ptp, ProtocolLevel.bacnetApplication, Set.of()));
+            thrown = assertThrows(BACnetServiceException.class, () -> ptp.writeProperty(
+                    new ValueSource(), PropertyIdentifier.command, NetworkPortCommand.disconnect));
             assertEquals(ErrorClass.property, thrown.getErrorClass());
             assertEquals(ErrorCode.optionalFunctionalityNotSupported, thrown.getErrorCode());
         });

--- a/src/test/java/com/serotonin/bacnet4j/obj/NetworkPortObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/NetworkPortObjectTest.java
@@ -41,7 +41,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.lang3.SystemUtils;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -86,7 +85,7 @@ public class NetworkPortObjectTest {
                 canRun = false;
             }
         }
-        Assume.assumeTrue(canRun);
+        //        Assume.assumeTrue(canRun);
     }
 
     @Test
@@ -355,27 +354,6 @@ public class NetworkPortObjectTest {
             localDevice.addObject(foreign);
             thrown = assertThrows(BACnetServiceException.class, () -> foreign.writeProperty(
                     new ValueSource(), PropertyIdentifier.command, NetworkPortCommand.renewFdRegistration));
-            assertEquals(ErrorClass.property, thrown.getErrorClass());
-            assertEquals(ErrorCode.optionalFunctionalityNotSupported, thrown.getErrorCode());
-        });
-    }
-
-    @Test
-    public void commands_restartSubordinateDiscovery() throws Exception {
-        withLocalDevice(localDevice -> {
-            // A non-MS/TP port rejects the command as out of range.
-            var virtual = localDevice.addObject(new NetworkPortObject(localDevice, 12, "NetworkPort",
-                    false, NetworkType.virtual, ProtocolLevel.bacnetApplication, Set.of()));
-            var thrown = assertThrows(BACnetServiceException.class, () -> virtual.writeProperty(
-                    new ValueSource(), PropertyIdentifier.command, NetworkPortCommand.restartSubordinateDiscovery));
-            assertEquals(ErrorClass.property, thrown.getErrorClass());
-            assertEquals(ErrorCode.valueOutOfRange, thrown.getErrorCode());
-
-            // An MS/TP port without subordinate proxy support rejects it as unsupported functionality.
-            var mstp = localDevice.addObject(new NetworkPortObject(localDevice, 13, "NetworkPortMstp",
-                    false, NetworkType.mstp, ProtocolLevel.bacnetApplication, Set.of()));
-            thrown = assertThrows(BACnetServiceException.class, () -> mstp.writeProperty(
-                    new ValueSource(), PropertyIdentifier.command, NetworkPortCommand.restartSubordinateDiscovery));
             assertEquals(ErrorClass.property, thrown.getErrorClass());
             assertEquals(ErrorCode.optionalFunctionalityNotSupported, thrown.getErrorCode());
         });

--- a/src/test/java/com/serotonin/bacnet4j/obj/NetworkPortObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/NetworkPortObjectTest.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.lang3.SystemUtils;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -85,7 +86,7 @@ public class NetworkPortObjectTest {
                 canRun = false;
             }
         }
-        //        Assume.assumeTrue(canRun);
+        Assume.assumeTrue(canRun);
     }
 
     @Test

--- a/src/test/java/com/serotonin/bacnet4j/obj/ScheduleObjectTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/obj/ScheduleObjectTest.java
@@ -48,6 +48,7 @@ import com.serotonin.bacnet4j.obj.ObjectTestUtils.ObjectWriteNotifier;
 import com.serotonin.bacnet4j.service.confirmed.AddListElementRequest;
 import com.serotonin.bacnet4j.service.confirmed.RemoveListElementRequest;
 import com.serotonin.bacnet4j.service.confirmed.WritePropertyMultipleRequest;
+import com.serotonin.bacnet4j.service.confirmed.WritePropertyRequest;
 import com.serotonin.bacnet4j.type.Encodable;
 import com.serotonin.bacnet4j.type.constructed.BACnetArray;
 import com.serotonin.bacnet4j.type.constructed.CalendarEntry;
@@ -566,6 +567,30 @@ public class ScheduleObjectTest extends AbstractTest {
         return d1.addObject(new CountingScheduleObject(
                 d1, 0, "sch-wesa", new DateRange(Date.UNSPECIFIED, Date.UNSPECIFIED), weeklySchedule,
                 new SequenceOf<>(), new Real(999), refs, 12, false));
+    }
+
+    /**
+     * Per BIBB SCHED-WS-I-B (K.3.8) as revised by addendum 135-2020ci-4: if the
+     * List_Of_Object_Property_References property is capable of referencing a commandable property,
+     * then the Priority_For_Writing property shall be writable. This schedule references commandable
+     * analog values, so the condition applies.
+     */
+    @Test
+    public void priorityForWritingIsWritable() throws Exception {
+        clock.set(2115, java.time.Month.MAY, 1, 12, 0, 0);
+
+        AnalogValueObject av0 = d2.addObject(new AnalogValueObject(
+                d2, 0, "av0", 98, EngineeringUnits.amperes, false).supportCommandable(-2));
+        AnalogValueObject av1 = d1.addObject(new AnalogValueObject(
+                d1, 1, "av1", 99, EngineeringUnits.amperesPerMeter, false).supportCommandable(-1));
+        ScheduleObject so = createScheduleObject(av0, av1, new Real(999));
+
+        assertEquals(new UnsignedInteger(12), so.readProperty(PropertyIdentifier.priorityForWriting));
+
+        var response = d2.send(rd1, new WritePropertyRequest(so.getId(), PropertyIdentifier.priorityForWriting, null,
+                new UnsignedInteger(9), null)).get();
+        assertNull(response);
+        assertEquals(new UnsignedInteger(9), so.readProperty(PropertyIdentifier.priorityForWriting));
     }
 
     private ScheduleObject createScheduleObject(AnalogValueObject av0, AnalogValueObject av1, Primitive scheduleDefault)

--- a/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadRangeRequestTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadRangeRequestTest.java
@@ -409,9 +409,10 @@ public class ReadRangeRequestTest {
                 () -> new ReadRangeRequest(d1.getId(), PropertyIdentifier.all, null).handle(d1, null),
                 ErrorClass.services, ErrorCode.parameterOutOfRange);
 
+        // Per 15.8.1.3.1 (addendum 135-2020ci-6), an array index of 0 returns INVALID_ARRAY_INDEX.
         TestUtils.assertRequestHandleException(
-                () -> new ReadRangeRequest(d1.getId(), pid, UnsignedInteger.ZERO).handle(d1, null), ErrorClass.services,
-                ErrorCode.parameterOutOfRange);
+                () -> new ReadRangeRequest(d1.getId(), pid, UnsignedInteger.ZERO).handle(d1, null), ErrorClass.property,
+                ErrorCode.invalidArrayIndex);
 
         TestUtils.assertRequestHandleException(
                 () -> new ReadRangeRequest(d1.getId(), pid, new UnsignedInteger(1), new ByPosition(1, 0)).handle(d1,


### PR DESCRIPTION
https://radixiot.atlassian.net/browse/MANGO-2969

This PR implements the changes required by the Protocol_Revision 27 addenda — ci (clarifications) — and raises the default Protocol_Revision of the Device object from 26 to 27. Each ci section was reviewed individually; the four that required code changes are below, and the remainder were verified as already compliant or not applicable.

Changes

- Event Enrollment: reject unsupported algorithm writes (ci-1) — 2f896aa0
- Network Port: optionally supported command procedure (ci-3) — 7ed9ead7
- Schedule Object requirements (ci-4) — 5f5ec28e
- INVALID_ARRAY_SIZE and array index errors (ci-6) — 0988b88f
- BVLC-Result in BACnet/SC (ci-9a) — c66ab276
- Claim Protocol_Revision 27 — 26943ee7

