### PR TITLE
MANGO-3108 Remove redundant logging messages

### DIFF
--- a/src/main/java/com/serotonin/bacnet4j/npdu/mstp/ManagerNode.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/mstp/ManagerNode.java
@@ -217,9 +217,7 @@ public class ManagerNode extends MstpNode {
     protected void idle() {
         if (silence() >= Constants.NO_TOKEN) {
             // LostToken
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("idle:LostToken");
-            }
+            LOG.debug("idle:LostToken");
             state = ManagerNodeState.noToken;
             activity = true;
         } else if (receivedInvalidFrame != null) {
@@ -231,9 +229,7 @@ public class ManagerNode extends MstpNode {
             frame();
             receivedValidFrame = false;
             activity = true;
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("idle:other");
-            }
+            LOG.debug("idle:other");
         }
     }
 

--- a/src/main/java/com/serotonin/bacnet4j/npdu/mstp/RealtimeManagerNode.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/mstp/RealtimeManagerNode.java
@@ -183,12 +183,10 @@ public class RealtimeManagerNode extends ManagerNode {
     @Override
     protected void waitForReply() {
         if (clock.millis() > lastFrameSendTime + responseTimeoutMs) {
-            if (LOG.isDebugEnabled())
-                LOG.debug("{} waitForReply:ReplyTimeout", thisStation);
+            LOG.debug("{} waitForReply:ReplyTimeout", thisStation);
             state = ManagerNodeState.idle;
         } else if (receivedValidFrame) {
-            if (LOG.isDebugEnabled())
-                LOG.debug("{} waitForReply:ReceivedReply", thisStation);
+            LOG.debug("{} waitForReply:ReceivedReply", thisStation);
             receivedDataNoReply(frame);
             state = ManagerNodeState.idle;
             receivedValidFrame = false;
@@ -203,8 +201,7 @@ public class RealtimeManagerNode extends ManagerNode {
         synchronized (this) {
             if (replyFrame != null) {
                 // Reply
-                if (LOG.isDebugEnabled())
-                    LOG.debug("{} answerDataRequest:Reply", thisStation);
+                LOG.debug("{} answerDataRequest:Reply", thisStation);
                 sendFrame(replyFrame);
                 replyFrame = null;
                 state = ManagerNodeState.idle;

--- a/src/main/java/com/serotonin/bacnet4j/npdu/mstp/RealtimeManagerNode.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/mstp/RealtimeManagerNode.java
@@ -32,7 +32,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 import com.serotonin.bacnet4j.exception.BACnetException;
 import com.serotonin.bacnet4j.npdu.mstp.realtime.RealtimeDriver;
@@ -145,7 +145,7 @@ public class RealtimeManagerNode extends ManagerNode {
                 receivedValidFrame = true;
             }
         } catch (IOException e) {
-            if (StringUtils.equals(e.getMessage(), "Stream closed."))
+            if (Strings.CS.equals(e.getMessage(), "Stream closed."))
                 throw new RuntimeException(e);
             LOG.debug("{} Input stream listener exception", thisStation, e);
             receiveError = true;
@@ -216,7 +216,6 @@ public class RealtimeManagerNode extends ManagerNode {
 
     @Override
     protected void sendFrame(Frame frame) {
-        LOG.info("Sending frame: {}", frame);
         try {
             if (LOG.isTraceEnabled()) {
                 LOG.trace("{} out: {}", tracePrefix(), frame);
@@ -243,11 +242,10 @@ public class RealtimeManagerNode extends ManagerNode {
             out.flush();
             bytesOut += frame.getLength() + 10; //Imply the missing bytes that the driver will add
             lastFrameSendTime = clock.millis();
-            LOG.info("Sent frame {}", frame);
         } catch (IOException e) {
             // Only write the same error message once. Prevents logs from getting filled up unnecessarily with repeated
             // error messages.
-            if (!StringUtils.equals(e.getMessage(), lastWriteError)) {
+            if (!Strings.CS.equals(e.getMessage(), lastWriteError)) {
                 // NOTE: should anything else be informed of this?
                 LOG.error("Error while sending frame", e);
                 lastWriteError = e.getMessage();

--- a/src/main/java/com/serotonin/bacnet4j/npdu/mstp/SubordinateNode.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/mstp/SubordinateNode.java
@@ -101,8 +101,7 @@ public class SubordinateNode extends MstpNode {
 
             if (type == null) {
                 // ReceivedUnwantedFrame
-                if (LOG.isDebugEnabled())
-                    LOG.debug("Unknown frame type");
+                LOG.debug("Unknown frame type");
             } else if (frame.broadcast()
                     && type.oneOf(FrameType.token, FrameType.bacnetDataExpectingReply, FrameType.testRequest)) {
                 // ReceivedUnwantedFrame

--- a/src/main/java/com/serotonin/bacnet4j/service/confirmed/WritePropertyMultipleRequest.java
+++ b/src/main/java/com/serotonin/bacnet4j/service/confirmed/WritePropertyMultipleRequest.java
@@ -85,7 +85,7 @@ public class WritePropertyMultipleRequest extends ConfirmedRequestService {
                 throw createException(ErrorClass.property, ErrorCode.unknownObject, spec, null);
 
             for (PropertyValue pv : spec.getListOfProperties()) {
-                LOG.info("Writing property {} into {}", pv, obj);
+                LOG.debug("Writing property {} into {}", pv, obj);
                 try {
                     if (localDevice.getEventHandler().checkAllowPropertyWrite(from, obj, pv)) {
                         obj.writeProperty(new ValueSource(from), pv);


### PR DESCRIPTION
https://radixiot.atlassian.net/browse/MANGO-3108

- Primary change is to remove redundant logging at info level of data that is logging - more appropriately - at trace level anyway
- Removed redundant logging guards
- SQ cleanup of `StringUtils` usages

There are still some info level logs in `MstpNode` in `receivedDataNoReply` and `receivedDataNeedingReply`, but i left those as they appear to be only called on incoming messages.