### PR TITLE
Fix for unsanitized input causing infinite loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ trendLogMult.writeProperty(PropertyIdentifier.recordCount, new UnsignedInteger(1
   `InMemeoryStreamAccess`. `FileStreamAccess` can be used as a drop in replacement for existing references to
   `StreamAccess`
 - Many non-breaking changes that bring BACnet4J up to compliance with protocol revision 30
+- The return value of `TagData.getTotalLength` has been changed from `int` to `long`. Fields that were previously public
+  have been changed to private and getters created.
 
 *Version 6.2.0*
 

--- a/src/main/java/com/serotonin/bacnet4j/type/AmbiguousValue.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/AmbiguousValue.java
@@ -31,8 +31,8 @@ import java.util.Arrays;
 import java.util.Objects;
 
 import com.serotonin.bacnet4j.exception.BACnetException;
+import com.serotonin.bacnet4j.exception.BACnetRuntimeException;
 import com.serotonin.bacnet4j.exception.BACnetServiceException;
-import com.serotonin.bacnet4j.type.primitive.Boolean;
 import com.serotonin.bacnet4j.type.primitive.Primitive;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
 import com.serotonin.bacnet4j.util.sero.StreamUtils;
@@ -61,9 +61,7 @@ public class AmbiguousValue extends Encodable {
     }
 
     public AmbiguousValue(ByteQueue queue) {
-        TagData tagData = new TagData();
-        peekTagData(queue, tagData);
-        readAmbiguousData(queue, tagData);
+        readAmbiguousData(queue, new TagData().peek(queue));
     }
 
     public AmbiguousValue(ByteQueue queue, int contextId) throws BACnetException {
@@ -71,7 +69,7 @@ public class AmbiguousValue extends Encodable {
 
         TagData tagData = new TagData();
         while (true) {
-            peekTagData(queue, tagData);
+            tagData.peek(queue);
             if (tagData.isEndTag(contextId))
                 break;
             readAmbiguousData(queue, tagData);
@@ -108,37 +106,6 @@ public class AmbiguousValue extends Encodable {
         this.data = newData;
     }
 
-    private void readAmbiguousData(ByteQueue queue, TagData tagData, ByteQueue data) {
-        if (!tagData.contextSpecific) {
-            // Application class.
-            if (tagData.tagNumber == Boolean.TYPE_ID)
-                copyData(queue, 1, data);
-            else
-                copyData(queue, tagData.getTotalLength(), data);
-        } else {
-            // Context specific class.
-            if (tagData.isStartTag()) {
-                // Copy the start tag
-                copyData(queue, 1, data);
-
-                // Remember the context id
-                int contextId = tagData.tagNumber;
-
-                // Read ambiguous data until we find the end tag.
-                while (true) {
-                    peekTagData(queue, tagData);
-                    if (tagData.isEndTag(contextId))
-                        break;
-                    readAmbiguousData(queue, tagData);
-                }
-
-                // Copy the end tag
-                copyData(queue, 1, data);
-            } else
-                copyData(queue, tagData.getTotalLength(), data);
-        }
-    }
-
     @Override
     public String toString() {
         if (data != null) {
@@ -155,7 +122,7 @@ public class AmbiguousValue extends Encodable {
                 try {
                     s = convertTo(Primitive.class).toString();
                 } catch (BACnetException e) {
-                    throw new RuntimeException(e);
+                    throw new BACnetRuntimeException(e);
                 }
                 return s;
             } else {
@@ -164,12 +131,6 @@ public class AmbiguousValue extends Encodable {
         } else {
             return "Ambiguous []";
         }
-    }
-
-    private static void copyData(ByteQueue queue, int length, ByteQueue data) {
-        int len = length;
-        while (len-- > 0)
-            data.push(queue.pop());
     }
 
     public boolean isNull() {

--- a/src/main/java/com/serotonin/bacnet4j/type/Encodable.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/Encodable.java
@@ -28,7 +28,6 @@
 package com.serotonin.bacnet4j.type;
 
 import static com.serotonin.bacnet4j.util.BACnetUtils.toInt;
-import static com.serotonin.bacnet4j.util.BACnetUtils.toLong;
 
 import java.lang.reflect.InvocationTargetException;
 
@@ -37,6 +36,7 @@ import org.slf4j.LoggerFactory;
 
 import com.serotonin.bacnet4j.exception.BACnetErrorException;
 import com.serotonin.bacnet4j.exception.BACnetException;
+import com.serotonin.bacnet4j.exception.BACnetRuntimeException;
 import com.serotonin.bacnet4j.exception.BACnetServiceException;
 import com.serotonin.bacnet4j.exception.ReflectionException;
 import com.serotonin.bacnet4j.obj.ObjectProperties;
@@ -54,6 +54,7 @@ import com.serotonin.bacnet4j.type.enumerated.ErrorCode;
 import com.serotonin.bacnet4j.type.enumerated.ObjectType;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
 import com.serotonin.bacnet4j.type.error.ErrorClassAndCode;
+import com.serotonin.bacnet4j.type.primitive.Boolean;
 import com.serotonin.bacnet4j.type.primitive.Null;
 import com.serotonin.bacnet4j.type.primitive.Primitive;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
@@ -74,34 +75,6 @@ public abstract class Encodable {
     @Override
     public String toString() {
         return "Encodable(" + getClass().getName() + ")";
-    }
-
-    protected static void popTagData(ByteQueue queue, TagData tagData) {
-        peekTagData(queue, tagData);
-        queue.pop(tagData.tagLength);
-    }
-
-    protected static void peekTagData(ByteQueue queue, TagData tagData) {
-        int peekIndex = 0;
-        byte b = queue.peek(peekIndex++);
-        tagData.tagNumber = (b & 0xff) >> 4;
-        tagData.contextSpecific = (b & 8) == 8;
-        tagData.length = b & 7;
-
-        if (tagData.tagNumber == 0xf)
-            // Extended tag.
-            tagData.tagNumber = toInt(queue.peek(peekIndex++));
-
-        if (tagData.length == 5) {
-            tagData.length = toInt(queue.peek(peekIndex++));
-            if (tagData.length == 254)
-                tagData.length = toLong(queue.peek(peekIndex++)) << 8 | toLong(queue.peek(peekIndex++));
-            else if (tagData.length == 255)
-                tagData.length = toLong(queue.peek(peekIndex++)) << 24 | toLong(queue.peek(peekIndex++)) << 16
-                        | toLong(queue.peek(peekIndex++)) << 8 | toLong(queue.peek(peekIndex++));
-        }
-
-        tagData.tagLength = peekIndex;
     }
 
     protected static boolean isContextTag(ByteQueue queue) {
@@ -136,7 +109,7 @@ public abstract class Encodable {
     // Write context tags for base types.
     protected void writeContextTag(ByteQueue queue, int contextId, boolean start) {
         if (contextId < 0 || contextId > 254)
-            throw new RuntimeException("Invalid context id: " + contextId);
+            throw new BACnetRuntimeException("Invalid context id: " + contextId);
 
         if (contextId <= 14)
             queue.push(contextId << 4 | (start ? 0xe : 0xf));
@@ -370,8 +343,7 @@ public abstract class Encodable {
     }
 
     private static Encodable readUnknown(ByteQueue queue, int contextId) throws BACnetException {
-        TagData tagData = new TagData();
-        peekTagData(queue, tagData);
+        TagData tagData = new TagData().peek(queue);
 
         // Check if the tag number matches the context id. If they match, then create the context-specific parameter,
         // otherwise an AmbiguousValue.
@@ -383,8 +355,8 @@ public abstract class Encodable {
 
         // Get the first tagData
         popStart(queue, contextId);
-        peekTagData(queue, tagData);
-        if (tagData.contextSpecific || !Primitive.isPrimitive(tagData.tagNumber)) {
+        tagData.peek(queue);
+        if (tagData.isContextSpecific() || !Primitive.isPrimitive(tagData.getTagNumber())) {
             // Constructed type or unknown primitive type. Give up and create an ambiguous.
             queue.clear();
             queue.push(originalQueue);
@@ -394,7 +366,7 @@ public abstract class Encodable {
             Primitive primitive = Primitive.createPrimitive(queue);
 
             // Peek again to see what the next tagData is.
-            peekTagData(queue, tagData);
+            tagData.peek(queue);
             if (tagData.isEndTag()) {
                 // Just one primitive. Check contextId in the End-Tag.
                 popEnd(queue, contextId);
@@ -405,13 +377,13 @@ public abstract class Encodable {
                 seq.add(primitive);
                 while (queue.size() > 0 && !tagData.isEndTag()) {
                     //If the data is something special, give up and create an ambiguous.
-                    if (tagData.contextSpecific || !Primitive.isPrimitive(tagData.tagNumber)) {
+                    if (tagData.isContextSpecific() || !Primitive.isPrimitive(tagData.getTagNumber())) {
                         queue.clear();
                         queue.push(originalQueue);
                         return new AmbiguousValue(queue, contextId);
                     }
                     seq.add(Primitive.createPrimitive(queue));
-                    peekTagData(queue, tagData);
+                    tagData.peek(queue);
                 }
                 // Check contextId in the End-Tag.
                 popEnd(queue, contextId);
@@ -635,4 +607,55 @@ public abstract class Encodable {
             type.write(queue, contextId);
     }
 
+    protected static void readAmbiguousData(ByteQueue queue, TagData tagData, ByteQueue data) {
+        if (!tagData.isContextSpecific()) {
+            // Application class.
+            if (tagData.getTagNumber() == Boolean.TYPE_ID)
+                copyAmbiguousData(queue, 1, data);
+            else
+                copyAmbiguousData(queue, tagData.getTotalLength(), data);
+        } else {
+            readContextSpecificAmbiguousData(queue, tagData, data);
+        }
+    }
+
+    protected static void readContextSpecificAmbiguousData(ByteQueue queue, TagData tagData, ByteQueue data) {
+        // Context specific class.
+        if (tagData.isStartTag()) {
+            // Copy the start tag
+            copyAmbiguousData(queue, 1, data);
+
+            // Remember the context id
+            var contextId = tagData.getTagNumber();
+
+            // Read ambiguous data until we find the end tag. The nested content must be written into the same
+            // queue as the enclosing start and end tags, otherwise it is appended to the accumulated data
+            // ahead of the start tag that introduces it.
+            while (true) {
+                tagData.peek(queue);
+                if (tagData.isEndTag(contextId))
+                    break;
+                readAmbiguousData(queue, tagData, data);
+            }
+
+            // Copy the end tag
+            copyAmbiguousData(queue, 1, data);
+        } else if (tagData.isEndTag()) {
+            // The callers break out of their read loops on the end tag that matches the start tag they are
+            // inside, so any end tag reaching here closes a context that was never opened.
+            throw new BACnetRuntimeException(
+                    "Unbalanced end tag " + tagData.getTagNumber() + ", encoded data may be corrupt");
+        } else {
+            copyAmbiguousData(queue, tagData.getTotalLength(), data);
+        }
+    }
+
+    private static void copyAmbiguousData(ByteQueue queue, long length, ByteQueue data) {
+        if (length > queue.size()) {
+            // Guard for https://github.com/RadixIoT/BACnet4J/issues/66
+            throw new BACnetRuntimeException("Illegal copy length: " + length + ", encoded data may be corrupt");
+        }
+        while (length-- > 0)
+            data.push(queue.pop());
+    }
 }

--- a/src/main/java/com/serotonin/bacnet4j/type/EncodedValue.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/EncodedValue.java
@@ -28,54 +28,53 @@
 package com.serotonin.bacnet4j.type;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 import com.serotonin.bacnet4j.exception.BACnetException;
-import com.serotonin.bacnet4j.exception.BACnetRuntimeException;
 import com.serotonin.bacnet4j.exception.BACnetServiceException;
-import com.serotonin.bacnet4j.type.primitive.Boolean;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
 import com.serotonin.bacnet4j.util.sero.StreamUtils;
 
 public class EncodedValue extends Encodable {
     private final byte[] data;
 
-    public EncodedValue(final byte[] data) {
+    public EncodedValue(byte[] data) {
         this.data = data;
     }
 
-    public EncodedValue(final Encodable... sequence) {
-        final ByteQueue queue = new ByteQueue();
-        for (final Encodable e : sequence) {
+    public EncodedValue(Encodable... sequence) {
+        ByteQueue queue = new ByteQueue();
+        for (Encodable e : sequence) {
             e.write(queue);
         }
         data = queue.popAll();
     }
 
-    public EncodedValue(final ByteQueue queue, final int contextId) throws BACnetException {
+    public EncodedValue(ByteQueue queue, int contextId) throws BACnetException {
         popStart(queue, contextId);
 
-        final TagData tagData = new TagData();
-        final ByteQueue data = new ByteQueue();
+        var tagData = new TagData();
+        var valueData = new ByteQueue();
         while (true) {
-            peekTagData(queue, tagData);
+            tagData.peek(queue);
             if (tagData.isEndTag(contextId))
                 break;
-            readData(queue, tagData, data);
+            readAmbiguousData(queue, tagData, valueData);
         }
-        this.data = data.popAll();
+        this.data = valueData.popAll();
 
         popEnd(queue, contextId);
     }
 
     @Override
-    public void write(final ByteQueue queue, final int contextId) {
+    public void write(ByteQueue queue, int contextId) {
         writeContextTag(queue, contextId, true);
         queue.push(data);
         writeContextTag(queue, contextId, false);
     }
 
     @Override
-    public void write(final ByteQueue queue) {
+    public void write(ByteQueue queue) {
         queue.push(data);
     }
 
@@ -83,73 +82,22 @@ public class EncodedValue extends Encodable {
         return data;
     }
 
-    private void readData(final ByteQueue queue, final TagData tagData, final ByteQueue data) {
-        if (!tagData.contextSpecific) {
-            // Application class.
-            if (tagData.tagNumber == Boolean.TYPE_ID)
-                copyData(queue, 1, data);
-            else
-                copyData(queue, tagData.getTotalLength(), data);
-        } else {
-            // Context specific class.
-            if (tagData.isStartTag()) {
-                // Copy the start tag
-                copyData(queue, 1, data);
-
-                // Remember the context id
-                final int contextId = tagData.tagNumber;
-
-                // Read ambiguous data until we find the end tag.
-                while (true) {
-                    peekTagData(queue, tagData);
-                    if (tagData.isEndTag(contextId))
-                        break;
-                    readData(queue, tagData, data);
-                }
-
-                // Copy the end tag
-                copyData(queue, 1, data);
-            } else {
-                copyData(queue, tagData.getTotalLength(), data);
-            }
-        }
-    }
-
     @Override
     public String toString() {
         return "Encoded(" + StreamUtils.dumpArrayHex(data) + ")";
     }
 
-    private static void copyData(final ByteQueue queue, final int length, final ByteQueue data) {
-        if (length <= 0) {
-            // Guard for https://github.com/RadixIoT/BACnet4J/issues/66
-            throw new BACnetRuntimeException("Illegal copy length: " + length + ", encoded data may be corrupt");
-        }
-        int len = length;
-        while (len-- > 0)
-            data.push(queue.pop());
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass())
+            return false;
+        EncodedValue that = (EncodedValue) o;
+        return Objects.deepEquals(data, that.data);
     }
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + Arrays.hashCode(data);
-        return result;
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        final EncodedValue other = (EncodedValue) obj;
-        if (!Arrays.equals(data, other.data))
-            return false;
-        return true;
+        return Arrays.hashCode(data);
     }
 
     @Override

--- a/src/main/java/com/serotonin/bacnet4j/type/TagData.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/TagData.java
@@ -27,18 +27,47 @@
 
 package com.serotonin.bacnet4j.type;
 
-public class TagData {
-    public int tagNumber;
-    public boolean contextSpecific;
-    public long length;
-    public int tagLength;
+import static com.serotonin.bacnet4j.util.BACnetUtils.toInt;
+import static com.serotonin.bacnet4j.util.BACnetUtils.toLong;
 
-    public int getTotalLength() {
-        return (int) (length + tagLength);
+import com.serotonin.bacnet4j.util.sero.ByteQueue;
+
+public class TagData {
+    /**
+     * An LVT of 5 means the tag header carries an extended length.
+     */
+    static final int LVT_EXTENDED_LENGTH = 5;
+
+    /**
+     * An LVT of 6 marks a start tag, which carries no length of its own.
+     */
+    static final int LVT_START_TAG = 6;
+
+    /**
+     * An LVT of 7 marks an end tag, which carries no length of its own.
+     */
+    static final int LVT_END_TAG = 7;
+
+    private int tagNumber;
+    private boolean contextSpecific;
+    /**
+     * The raw length/value/type (LVT) field of the tag header. Values 0 through 4 are literal lengths, 5 means an
+     * extended length follows, and 6 and 7 mark start and end tags.
+     * <p>
+     * Start and end tags must be recognized from this field rather than from {@link #length}, because an extended
+     * length overwrites {@link #length} with a decoded value whose low bits are arbitrary and can therefore imitate
+     * a start or end tag.
+     */
+    private int lvt;
+    private long length;
+    private int tagLength;
+
+    public long getTotalLength() {
+        return length + tagLength;
     }
 
     public boolean isStartTag() {
-        return contextSpecific && ((length & 6) == 6);
+        return contextSpecific && lvt == LVT_START_TAG;
     }
 
     public boolean isStartTag(int contextId) {
@@ -46,10 +75,64 @@ public class TagData {
     }
 
     public boolean isEndTag() {
-        return contextSpecific && ((length & 7) == 7);
+        return contextSpecific && lvt == LVT_END_TAG;
     }
 
     public boolean isEndTag(int contextId) {
         return isEndTag() && tagNumber == contextId;
+    }
+
+    public int getTagNumber() {
+        return tagNumber;
+    }
+
+    public boolean isContextSpecific() {
+        return contextSpecific;
+    }
+
+    public int getLvt() {
+        return lvt;
+    }
+
+    public long getLength() {
+        return length;
+    }
+
+    public int getTagLength() {
+        return tagLength;
+    }
+
+    public TagData pop(ByteQueue queue) {
+        peek(queue);
+        queue.pop(tagLength);
+        return this;
+    }
+
+    public TagData peek(ByteQueue queue) {
+        var peekIndex = 0;
+        var b = queue.peek(peekIndex++);
+        tagNumber = (b & 0xff) >> 4;
+        contextSpecific = (b & 8) == 8;
+        lvt = b & 7;
+        length = lvt;
+
+        if (tagNumber == 0xf) {
+            // Extended tag.
+            tagNumber = toInt(queue.peek(peekIndex++));
+        }
+
+        if (lvt == TagData.LVT_EXTENDED_LENGTH) {
+            length = toInt(queue.peek(peekIndex++));
+            if (length == 254) {
+                length = toLong(queue.peek(peekIndex++)) << 8 | toLong(queue.peek(peekIndex++));
+            } else if (length == 255) {
+                length = toLong(queue.peek(peekIndex++)) << 24 | toLong(queue.peek(peekIndex++)) << 16
+                        | toLong(queue.peek(peekIndex++)) << 8 | toLong(queue.peek(peekIndex++));
+            }
+        }
+
+        tagLength = peekIndex;
+
+        return this;
     }
 }

--- a/src/test/java/com/serotonin/bacnet4j/type/AmbiguousValueTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/type/AmbiguousValueTest.java
@@ -27,13 +27,16 @@
 
 package com.serotonin.bacnet4j.type;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
 import com.serotonin.bacnet4j.exception.BACnetException;
+import com.serotonin.bacnet4j.exception.BACnetRuntimeException;
 import com.serotonin.bacnet4j.type.primitive.Null;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 import com.serotonin.bacnet4j.util.sero.ByteQueue;
@@ -60,5 +63,89 @@ public class AmbiguousValueTest {
         var amb = new AmbiguousValue(content, 0xa);
         assertFalse(amb.isNull());
         assertEquals(new UnsignedInteger(13), amb.convertTo(UnsignedInteger.class));
+    }
+
+    /**
+     * A corrupt 4-byte extended length used to wrap to zero or negative in TagData.getTotalLength, which made
+     * copyAmbiguousData consume nothing and left the enclosing read loops spinning forever. Each vector below is
+     * "3e" (context 3 start tag) followed by a tag whose declared length exceeds the remaining content.
+     */
+    @Test(timeout = 5_000)
+    public void corruptExtendedLengthIsRejected() {
+        // 2 = tag number, 5 = extended length, ff = 4-byte length follows.
+        // The lowest and highest lengths that wrapped to a non-positive int, plus one that wrapped to 1.
+        assertCorrupt("3e25ff7ffffffa", 3);
+        assertCorrupt("3e25fffffffffa", 3);
+        assertCorrupt("3e25fffffffffb", 3);
+        // Same, but context specific rather than application class.
+        assertCorrupt("3e2dfff0000000", 3);
+        // f5 = extended tag number, which makes the tag header one byte longer and shifts the wrap point.
+        assertCorrupt("3ef550ff7ffffff9", 3);
+        assertCorrupt("3ef550fffffffff9", 3);
+        // A large length that never wrapped, but still overruns the queue.
+        assertCorrupt("3e25ff7ffffff9", 3);
+    }
+
+    /**
+     * The single argument constructor reaches the same read loop via the start tag branch.
+     */
+    @Test(timeout = 5_000)
+    public void corruptExtendedLengthIsRejectedWithoutContextId() {
+        var queue = new ByteQueue("3e25fff0000000");
+        assertThrows(BACnetRuntimeException.class, () -> new AmbiguousValue(queue));
+    }
+
+    /**
+     * An extended length is an arbitrary 32 bit number, so its low bits can imitate the start and end tag markers.
+     * Such a tag must not be mistaken for a start or end tag, since that would consume the wrong number of bytes.
+     */
+    @Test(timeout = 5_000)
+    public void extendedLengthIsNotMistakenForStartOrEndTag() {
+        // 7 = tag number, d = context specific with extended length, ff = 4-byte length follows.
+        // The low bits of f0000006 match the start tag marker, and those of f0000007 match the end tag marker.
+        assertCorrupt("3e7dfff0000006", 3);
+        assertCorrupt("3e7dfff0000007", 3);
+    }
+
+    /**
+     * An end tag closing a context that was never opened is malformed rather than something to copy through.
+     */
+    @Test(timeout = 5_000)
+    public void unbalancedEndTagIsRejected() {
+        assertCorrupt("3e4f", 3);
+    }
+
+    /**
+     * The matching end tag still terminates the read, leaving empty content.
+     */
+    @Test(timeout = 5_000)
+    public void matchingEndTagTerminatesRead() throws BACnetException {
+        var amb = new AmbiguousValue(new ByteQueue("3e3f"), 3);
+        assertTrue(amb.isNull());
+    }
+
+    /**
+     * Nested start and end tags are copied through intact.
+     */
+    @Test(timeout = 5_000)
+    public void nestedStartAndEndTagsAreCopied() throws BACnetException {
+        // 3e ( 5e ( 21 0d ) 5f ) 3f
+        var amb = new AmbiguousValue(new ByteQueue("3e5e210d5f3f"), 3);
+        assertArrayEquals(new byte[] { 0x5e, 0x21, 0x0d, 0x5f }, amb.getData());
+    }
+
+    /**
+     * A tag declaring a length of zero is legitimate: only the tag byte itself is consumed.
+     */
+    @Test(timeout = 5_000)
+    public void zeroLengthTagIsNotCorrupt() throws BACnetException {
+        var queue = new ByteQueue("3e203f");
+        var amb = new AmbiguousValue(queue, 3);
+        assertArrayEquals(new byte[] { 0x20 }, amb.getData());
+    }
+
+    private static void assertCorrupt(String hex, int contextId) {
+        var queue = new ByteQueue(hex);
+        assertThrows(hex, BACnetRuntimeException.class, () -> new AmbiguousValue(queue, contextId));
     }
 }

--- a/src/test/java/com/serotonin/bacnet4j/type/AmbiguousValueTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/type/AmbiguousValueTest.java
@@ -131,7 +131,7 @@ public class AmbiguousValueTest {
     public void nestedStartAndEndTagsAreCopied() throws BACnetException {
         // 3e ( 5e ( 21 0d ) 5f ) 3f
         var amb = new AmbiguousValue(new ByteQueue("3e5e210d5f3f"), 3);
-        assertArrayEquals(new byte[] { 0x5e, 0x21, 0x0d, 0x5f }, amb.getData());
+        assertArrayEquals(new byte[] {0x5e, 0x21, 0x0d, 0x5f}, amb.getData());
     }
 
     /**
@@ -141,7 +141,7 @@ public class AmbiguousValueTest {
     public void zeroLengthTagIsNotCorrupt() throws BACnetException {
         var queue = new ByteQueue("3e203f");
         var amb = new AmbiguousValue(queue, 3);
-        assertArrayEquals(new byte[] { 0x20 }, amb.getData());
+        assertArrayEquals(new byte[] {0x20}, amb.getData());
     }
 
     private static void assertCorrupt(String hex, int contextId) {

--- a/src/test/java/com/serotonin/bacnet4j/type/EncodableTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/type/EncodableTest.java
@@ -28,8 +28,8 @@
 package com.serotonin.bacnet4j.type;
 
 import static org.junit.Assert.assertEquals;
-
-import java.io.UnsupportedEncodingException;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -150,7 +150,6 @@ public class EncodableTest {
                 new CharacterString("This is a BACnet string!"));
         decodePrimitive("FD7F1900546869732069732061204241436E657420737472696E6721", 127,
                 new CharacterString("This is a BACnet string!"));
-        // TODO The spec say this starts with '75'. Should probably point this out.
         decodePrimitive("7D0A004672616EC3A7616973", 7, new CharacterString("Français"));
         decodePrimitive("0A03A8", 0, new BitString(new boolean[] {true, false, true, false, true,}));
         decodePrimitive("9900", 9, new Enumerated(0));
@@ -160,7 +159,7 @@ public class EncodableTest {
     }
 
     @Test
-    public void shouldDecodeJapaneseEncoding() throws BACnetException, UnsupportedEncodingException {
+    public void shouldDecodeJapaneseEncoding() throws BACnetException {
         ByteQueue queue = new ByteQueue();
         String text = "JapaneseEncoding ｦ";
         CharacterString value = new CharacterString(
@@ -173,10 +172,10 @@ public class EncodableTest {
         assertEquals(text, characterString.getValue());
     }
 
-    private static void decodePrimitive(final String hex, final Primitive expected) throws BACnetException {
+    private static void decodePrimitive(String hex, Primitive expected) throws BACnetException {
         // Decode the given hex and compare
-        final ByteQueue queue = new ByteQueue(hex);
-        final Primitive p = Encodable.read(queue, Primitive.class);
+        ByteQueue queue = new ByteQueue(hex);
+        Primitive p = Encodable.read(queue, Primitive.class);
         assertEquals(expected, p);
 
         assertEquals(0, queue.size());
@@ -186,11 +185,10 @@ public class EncodableTest {
         assertEquals(new ByteQueue(hex), queue);
     }
 
-    private static void decodePrimitive(final String hex, final int ctxId, final Primitive expected)
-            throws BACnetException {
+    private static void decodePrimitive(String hex, int ctxId, Primitive expected) throws BACnetException {
         // Decode the given hex and compare
-        final ByteQueue queue = new ByteQueue(hex);
-        final Primitive p = Encodable.read(queue, expected.getClass(), ctxId);
+        ByteQueue queue = new ByteQueue(hex);
+        Primitive p = Encodable.read(queue, expected.getClass(), ctxId);
         assertEquals(expected, p);
 
         assertEquals(0, queue.size());
@@ -202,28 +200,28 @@ public class EncodableTest {
 
     @Test
     public void portPermission() throws BACnetException {
-        final PortPermission pp = new PortPermission(new Unsigned8(14), Boolean.TRUE);
-        final ByteQueue queue = new ByteQueue();
+        PortPermission pp = new PortPermission(new Unsigned8(14), Boolean.TRUE);
+        ByteQueue queue = new ByteQueue();
         Encodable.write(queue, pp, 9);
 
         assertEquals(new ByteQueue("9e090e19019f"), queue);
 
-        final PortPermission pp2 = Encodable.read(queue, PortPermission.class, 9);
+        PortPermission pp2 = Encodable.read(queue, PortPermission.class, 9);
         assertEquals(14, pp2.getPortId().intValue());
-        assertEquals(true, pp2.getEnabled().booleanValue());
+        assertTrue(pp2.getEnabled().booleanValue());
     }
 
     @Test
     public void calendarEntry() throws BACnetException {
-        final CalendarEntry ce = new CalendarEntry(
+        CalendarEntry ce = new CalendarEntry(
                 new DateRange(new Date(2017, Month.JANUARY, 19, null), new Date(2017, Month.JANUARY, 23, null)));
-        final ByteQueue queue = new ByteQueue();
+        ByteQueue queue = new ByteQueue();
         Encodable.write(queue, ce, 43);
 
         assertEquals(new ByteQueue("fe2b1ea4750113ffa4750117ff1fff2b"), queue);
 
-        final CalendarEntry ce2 = Encodable.read(queue, CalendarEntry.class, 43);
-        assertEquals(true, ce2.isDateRange());
+        CalendarEntry ce2 = Encodable.read(queue, CalendarEntry.class, 43);
+        assertTrue(ce2.isDateRange());
         assertEquals(19, ce2.getDateRange().getStartDate().getDay());
         assertEquals(Month.JANUARY, ce2.getDateRange().getStartDate().getMonth());
         assertEquals(DayOfWeek.UNSPECIFIED, ce2.getDateRange().getStartDate().getDayOfWeek());
@@ -236,14 +234,14 @@ public class EncodableTest {
 
     @Test
     public void scale() throws BACnetException {
-        final Scale scale = new Scale(new SignedInteger(-123));
-        final ByteQueue queue = new ByteQueue();
+        Scale scale = new Scale(new SignedInteger(-123));
+        ByteQueue queue = new ByteQueue();
         Encodable.write(queue, scale, 123);
 
         assertEquals(new ByteQueue("fe7b1985ff7b"), queue);
 
-        final Scale scale2 = Encodable.read(queue, Scale.class, 123);
-        assertEquals(false, scale2.isReal());
+        Scale scale2 = Encodable.read(queue, Scale.class, 123);
+        assertFalse(scale2.isReal());
         assertEquals(-123, scale2.getSignedInteger().intValue());
     }
 
@@ -279,14 +277,14 @@ public class EncodableTest {
                 254, "fefe3e09031c42dc00002c40a000003c3f800000493c59083ffffe");
     }
 
-    private static void testTimerStateChangeValue(final TimerStateChangeValue value, final int ctxId, final String hex)
+    private static void testTimerStateChangeValue(TimerStateChangeValue value, int ctxId, String hex)
             throws BACnetException {
-        final ByteQueue queue = new ByteQueue();
+        ByteQueue queue = new ByteQueue();
         Encodable.write(queue, value, ctxId);
 
         assertEquals(new ByteQueue(hex), queue);
 
-        final TimerStateChangeValue value2 = Encodable.read(queue, TimerStateChangeValue.class, ctxId);
+        TimerStateChangeValue value2 = Encodable.read(queue, TimerStateChangeValue.class, ctxId);
         assertEquals(value, value2);
     }
 }

--- a/src/test/java/com/serotonin/bacnet4j/type/EncodedValueTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/type/EncodedValueTest.java
@@ -28,9 +28,11 @@
 package com.serotonin.bacnet4j.type;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import org.junit.Test;
 
+import com.serotonin.bacnet4j.exception.BACnetRuntimeException;
 import com.serotonin.bacnet4j.type.constructed.DateTime;
 import com.serotonin.bacnet4j.type.primitive.Boolean;
 import com.serotonin.bacnet4j.type.primitive.CharacterString;
@@ -40,13 +42,13 @@ import com.serotonin.bacnet4j.util.sero.ByteQueue;
 public class EncodedValueTest {
     @Test
     public void constructed() throws Exception {
-        final EncodedValue original = new EncodedValue(new CharacterString("test"), Boolean.TRUE,
+        EncodedValue original = new EncodedValue(new CharacterString("test"), Boolean.TRUE,
                 new DateTime(1491329790372L));
 
         ByteQueue queue = new ByteQueue();
         original.write(queue, 4);
 
-        final EncodedValue parsed = new EncodedValue(queue, 4);
+        EncodedValue parsed = new EncodedValue(queue, 4);
         assertEquals(original, parsed);
 
         queue = new ByteQueue(parsed.getData());
@@ -63,11 +65,11 @@ public class EncodedValueTest {
         new DateTime(1491329790372L).write(queue, 0);
         Boolean.TRUE.write(queue, 1);
         Boolean.FALSE.write(queue, 12);
-        final EncodedValue original = new EncodedValue(queue.popAll());
+        EncodedValue original = new EncodedValue(queue.popAll());
 
         original.write(queue, 17);
 
-        final EncodedValue parsed = new EncodedValue(queue, 17);
+        EncodedValue parsed = new EncodedValue(queue, 17);
         queue = new ByteQueue(parsed.getData());
 
         assertEquals(new Real(3.14F), new Real(queue));
@@ -75,5 +77,25 @@ public class EncodedValueTest {
         assertEquals(new DateTime(1491329790372L), Encodable.read(queue, DateTime.class, 0));
         assertEquals(Boolean.TRUE, Encodable.read(queue, Boolean.class, 1));
         assertEquals(Boolean.FALSE, Encodable.read(queue, Boolean.class, 12));
+    }
+
+    /**
+     * EncodedValue reads its content with the same Encodable.readAmbiguousData that AmbiguousValue uses, so the
+     * corrupt encodings are enumerated in AmbiguousValueTest. These cases only confirm that this constructor
+     * routes into that shared reader rather than spinning or overrunning the queue.
+     */
+    @Test(timeout = 5_000)
+    public void corruptContentIsRejected() {
+        // An extended length that used to wrap to a non-positive int.
+        assertCorrupt("3e25fffffffffa", 3);
+        // An extended length whose low bits imitate the start tag marker.
+        assertCorrupt("3e7dfff0000006", 3);
+        // An end tag closing a context that was never opened.
+        assertCorrupt("3e4f", 3);
+    }
+
+    private static void assertCorrupt(String hex, int contextId) {
+        ByteQueue queue = new ByteQueue(hex);
+        assertThrows(hex, BACnetRuntimeException.class, () -> new EncodedValue(queue, contextId));
     }
 }

--- a/src/test/java/com/serotonin/bacnet4j/type/TagDataTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/type/TagDataTest.java
@@ -1,0 +1,196 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2025 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
+package com.serotonin.bacnet4j.type;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.serotonin.bacnet4j.util.sero.ByteQueue;
+
+public class TagDataTest {
+    @Test
+    public void applicationTagWithLiteralLength() {
+        TagData tagData = new TagData().peek(new ByteQueue("210d"));
+
+        assertEquals(2, tagData.getTagNumber());
+        assertFalse(tagData.isContextSpecific());
+        assertEquals(1, tagData.getLvt());
+        assertEquals(1, tagData.getLength());
+        assertEquals(1, tagData.getTagLength());
+        assertEquals(2, tagData.getTotalLength());
+    }
+
+    @Test
+    public void extendedTagNumberLengthensTheHeader() {
+        // f = extended tag number, so the tag number is taken from the second byte.
+        TagData tagData = new TagData().peek(new ByteQueue("f55002"));
+
+        assertEquals(0x50, tagData.getTagNumber());
+        assertEquals(2, tagData.getLength());
+        assertEquals(3, tagData.getTagLength());
+    }
+
+    @Test
+    public void twoByteExtendedLength() {
+        // 5 = extended length, fe = 2-byte length follows.
+        TagData tagData = new TagData().peek(new ByteQueue("25fe1234"));
+
+        assertEquals(TagData.LVT_EXTENDED_LENGTH, tagData.getLvt());
+        assertEquals(0x1234, tagData.getLength());
+        assertEquals(4, tagData.getTagLength());
+    }
+
+    /**
+     * A 4-byte extended length can hold values that do not fit in a signed int. getTotalLength must report the
+     * decoded length without truncating it, otherwise callers see a non-positive length and consume nothing.
+     */
+    @Test
+    public void fourByteExtendedLengthIsNotTruncated() {
+        // 7 = tag number, 5 = extended length, ff = 4-byte length follows.
+        TagData tagData = new TagData().peek(new ByteQueue("75fff0000000"));
+
+        assertEquals(7, tagData.getTagNumber());
+        assertFalse(tagData.isContextSpecific());
+        assertEquals(0xf0000000L, tagData.getLength());
+        assertEquals(6, tagData.getTagLength());
+        assertEquals(0xf0000000L + 6, tagData.getTotalLength());
+    }
+
+    /**
+     * The largest encodable length must still yield a positive total, since a non-positive one stalls the read
+     * loops that consume getTotalLength bytes at a time.
+     */
+    @Test
+    public void maximumExtendedLengthStaysPositive() {
+        TagData tagData = new TagData().peek(new ByteQueue("75ffffffffff"));
+
+        assertEquals(0xffffffffL, tagData.getLength());
+        assertEquals(0xffffffffL + 6, tagData.getTotalLength());
+        assertTrue(tagData.getTotalLength() > 0);
+    }
+
+    /**
+     * A start tag is not an end tag and vice versa. The two markers previously overlapped, so an end tag also
+     * reported itself as a start tag.
+     */
+    @Test
+    public void startAndEndTagsAreDistinct() {
+        TagData tagData = new TagData();
+
+        tagData.peek(new ByteQueue("3e"));
+        assertEquals(TagData.LVT_START_TAG, tagData.getLvt());
+        assertTrue(tagData.isStartTag());
+        assertTrue(tagData.isStartTag(3));
+        assertFalse(tagData.isStartTag(4));
+        assertFalse(tagData.isEndTag());
+
+        tagData.peek(new ByteQueue("3f"));
+        assertEquals(TagData.LVT_END_TAG, tagData.getLvt());
+        assertTrue(tagData.isEndTag());
+        assertTrue(tagData.isEndTag(3));
+        assertFalse(tagData.isEndTag(4));
+        assertFalse(tagData.isStartTag());
+    }
+
+    /**
+     * The markers are only meaningful for context specific tags. For an application class tag the same lvt values
+     * are ordinary lengths.
+     */
+    @Test
+    public void applicationTagIsNeverAStartOrEndTag() {
+        TagData tagData = new TagData();
+
+        tagData.peek(new ByteQueue("26"));
+        assertEquals(TagData.LVT_START_TAG, tagData.getLvt());
+        assertFalse(tagData.isContextSpecific());
+        assertFalse(tagData.isStartTag());
+        assertFalse(tagData.isEndTag());
+
+        tagData.peek(new ByteQueue("27"));
+        assertEquals(TagData.LVT_END_TAG, tagData.getLvt());
+        assertFalse(tagData.isStartTag());
+        assertFalse(tagData.isEndTag());
+    }
+
+    /**
+     * Start and end tags are identified by the raw lvt field, so an extended length whose low bits happen to match
+     * those markers must not be reported as a start or end tag.
+     */
+    @Test
+    public void extendedLengthIsNotMistakenForAMarker() {
+        TagData tagData = new TagData();
+
+        // 7 = tag number, d = context specific with extended length, ff = 4-byte length follows.
+        // The low bits of f0000006 match the start tag marker, and those of f0000007 match the end tag marker.
+        tagData.peek(new ByteQueue("7dfff0000006"));
+        assertEquals(TagData.LVT_EXTENDED_LENGTH, tagData.getLvt());
+        assertTrue(tagData.isContextSpecific());
+        assertEquals(0xf0000006L, tagData.getLength());
+        assertFalse(tagData.isStartTag());
+        assertFalse(tagData.isEndTag());
+
+        tagData.peek(new ByteQueue("7dfff0000007"));
+        assertEquals(0xf0000007L, tagData.getLength());
+        assertFalse(tagData.isStartTag());
+        assertFalse(tagData.isEndTag());
+    }
+
+    @Test
+    public void peekLeavesTheQueueIntact() {
+        ByteQueue queue = new ByteQueue("25fe1234aabb");
+        TagData tagData = new TagData().peek(queue);
+
+        assertEquals(4, tagData.getTagLength());
+        assertEquals(6, queue.size());
+    }
+
+    @Test
+    public void popConsumesExactlyTheHeader() {
+        ByteQueue queue = new ByteQueue("25fe1234aabb");
+        TagData tagData = new TagData().pop(queue);
+
+        assertEquals(4, tagData.getTagLength());
+        assertEquals(0x1234, tagData.getLength());
+        assertArrayEquals(new byte[] { (byte) 0xaa, (byte) 0xbb }, queue.popAll());
+    }
+
+    /**
+     * Both entry points return this, so they can be chained from a constructor call.
+     */
+    @Test
+    public void peekAndPopReturnTheSameInstance() {
+        TagData tagData = new TagData();
+        assertSame(tagData, tagData.peek(new ByteQueue("210d")));
+        assertSame(tagData, tagData.pop(new ByteQueue("210d")));
+    }
+}

--- a/src/test/java/com/serotonin/bacnet4j/type/TagDataTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/type/TagDataTest.java
@@ -181,7 +181,7 @@ public class TagDataTest {
 
         assertEquals(4, tagData.getTagLength());
         assertEquals(0x1234, tagData.getLength());
-        assertArrayEquals(new byte[] { (byte) 0xaa, (byte) 0xbb }, queue.popAll());
+        assertArrayEquals(new byte[] {(byte) 0xaa, (byte) 0xbb}, queue.popAll());
     }
 
     /**


### PR DESCRIPTION
https://radixiot.atlassian.net/browse/MANGO-3139

Fixes unsanitized input causing infinite loop in ambiguous value parsing

Fixes three defects in tag parsing, all reachable from malformed network input, and consolidates the duplicated tag-handling code.

Bugs fixed

1. Remotely reachable hang. TagData.getTotalLength() computed length + tagLength as a long and cast to int. A 4-byte extended length can exceed Integer.MAX_VALUE, so the total wrapped to zero or negative, copyData consumed nothing, and the read loops in AmbiguousValue/EncodedValue spun forever. Roughly half the 4-byte length space triggered it. getTotalLength() now returns long.
2. Start/end tag misclassification. isStartTag()/isEndTag() tested the decoded length, which an extended length overwrites, so a corrupt length could imitate a marker. Separately, (length & 6) == 6 matched both 6 and 7, so every end tag also reported itself as a start tag. Both now test the raw LVT field, which is preserved before decoding.
3. Nested content reordering. AmbiguousValue recursed into an overload that appended to this.data immediately, while the enclosing start/end tags were buffered and appended afterwards, so nested content landed ahead of its own start tag. 3e5e210d5f3f decoded to 210d5e5f.

The copyData guard is retargeted from length <= 0 (unreachable once the total is a long) to length > queue.size(), so an overlong length raises BACnetRuntimeException instead of ArrayIndexOutOfBoundsException. Unbalanced end tags are now rejected explicitly.

Refactor

Tag parsing moves into TagData (peek/pop, fields encapsulated); readAmbiguousData/copyAmbiguousData move to Encodable, replacing two copies that had already drifted apart — the source of bugs 1 and 3 existing in one class but not the other.

Compatibility: TagData.getTotalLength() changes from int to long and its fields are now private — source- and binary-breaking for external callers. Release notes have been updated.

Tests: new TagDataTest; corrupt-input vectors covering both wrap boundaries, marker imitation, and unbalanced tags, all with timeouts. Full suite passes (1123 tests).