### PR TITLE
MANGO-3141 Reject NPDUs without sufficient data

### DIFF
--- a/src/main/java/com/serotonin/bacnet4j/npdu/NPCI.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/NPCI.java
@@ -34,11 +34,9 @@ import com.serotonin.bacnet4j.util.sero.ByteQueue;
 
 /**
  * Network layer protocol control information. This class currently only implements the reading of information.
- *
- * @author mlohbihler
  */
 public class NPCI {
-    public static enum NetworkPriority {
+    public enum NetworkPriority {
         lifeSafety(3), criticalEquipment(2), urgent(1), normal(0);
 
         public final int value;
@@ -142,33 +140,53 @@ public class NPCI {
         }
     }
 
-    public NPCI(ByteQueue queue) {
+    public NPCI(ByteQueue queue) throws MessageValidationException {
+        // Each field is checked against the data remaining before it is read. The control octet says which of the
+        // optional fields follow, so a truncated message can otherwise run the queue empty part way through and
+        // fail with an unchecked exception out of ByteQueue rather than as a malformed message.
+        requireAvailable(queue, 2, "version and control");
         version = queue.popU1B();
         control = BigInteger.valueOf(queue.popU1B());
 
         if (control.testBit(5)) {
+            requireAvailable(queue, 3, "destination network and length");
             destinationNetwork = queue.popU2B();
             destinationLength = queue.popU1B();
             if (destinationLength > 0) {
+                requireAvailable(queue, destinationLength, "destination address");
                 destinationAddress = new byte[destinationLength];
                 queue.pop(destinationAddress);
             }
         }
 
         if (control.testBit(3)) {
+            requireAvailable(queue, 3, "source network and length");
             sourceNetwork = queue.popU2B();
             sourceLength = queue.popU1B();
+            requireAvailable(queue, sourceLength, "source address");
             sourceAddress = new byte[sourceLength];
             queue.pop(sourceAddress);
         }
 
-        if (control.testBit(5))
+        if (control.testBit(5)) {
+            requireAvailable(queue, 1, "hop count");
             hopCount = queue.popU1B();
+        }
 
         if (control.testBit(7)) {
+            requireAvailable(queue, 1, "message type");
             messageType = queue.popU1B();
-            if (messageType >= 80)
+            if (messageType >= 80) {
+                requireAvailable(queue, 2, "vendor id");
                 vendorId = queue.popU2B();
+            }
+        }
+    }
+
+    private static void requireAvailable(ByteQueue queue, int count, String field) throws MessageValidationException {
+        if (queue.size() < count) {
+            throw new MessageValidationException("Truncated NPCI: " + count + " octets needed for the " + field
+                    + ", " + queue.size() + " remaining");
         }
     }
 
@@ -266,14 +284,4 @@ public class NPCI {
     public int getVersion() {
         return version;
     }
-    //    
-    // public static void main(String[] args) {
-    // byte[] b1 = {(byte)0x81,(byte)0xb,(byte)0x0,(byte)0x18};
-    // byte[] b2 = {(byte)0x1,(byte)0x8,(byte)0x0,(byte)0x64,(byte)0x1,
-    // (byte)0x2,(byte)0x10,(byte)0x0,(byte)0xc4,(byte)0x2,(byte)0x0,(byte)0x7,(byte)0xd0,(byte)0x22,
-    // (byte)0x1,(byte)0xe0,(byte)0x91,(byte)0x0,(byte)0x21,(byte)0x23};
-    // ByteQueue q = new ByteQueue(b2);
-    // new NPCI(q);
-    //
-    // }
 }

--- a/src/main/java/com/serotonin/bacnet4j/npdu/ip/IpNetwork.java
+++ b/src/main/java/com/serotonin/bacnet4j/npdu/ip/IpNetwork.java
@@ -520,6 +520,14 @@ public class IpNetwork extends Network {
 
         // Initial parsing of IP message.
         // BACnet/IP
+        // The BVLC header is four octets: type, function, and a two octet length. Check for them before reading,
+        // so that a datagram too short to hold a header is reported as a malformed message rather than as an
+        // unchecked exception out of ByteQueue.
+        if (queue.size() < 4) {
+            throw new MessageValidationException("Truncated BVLC header: 4 octets needed, " + queue.size()
+                    + " remaining");
+        }
+
         if (queue.pop() != BVLC_TYPE)
             throw new MessageValidationException("Protocol id is not BACnet/IP (0x81)");
 

--- a/src/main/java/com/serotonin/bacnet4j/util/sero/ByteQueue.java
+++ b/src/main/java/com/serotonin/bacnet4j/util/sero/ByteQueue.java
@@ -36,6 +36,8 @@ import java.util.Arrays;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.serotonin.bacnet4j.exception.BACnetRuntimeException;
+
 public class ByteQueue implements Cloneable {
     private byte[] queue;
     private int head = -1;
@@ -50,35 +52,33 @@ public class ByteQueue implements Cloneable {
         this(1024);
     }
 
-    public ByteQueue(final int initialLength) {
+    public ByteQueue(int initialLength) {
         queue = new byte[initialLength];
     }
 
-    public ByteQueue(final byte[] b) {
+    public ByteQueue(byte[] b) {
         this(b.length);
         push(b, 0, b.length);
     }
 
-    public ByteQueue(final byte[] b, final int pos, final int length) {
+    public ByteQueue(byte[] b, int pos, int length) {
         this(length);
         push(b, pos, length);
     }
 
-    public ByteQueue(final String hex) {
+    public ByteQueue(String hex) {
         this(hex.length() / 2);
         push(hex);
     }
 
-    public void push(final String hex) {
+    public void push(String hex) {
         if (hex.length() % 2 != 0)
             throw new IllegalArgumentException("Hex string must have an even number of characters");
-        final byte[] b = new byte[hex.length() / 2];
-        for (int i = 0; i < b.length; i++)
-            b[i] = (byte) Integer.parseInt(hex.substring(i * 2, i * 2 + 2), 16);
+        byte[] b = StreamUtils.fromHex(hex);
         push(b, 0, b.length);
     }
 
-    public void push(final byte b) {
+    public void push(byte b) {
         if (room() == 0)
             expand();
 
@@ -90,18 +90,18 @@ public class ByteQueue implements Cloneable {
         size++;
     }
 
-    public void push(final int i) {
+    public void push(int i) {
         push((byte) i);
     }
 
-    public void push(final long l) {
+    public void push(long l) {
         push((byte) l);
     }
 
     /**
      * Push unsigned 2 bytes.
      */
-    public void pushU2B(final int i) {
+    public void pushU2B(int i) {
         push((byte) (i >> 8));
         push((byte) i);
     }
@@ -109,7 +109,7 @@ public class ByteQueue implements Cloneable {
     /**
      * Push unsigned 3 bytes.
      */
-    public void pushU3B(final int i) {
+    public void pushU3B(int i) {
         push((byte) (i >> 16));
         push((byte) (i >> 8));
         push((byte) i);
@@ -118,41 +118,41 @@ public class ByteQueue implements Cloneable {
     /**
      * Push signed 4 bytes.
      */
-    public void pushS4B(final int i) {
+    public void pushS4B(int i) {
         pushInt(i);
     }
 
     /**
      * Push unsigned 4 bytes.
      */
-    public void pushU4B(final long l) {
+    public void pushU4B(long l) {
         push((byte) (l >> 24));
         push((byte) (l >> 16));
         push((byte) (l >> 8));
         push((byte) l);
     }
 
-    public void pushChar(final char c) {
+    public void pushChar(char c) {
         push((byte) (c >> 8));
         push((byte) c);
     }
 
-    public void pushDouble(final double d) {
+    public void pushDouble(double d) {
         pushLong(Double.doubleToLongBits(d));
     }
 
-    public void pushFloat(final float f) {
+    public void pushFloat(float f) {
         pushInt(Float.floatToIntBits(f));
     }
 
-    public void pushInt(final int i) {
+    public void pushInt(int i) {
         push((byte) (i >> 24));
         push((byte) (i >> 16));
         push((byte) (i >> 8));
         push((byte) i);
     }
 
-    public void pushLong(final long l) {
+    public void pushLong(long l) {
         push((byte) (l >> 56));
         push((byte) (l >> 48));
         push((byte) (l >> 40));
@@ -163,23 +163,20 @@ public class ByteQueue implements Cloneable {
         push((byte) l);
     }
 
-    public void pushShort(final short s) {
+    public void pushShort(short s) {
         push((byte) (s >> 8));
         push((byte) s);
     }
 
-    public void read(final InputStream in, final int length) throws IOException {
+    public void read(InputStream in, int length) throws IOException {
         if (length == 0)
             return;
 
         while (room() < length)
             expand();
 
-        final int tailLength = queue.length - tail;
-        if (tailLength > length)
-            readImpl(in, tail, length);
-        else
-            readImpl(in, tail, tailLength);
+        int tailLength = queue.length - tail;
+        readImpl(in, tail, Math.min(tailLength, length));
 
         if (length > tailLength)
             readImpl(in, 0, length - tailLength);
@@ -190,33 +187,29 @@ public class ByteQueue implements Cloneable {
         size += length;
     }
 
-    private void readImpl(final InputStream in, final int offset, final int length) throws IOException {
+    private void readImpl(InputStream in, int offset, int length) throws IOException {
         int readcount;
         int off = offset;
-        int len = length;
         while (length > 0) {
-            readcount = in.read(queue, off, len);
+            readcount = in.read(queue, off, length);
             off += readcount;
-            len -= readcount;
+            length -= readcount;
         }
     }
 
-    public void push(final byte[] b) {
+    public void push(byte[] b) {
         push(b, 0, b.length);
     }
 
-    public void push(final byte[] b, final int pos, final int length) {
+    public void push(byte[] b, int pos, int length) {
         if (length == 0)
             return;
 
         while (room() < length)
             expand();
 
-        final int tailLength = queue.length - tail;
-        if (tailLength > length)
-            System.arraycopy(b, pos, queue, tail, length);
-        else
-            System.arraycopy(b, pos, queue, tail, tailLength);
+        int tailLength = queue.length - tail;
+        System.arraycopy(b, pos, queue, tail, Math.min(tailLength, length));
 
         if (length > tailLength)
             System.arraycopy(b, tailLength + pos, queue, 0, length - tailLength);
@@ -227,7 +220,7 @@ public class ByteQueue implements Cloneable {
         size += length;
     }
 
-    public void push(final ByteQueue source) {
+    public void push(ByteQueue source) {
         if (source.size == 0)
             return;
 
@@ -244,26 +237,23 @@ public class ByteQueue implements Cloneable {
             push(q.queue, 0, q.tail);
     }
 
-    public void push(final ByteQueue source, final int len) {
-        // TODO There is certainly a more elegant way to do this...
+    public void push(ByteQueue source, int len) {
+        // There is certainly a more elegant way to do this...
         int l = len;
         while (l-- > 0)
             push(source.pop());
     }
 
-    public void push(final ByteBuffer source) {
-        final int length = source.remaining();
+    public void push(ByteBuffer source) {
+        int length = source.remaining();
         if (length == 0)
             return;
 
         while (room() < length)
             expand();
 
-        final int tailLength = queue.length - tail;
-        if (tailLength > length)
-            source.get(queue, tail, length);
-        else
-            source.get(queue, tail, tailLength);
+        int tailLength = queue.length - tail;
+        source.get(queue, tail, Math.min(tailLength, length));
 
         if (length > tailLength)
             source.get(queue, 0, length - tailLength);
@@ -287,7 +277,13 @@ public class ByteQueue implements Cloneable {
     }
 
     public byte pop() {
-        final byte retval = queue[head];
+        // Emptying the queue sets head to -1, so without this an over-read indexes the backing array with it and
+        // fails with a message about array indices rather than about the queue being empty. The other extraction
+        // methods already check, so match them.
+        if (size == 0)
+            throw new ArrayIndexOutOfBoundsException(-1);
+
+        byte retval = queue[head];
 
         if (size == 1) {
             head = -1;
@@ -324,12 +320,12 @@ public class ByteQueue implements Cloneable {
         return (long) (pop() & 0xff) << 24 | (long) (pop() & 0xff) << 16 | (long) (pop() & 0xff) << 8 | pop() & 0xff;
     }
 
-    public int pop(final byte[] buf) {
+    public int pop(byte[] buf) {
         return pop(buf, 0, buf.length);
     }
 
-    public int pop(final byte[] buf, final int pos, final int length) {
-        final int len = peek(buf, pos, length);
+    public int pop(byte[] buf, int pos, int length) {
+        int len = peek(buf, pos, length);
 
         size -= len;
 
@@ -342,7 +338,7 @@ public class ByteQueue implements Cloneable {
         return len;
     }
 
-    public int pop(final int length) {
+    public int pop(int length) {
         if (length == 0)
             return 0;
         if (size == 0)
@@ -363,23 +359,23 @@ public class ByteQueue implements Cloneable {
         return len;
     }
 
-    public String popString(final int length, final Charset charset) {
-        final byte[] b = new byte[length];
+    public String popString(int length, Charset charset) {
+        byte[] b = new byte[length];
         pop(b);
         return new String(b, charset);
     }
 
     public byte[] popAll() {
-        final byte[] data = new byte[size];
+        byte[] data = new byte[size];
         pop(data, 0, data.length);
         return data;
     }
 
-    public void write(final OutputStream out) throws IOException {
+    public void write(OutputStream out) throws IOException {
         write(out, size);
     }
 
-    public void write(final OutputStream out, final int length) throws IOException {
+    public void write(OutputStream out, int length) throws IOException {
         if (length == 0)
             return;
         if (size == 0)
@@ -411,7 +407,7 @@ public class ByteQueue implements Cloneable {
             throw new ArrayIndexOutOfBoundsException(-1);
 
         tail = (tail + queue.length - 1) % queue.length;
-        final byte retval = queue[tail];
+        byte retval = queue[tail];
 
         if (size == 1) {
             head = -1;
@@ -423,33 +419,33 @@ public class ByteQueue implements Cloneable {
         return retval;
     }
 
-    public byte peek(final int index) {
+    public byte peek(int index) {
         if (index >= size)
             throw new IllegalArgumentException("index " + index + " is >= queue size " + size);
 
-        final int pos = (index + head) % queue.length;
+        int pos = (index + head) % queue.length;
         return queue[pos];
     }
 
-    public byte[] peek(final int index, final int length) {
-        final byte[] result = new byte[length];
-        // TODO: use System.arraycopy instead.
+    public byte[] peek(int index, int length) {
+        byte[] result = new byte[length];
+        // Maybe use System.arraycopy instead.
         for (int i = 0; i < length; i++)
             result[i] = peek(index + i);
         return result;
     }
 
     public byte[] peekAll() {
-        final byte[] data = new byte[size];
+        byte[] data = new byte[size];
         peek(data, 0, data.length);
         return data;
     }
 
-    public int peek(final byte[] buf) {
+    public int peek(byte[] buf) {
         return peek(buf, 0, buf.length);
     }
 
-    public int peek(final byte[] buf, final int pos, final int length) {
+    public int peek(byte[] buf, int pos, int length) {
         if (length == 0)
             return 0;
         if (size == 0)
@@ -470,11 +466,11 @@ public class ByteQueue implements Cloneable {
         return len;
     }
 
-    public int indexOf(final byte b) {
+    public int indexOf(byte b) {
         return indexOf(b, 0);
     }
 
-    public int indexOf(final byte b, final int start) {
+    public int indexOf(byte b, int start) {
         if (start >= size)
             return -1;
 
@@ -487,11 +483,11 @@ public class ByteQueue implements Cloneable {
         return -1;
     }
 
-    public int indexOf(final byte[] b) {
+    public int indexOf(byte[] b) {
         return indexOf(b, 0);
     }
 
-    public int indexOf(final byte[] b, final int start) {
+    public int indexOf(byte[] b, int start) {
         if (b == null || b.length == 0)
             throw new IllegalArgumentException("cannot search for empty values");
 
@@ -530,7 +526,7 @@ public class ByteQueue implements Cloneable {
     }
 
     private void expand() {
-        final byte[] newb = new byte[queue.length * 2];
+        byte[] newb = new byte[queue.length * 2];
 
         if (head == -1) {
             queue = newb;
@@ -552,13 +548,13 @@ public class ByteQueue implements Cloneable {
     @Override
     public Object clone() {
         try {
-            final ByteQueue clone = (ByteQueue) super.clone();
+            ByteQueue clone = (ByteQueue) super.clone();
             // Array is mutable, so make a copy of it too.
             clone.queue = queue.clone();
             return clone;
-        } catch (final CloneNotSupportedException e) {
+        } catch (CloneNotSupportedException e) {
             // Will never happen because we're Cloneable
-            throw new RuntimeException(e);
+            throw new BACnetRuntimeException(e);
         }
     }
 
@@ -567,7 +563,7 @@ public class ByteQueue implements Cloneable {
         if (size == 0)
             return "[]";
 
-        final StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder();
         sb.append('[');
         sb.append(Integer.toHexString(peek(0) & 0xff));
         for (int i = 1; i < size; i++)
@@ -578,14 +574,14 @@ public class ByteQueue implements Cloneable {
     }
 
     public String toHexString() {
-        final StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder();
         for (int i = 0; i < size; i++)
             sb.append(StringUtils.leftPad(Integer.toHexString(peek(i) & 0xff), 2, '0'));
         return sb.toString();
     }
 
     public String dumpQueue() {
-        final StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder();
 
         if (queue.length == 0)
             sb.append("[]");
@@ -605,7 +601,7 @@ public class ByteQueue implements Cloneable {
 
     @Override
     public int hashCode() {
-        final int prime = 31;
+        int prime = 31;
         int result = 1;
         result = prime * result + head;
         result = prime * result + Arrays.hashCode(queue);
@@ -615,14 +611,14 @@ public class ByteQueue implements Cloneable {
     }
 
     @Override
-    public boolean equals(final Object obj) {
+    public boolean equals(Object obj) {
         if (this == obj)
             return true;
         if (obj == null)
             return false;
         if (getClass() != obj.getClass())
             return false;
-        final ByteQueue other = (ByteQueue) obj;
+        ByteQueue other = (ByteQueue) obj;
 
         if (size != other.size)
             return false;

--- a/src/test/java/com/serotonin/bacnet4j/npdu/NPCITest.java
+++ b/src/test/java/com/serotonin/bacnet4j/npdu/NPCITest.java
@@ -28,6 +28,9 @@
 package com.serotonin.bacnet4j.npdu;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -57,5 +60,55 @@ public class NPCITest {
                 (byte) 0xff, // hop count
         };
         assertArrayEquals(expected, queue.popAll());
+    }
+
+    /**
+     * A fully populated NPCI still decodes, so the truncation checks below are not simply rejecting everything.
+     */
+    @Test
+    public void roundTrip() throws Exception {
+        NPCI original = new NPCI(new Address(2, new byte[] {1}));
+        ByteQueue queue = new ByteQueue();
+        original.write(queue);
+
+        NPCI parsed = new NPCI(queue);
+        assertEquals(1, parsed.getVersion());
+        assertEquals(0xFFFF, parsed.getDestinationNetwork());
+        assertEquals(0, queue.size());
+    }
+
+    /**
+     * The control octet says which of the optional fields follow, so a message truncated part way through them used
+     * to run the queue empty and fail with an ArrayIndexOutOfBoundsException naming an array index. Each field is
+     * now checked against the data remaining, and reported as the malformed message it is.
+     */
+    @Test
+    public void truncatedNpciIsReportedAsMalformed() {
+        // Nothing at all, and the version octet without the control octet.
+        assertTruncated("");
+        assertTruncated("01");
+        // Control bit 5 set: a destination network, length and address follow.
+        assertTruncated("0120");
+        assertTruncated("012000");
+        assertTruncated("0120ffff");
+        // A destination address length longer than the data that follows it.
+        assertTruncated("0120ffff04010203");
+        // Control bit 3 set: a source network, length and address follow.
+        assertTruncated("0108");
+        assertTruncated("01080002");
+        assertTruncated("0108000204010203");
+        // Control bit 5 also requires a hop count after the destination.
+        assertTruncated("0120ffff00");
+        // Control bit 7 set: a message type, and a vendor id when the type is 80 or above.
+        assertTruncated("0180");
+        assertTruncated("018050");
+        assertTruncated("01805000");
+    }
+
+    private static void assertTruncated(String hex) {
+        ByteQueue queue = new ByteQueue(hex);
+        MessageValidationException e =
+                assertThrows(hex, MessageValidationException.class, () -> new NPCI(queue));
+        assertTrue(e.getMessage(), e.getMessage().startsWith("Truncated NPCI"));
     }
 }

--- a/src/test/java/com/serotonin/bacnet4j/npdu/ip/IpNetworkBvlcHeaderTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/npdu/ip/IpNetworkBvlcHeaderTest.java
@@ -1,0 +1,105 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2025 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
+package com.serotonin.bacnet4j.npdu.ip;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.serotonin.bacnet4j.LocalDevice;
+import com.serotonin.bacnet4j.npdu.MessageValidationException;
+import com.serotonin.bacnet4j.transport.Transport;
+import com.serotonin.bacnet4j.type.primitive.OctetString;
+import com.serotonin.bacnet4j.util.sero.ByteQueue;
+
+/**
+ * A BVLC header is four octets: type, function, and a two octet length. They used to be read before anything
+ * checked that they were present, so a datagram shorter than the header ran the queue empty and failed with an
+ * ArrayIndexOutOfBoundsException naming an array index, rather than as the malformed message it is.
+ */
+public class IpNetworkBvlcHeaderTest {
+    private static final int PORT = 47806;
+
+    private IpNetwork network;
+    private OctetString linkService;
+
+    @Before
+    public void before() throws Exception {
+        network = spy(new IpNetworkBuilder() //
+                .withLocalBindAddress("1.2.3.4") //
+                .withBroadcast("1.2.3.255", 24) //
+                .withPort(PORT) //
+                .build());
+
+        doNothing().when(network).listen(any());
+        doReturn(null).when(network).createSocket(any());
+        doReturn(null).when(network).parseNpduData(any(), any());
+
+        Transport transport = mock(Transport.class);
+        doReturn(mock(LocalDevice.class)).when(transport).getLocalDevice();
+        network.initialize(transport);
+
+        linkService = IpNetworkUtils.toOctetString("1.2.3.9", PORT);
+    }
+
+    @Test
+    public void datagramShorterThanTheBvlcHeader() {
+        assertTruncated(new byte[] {});
+        assertTruncated(new byte[] {IpNetwork.BVLC_TYPE});
+        assertTruncated(new byte[] {IpNetwork.BVLC_TYPE, 0x4});
+        assertTruncated(new byte[] {IpNetwork.BVLC_TYPE, 0x4, 0x0});
+    }
+
+    /**
+     * A complete header is still accepted, so the check is not simply rejecting everything. Original-Unicast-NPDU
+     * carries nothing between the header and the NPDU itself, so a bare header is a complete message for it.
+     */
+    @Test
+    public void completeBvlcHeaderIsAccepted() throws Exception {
+        ByteQueue queue = new ByteQueue();
+        queue.push(IpNetwork.BVLC_TYPE);
+        queue.push(0xa); // Original-Unicast-NPDU
+        queue.pushShort((short) 4); // Length, counting the header itself
+
+        network.handleIncomingDataImpl(queue, linkService);
+    }
+
+    private void assertTruncated(byte[] data) {
+        ByteQueue queue = new ByteQueue(data);
+        MessageValidationException e = assertThrows(MessageValidationException.class,
+                () -> network.handleIncomingDataImpl(queue, linkService));
+        assertTrue(e.getMessage(), e.getMessage().startsWith("Truncated BVLC header"));
+    }
+}

--- a/src/test/java/com/serotonin/bacnet4j/util/sero/ByteQueueTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/util/sero/ByteQueueTest.java
@@ -43,7 +43,8 @@ public class ByteQueueTest {
      */
     @Test
     public void popOnAnEmptyQueue() {
-        assertThrows("never pushed", ArrayIndexOutOfBoundsException.class, () -> new ByteQueue().pop());
+        var queue = new ByteQueue();
+        assertThrows("never pushed", ArrayIndexOutOfBoundsException.class, queue::pop);
 
         ByteQueue emptiedByPop = new ByteQueue("01");
         assertEquals(1, emptiedByPop.pop());
@@ -71,9 +72,12 @@ public class ByteQueueTest {
      */
     @Test
     public void multiOctetPopsPastTheEnd() {
-        assertThrows(ArrayIndexOutOfBoundsException.class, () -> new ByteQueue("01").popU2B());
-        assertThrows(ArrayIndexOutOfBoundsException.class, () -> new ByteQueue("0102").popU4B());
-        assertThrows(ArrayIndexOutOfBoundsException.class, () -> new ByteQueue("01").popS2B());
+        var queue1 = new ByteQueue("01");
+        assertThrows(ArrayIndexOutOfBoundsException.class, queue1::popU2B);
+        var queue2 = new ByteQueue("0102");
+        assertThrows(ArrayIndexOutOfBoundsException.class, queue2::popU4B);
+        var queue3 = new ByteQueue("01");
+        assertThrows(ArrayIndexOutOfBoundsException.class, queue3::popS2B);
     }
 
     /**

--- a/src/test/java/com/serotonin/bacnet4j/util/sero/ByteQueueTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/util/sero/ByteQueueTest.java
@@ -1,0 +1,98 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2025 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
+package com.serotonin.bacnet4j.util.sero;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import org.junit.Test;
+
+public class ByteQueueTest {
+    /**
+     * Popping an empty queue throws, whichever way the queue became empty.
+     *
+     * <p>Note that this held before the size check was added too, but only incidentally: emptying the queue sets
+     * head to -1 as a sentinel, and the read of {@code queue[head]} then failed because -1 happens to be an invalid
+     * array index. The check makes the throw deliberate and independent of how the empty state is represented, and
+     * keeps the capacity of the backing array out of the message. The other extraction methods already checked.</p>
+     */
+    @Test
+    public void popOnAnEmptyQueue() {
+        assertThrows("never pushed", ArrayIndexOutOfBoundsException.class, () -> new ByteQueue().pop());
+
+        ByteQueue emptiedByPop = new ByteQueue("01");
+        assertEquals(1, emptiedByPop.pop());
+        assertEquals(0, emptiedByPop.size());
+        assertThrows("emptied by pop()", ArrayIndexOutOfBoundsException.class, emptiedByPop::pop);
+
+        ByteQueue emptiedByPopLength = new ByteQueue("0102");
+        emptiedByPopLength.pop(2);
+        assertEquals(0, emptiedByPopLength.size());
+        assertThrows("emptied by pop(int)", ArrayIndexOutOfBoundsException.class, emptiedByPopLength::pop);
+
+        ByteQueue emptiedByPopArray = new ByteQueue("0102");
+        emptiedByPopArray.pop(new byte[2]);
+        assertEquals(0, emptiedByPopArray.size());
+        assertThrows("emptied by pop(byte[])", ArrayIndexOutOfBoundsException.class, emptiedByPopArray::pop);
+
+        ByteQueue emptiedByPopAll = new ByteQueue("0102");
+        emptiedByPopAll.popAll();
+        assertEquals(0, emptiedByPopAll.size());
+        assertThrows("emptied by popAll()", ArrayIndexOutOfBoundsException.class, emptiedByPopAll::pop);
+    }
+
+    /**
+     * The multi octet reads chain pop calls, so they run the queue empty part way through rather than at the start.
+     */
+    @Test
+    public void multiOctetPopsPastTheEnd() {
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> new ByteQueue("01").popU2B());
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> new ByteQueue("0102").popU4B());
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> new ByteQueue("01").popS2B());
+    }
+
+    /**
+     * The guard must not disturb a queue that has the data, including after it has wrapped around the end of the
+     * backing array.
+     */
+    @Test
+    public void popsWithinTheDataAreUnaffected() {
+        ByteQueue queue = new ByteQueue(4);
+        queue.push(new byte[] {1, 2, 3});
+        queue.pop(2);
+        // Head is now near the end of the four byte backing array, so this push wraps.
+        queue.push(new byte[] {4, 5, 6});
+
+        assertEquals(3, queue.pop());
+        assertEquals(4, queue.pop());
+        assertEquals(5, queue.pop());
+        assertEquals(6, queue.pop());
+        assertEquals(0, queue.size());
+        assertThrows(ArrayIndexOutOfBoundsException.class, queue::pop);
+    }
+}


### PR DESCRIPTION
https://radixiot.atlassian.net/browse/MANGO-3141

Malformed or truncated network input could reach `ByteQueue.pop()` on an empty queue, raising `ArrayIndexOutOfBoundsException` from deep inside the codec. The fuzzer report counts 40+ affected message types and 80+ execution paths.

Changes

- ByteQueue.pop() checks size == 0 and throws ArrayIndexOutOfBoundsException(-1), matching what pop(int) and peek(byte[], int, int) already did. The failure is now deliberate and independent of how the empty state is represented, and the message no longer leaks the capacity of the backing array.
- NPCI(ByteQueue) checks each field against the data remaining before reading it. The control octet selects which optional fields follow, so a truncated message could otherwise run the queue empty part way through. Truncation is now reported as
MessageValidationException, which is what parseNpduData already throws for a bad protocol version.
- IpNetwork.handleIncomingDataImpl checks for the four octet BVLC header before reading type, function and length.

Scope

The report lists four stack traces. This closes the two at the NPDU layer (NPCI.<init> and BACnetUtils.popShort from the IP listener). The other two are at the APDU layer (Primitive.readTag → ObjectIdentifier, and CharacterString code page) and are closed by MANGO-3140, which is not in this branch.

Impact

Not a remote thread kill. Network.handleIncomingData catches Exception and dispatches it, and IpNetwork.listen loops on while (!socket.isClosed()), so the listener survives. The report's "Uncaught exception detected" is its fuzzer's label for reaching the ExceptionDispatcher. This change turns a misleading unchecked failure into a clear protocol-level one.

Compatibility

NPCI(ByteQueue) now declares throws MessageValidationException. Source-incompatible for external callers; the only in-repo parse caller, Network.parseNpduData, already declared it.
