### PR TITLE
MANGO-3208 Fix priority array decoding bug

### DIFF
--- a/src/main/java/com/serotonin/bacnet4j/type/Encodable.java
+++ b/src/main/java/com/serotonin/bacnet4j/type/Encodable.java
@@ -469,7 +469,7 @@ public abstract class Encodable {
     }
 
     /**
-     * Peeks at the byte following the opening context tag and reports whether it is a NULL primitive
+     * Reports whether the value between the opening context tag and its closing tag is a lone NULL primitive
      * (application tag 0, length 0). Used by {@link #readANY} to detect a relinquish-style Null value
      * that would otherwise be rejected by strict-type decode. Does not consume any bytes.
      */
@@ -477,13 +477,29 @@ public abstract class Encodable {
         if (readStart(queue) != contextId) {
             return false;
         }
-        int startTagLength = contextId > 14 ? 2 : 1;
-        if (queue.size() < startTagLength + 2) {
+        int tagLength = contextId > 14 ? 2 : 1;
+        if (queue.size() < tagLength + 1 + tagLength) {
             return false;
         }
         // The byte after the opening context tag encodes the value tag. NULL is application tag 0, primitive,
-        // length 0 — a single 0x00 byte. The following byte should be the closing context tag.
-        return (queue.peek(startTagLength) & 0xff) == 0x00;
+        // length 0 — a single 0x00 byte. The closing context tag must immediately follow it, otherwise this is a
+        // constructed value that merely begins with a NULL, such as a priority array whose first element is NULL.
+        return (queue.peek(tagLength) & 0xff) == 0x00 && isEndTagAt(queue, tagLength + 1, contextId);
+    }
+
+    /**
+     * Return true if the tag at the given index of the queue is the closing tag for contextId. A tag that runs off
+     * the end of the queue, as it does in a truncated message, is not a match. Does not consume any bytes.
+     */
+    private static boolean isEndTagAt(ByteQueue queue, int index, int contextId) {
+        if (index >= queue.size())
+            return false;
+        int b = toInt(queue.peek(index));
+        if ((b & 0xf) != 0xf)
+            return false;
+        if ((b & 0xf0) == 0xf0)
+            return index + 1 < queue.size() && toInt(queue.peek(index + 1)) == contextId;
+        return (b >> 4) == contextId;
     }
 
     /**

--- a/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadPriorityArrayTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadPriorityArrayTest.java
@@ -47,6 +47,7 @@ import com.serotonin.bacnet4j.type.enumerated.EngineeringUnits;
 import com.serotonin.bacnet4j.type.enumerated.ObjectType;
 import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
 import com.serotonin.bacnet4j.type.primitive.ObjectIdentifier;
+import com.serotonin.bacnet4j.type.primitive.Real;
 import com.serotonin.bacnet4j.type.primitive.UnsignedInteger;
 
 public class ReadPriorityArrayTest {
@@ -101,6 +102,25 @@ public class ReadPriorityArrayTest {
         assertEquals(UnsignedInteger.class, ack.getValue().getClass());
         //Check the Size
         assertEquals("16", ack.getValue().toString());
+    }
+
+    /**
+     * A priority array whose first element is Null, as it is when a value has only been commanded at a lower
+     * priority, must decode as a priority array rather than as the Null of its first element.
+     */
+    @Test
+    public void readPriorityArrayWithNullFirstElement() throws BACnetException {
+        // Only the eighth element is set, so the first is Null.
+        final PriorityArray nullFirst = new PriorityArray().put(8, new Real(12.3f));
+        remoteDevice.<AnalogValueObject>getObject(new ObjectIdentifier(ObjectType.analogValue, 1))
+                .writePropertyInternal(PropertyIdentifier.priorityArray, nullFirst);
+
+        final ReadPropertyRequest req = new ReadPropertyRequest(new ObjectIdentifier(ObjectType.analogValue, 1),
+                PropertyIdentifier.priorityArray);
+        final ReadPropertyAck ack = localDevice.send(rDevice, req).get();
+
+        assertEquals(PriorityArray.class, ack.getValue().getClass());
+        assertEquals(nullFirst, ack.getValue());
     }
 
     @Test

--- a/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadPriorityArrayTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/service/confirmed/ReadPriorityArrayTest.java
@@ -69,7 +69,7 @@ public class ReadPriorityArrayTest {
         //Add Objects and properties
         priorityArray = new PriorityArray().put(1, new UnsignedInteger(11111)).put(2, new UnsignedInteger(22222)).put(3,
                 new UnsignedInteger(33333));
-        final AnalogValueObject analogValueObject = remoteDevice.addObject(new AnalogValueObject(
+        AnalogValueObject analogValueObject = remoteDevice.addObject(new AnalogValueObject(
                 remoteDevice, 1, "analogValueOne", 77.7f, EngineeringUnits.degreesFahrenheit, false));
         analogValueObject.writePropertyInternal(PropertyIdentifier.priorityArray, priorityArray);
 
@@ -85,9 +85,9 @@ public class ReadPriorityArrayTest {
 
     @Test
     public void readPriorityArrayCompletely() throws BACnetException {
-        final ReadPropertyRequest req = new ReadPropertyRequest(new ObjectIdentifier(ObjectType.analogValue, 1),
+        ReadPropertyRequest req = new ReadPropertyRequest(new ObjectIdentifier(ObjectType.analogValue, 1),
                 PropertyIdentifier.priorityArray);
-        final ReadPropertyAck ack = localDevice.send(rDevice, req).get();
+        ReadPropertyAck ack = localDevice.send(rDevice, req).get();
         //Check the Class
         assertEquals(PriorityArray.class, ack.getValue().getClass());
         assertEquals(priorityArray.toString(), ack.getValue().toString());
@@ -95,9 +95,9 @@ public class ReadPriorityArrayTest {
 
     @Test
     public void readPriorityArraySize() throws BACnetException {
-        final ReadPropertyRequest req = new ReadPropertyRequest(new ObjectIdentifier(ObjectType.analogValue, 1),
+        ReadPropertyRequest req = new ReadPropertyRequest(new ObjectIdentifier(ObjectType.analogValue, 1),
                 PropertyIdentifier.priorityArray, new UnsignedInteger(0)); //Reading size going wrong
-        final ReadPropertyAck ack = localDevice.send(rDevice, req).get();
+        ReadPropertyAck ack = localDevice.send(rDevice, req).get();
         //Check the Class
         assertEquals(UnsignedInteger.class, ack.getValue().getClass());
         //Check the Size
@@ -111,13 +111,13 @@ public class ReadPriorityArrayTest {
     @Test
     public void readPriorityArrayWithNullFirstElement() throws BACnetException {
         // Only the eighth element is set, so the first is Null.
-        final PriorityArray nullFirst = new PriorityArray().put(8, new Real(12.3f));
+        PriorityArray nullFirst = new PriorityArray().put(8, new Real(12.3f));
         remoteDevice.<AnalogValueObject>getObject(new ObjectIdentifier(ObjectType.analogValue, 1))
                 .writePropertyInternal(PropertyIdentifier.priorityArray, nullFirst);
 
-        final ReadPropertyRequest req = new ReadPropertyRequest(new ObjectIdentifier(ObjectType.analogValue, 1),
+        ReadPropertyRequest req = new ReadPropertyRequest(new ObjectIdentifier(ObjectType.analogValue, 1),
                 PropertyIdentifier.priorityArray);
-        final ReadPropertyAck ack = localDevice.send(rDevice, req).get();
+        ReadPropertyAck ack = localDevice.send(rDevice, req).get();
 
         assertEquals(PriorityArray.class, ack.getValue().getClass());
         assertEquals(nullFirst, ack.getValue());
@@ -125,9 +125,9 @@ public class ReadPriorityArrayTest {
 
     @Test
     public void readPriorityArrayElement() throws BACnetException {
-        final ReadPropertyRequest req = new ReadPropertyRequest(new ObjectIdentifier(ObjectType.analogValue, 1),
+        ReadPropertyRequest req = new ReadPropertyRequest(new ObjectIdentifier(ObjectType.analogValue, 1),
                 PropertyIdentifier.priorityArray, new UnsignedInteger(3)); //Reading element going wrong
-        final ReadPropertyAck ack = localDevice.send(rDevice, req).get();
+        ReadPropertyAck ack = localDevice.send(rDevice, req).get();
         //Check the Class
         assertEquals(PriorityValue.class, ack.getValue().getClass());
         //Check the Size

--- a/src/test/java/com/serotonin/bacnet4j/type/EncodableNullPrimitiveBodyTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/type/EncodableNullPrimitiveBodyTest.java
@@ -1,0 +1,165 @@
+/*
+ * ============================================================================
+ * GNU General Public License
+ * ============================================================================
+ *
+ * Copyright (C) 2025 Radix IoT LLC. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * When signing a commercial license with Radix IoT LLC,
+ * the following extension to GPL is made. A special exception to the GPL is
+ * included to allow you to distribute a combined work that includes BAcnet4J
+ * without being obliged to provide the source code for any proprietary components.
+ *
+ * See www.radixiot.com for commercial license options.
+ */
+
+package com.serotonin.bacnet4j.type;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import org.junit.Test;
+
+import com.serotonin.bacnet4j.exception.BACnetException;
+import com.serotonin.bacnet4j.type.constructed.PriorityArray;
+import com.serotonin.bacnet4j.type.enumerated.ObjectType;
+import com.serotonin.bacnet4j.type.enumerated.PropertyIdentifier;
+import com.serotonin.bacnet4j.type.primitive.Null;
+import com.serotonin.bacnet4j.type.primitive.Real;
+import com.serotonin.bacnet4j.util.sero.ByteQueue;
+
+/**
+ * Tests of the branch of {@link Encodable#readANY} that recognises a property value encoded as a lone NULL, which
+ * addendum 135-2016br-2 allows in place of the property's declared datatype. A value is only a lone NULL when the
+ * closing context tag immediately follows it; a constructed value that merely begins with a NULL, such as a priority
+ * array whose first element is NULL, has to be decoded normally.
+ */
+public class EncodableNullPrimitiveBodyTest {
+    /**
+     * A property whose declared type is a leaf primitive, so that a NULL value takes the branch under test.
+     */
+    private static final PropertyIdentifier PRIMITIVE_PROPERTY = PropertyIdentifier.description;
+
+    @Test
+    public void loneNullDecodesAsNull() throws BACnetException {
+        final ByteQueue queue = wrap(Null.instance, 4);
+
+        final Encodable value = Encodable.readANY(queue, ObjectType.analogValue, PRIMITIVE_PROPERTY, null, 4);
+
+        assertEquals(Null.class, value.getClass());
+        assertEquals("the whole value should be consumed", 0, queue.size());
+    }
+
+    /**
+     * The tag of a context id above 14 is two octets rather than one, so the NULL and the closing tag are found at
+     * different offsets.
+     */
+    @Test
+    public void loneNullWithExtendedTagDecodesAsNull() throws BACnetException {
+        final ByteQueue queue = wrap(Null.instance, 15);
+
+        final Encodable value = Encodable.readANY(queue, ObjectType.analogValue, PRIMITIVE_PROPERTY, null, 15);
+
+        assertEquals(Null.class, value.getClass());
+        assertEquals("the whole value should be consumed", 0, queue.size());
+    }
+
+    @Test
+    public void priorityArrayWithNullFirstElementDecodesAsPriorityArray() throws BACnetException {
+        final PriorityArray array = new PriorityArray().put(8, new Real(12.3f));
+        final ByteQueue queue = wrap(array, 4);
+
+        final Encodable value = Encodable.readANY(queue, ObjectType.analogValue, PropertyIdentifier.priorityArray,
+                null, 4);
+
+        assertEquals(array, value);
+        assertEquals("the whole value should be consumed", 0, queue.size());
+    }
+
+    @Test
+    public void priorityArrayWithNullFirstElementAndExtendedTagDecodesAsPriorityArray() throws BACnetException {
+        final PriorityArray array = new PriorityArray().put(8, new Real(12.3f));
+        final ByteQueue queue = wrap(array, 15);
+
+        final Encodable value = Encodable.readANY(queue, ObjectType.analogValue, PropertyIdentifier.priorityArray,
+                null, 15);
+
+        assertEquals(array, value);
+        assertEquals("the whole value should be consumed", 0, queue.size());
+    }
+
+    /**
+     * An array of every element NULL is the state of a commandable object that has never been commanded. It is not a
+     * lone NULL either.
+     */
+    @Test
+    public void priorityArrayOfAllNullsDecodesAsPriorityArray() throws BACnetException {
+        final PriorityArray array = new PriorityArray();
+        final ByteQueue queue = wrap(array, 4);
+
+        final Encodable value = Encodable.readANY(queue, ObjectType.analogValue, PropertyIdentifier.priorityArray,
+                null, 4);
+
+        assertEquals(array, value);
+        assertEquals("the whole value should be consumed", 0, queue.size());
+    }
+
+    /**
+     * A message that ends part way through the closing tag must be reported as a BACnet error rather than throwing
+     * out of the decoder as an unchecked exception.
+     */
+    @Test
+    public void truncatedExtendedClosingTagIsReportedAsABACnetError() {
+        final ByteQueue queue = new ByteQueue();
+        queue.push("4e"); // Opening tag, context id 4.
+        queue.push("00"); // NULL.
+        queue.push("ff"); // The first octet of an extended closing tag, with its tag number octet missing.
+
+        assertThrows(BACnetException.class,
+                () -> Encodable.readANY(queue, ObjectType.analogValue, PRIMITIVE_PROPERTY, null, 4));
+    }
+
+    @Test
+    public void missingClosingTagIsReportedAsABACnetError() {
+        final ByteQueue queue = new ByteQueue();
+        queue.push("4e"); // Opening tag, context id 4.
+        queue.push("00"); // NULL, and then nothing at all.
+
+        assertThrows(BACnetException.class,
+                () -> Encodable.readANY(queue, ObjectType.analogValue, PRIMITIVE_PROPERTY, null, 4));
+    }
+
+    /**
+     * Encode the value in its application form between the opening and closing context tags of the given context id,
+     * which is how a property value is carried. Written here rather than with Encodable's own context write because
+     * a primitive encodes itself with a single context tag instead.
+     */
+    private static ByteQueue wrap(final Encodable value, final int contextId) {
+        final ByteQueue queue = new ByteQueue();
+        pushContextTag(queue, contextId, true);
+        value.write(queue);
+        pushContextTag(queue, contextId, false);
+        return queue;
+    }
+
+    private static void pushContextTag(final ByteQueue queue, final int contextId, final boolean start) {
+        if (contextId <= 14) {
+            queue.push(contextId << 4 | (start ? 0xe : 0xf));
+        } else {
+            queue.push(start ? 0xfe : 0xff);
+            queue.push(contextId);
+        }
+    }
+}

--- a/src/test/java/com/serotonin/bacnet4j/type/EncodableNullPrimitiveBodyTest.java
+++ b/src/test/java/com/serotonin/bacnet4j/type/EncodableNullPrimitiveBodyTest.java
@@ -54,9 +54,9 @@ public class EncodableNullPrimitiveBodyTest {
 
     @Test
     public void loneNullDecodesAsNull() throws BACnetException {
-        final ByteQueue queue = wrap(Null.instance, 4);
+        ByteQueue queue = wrap(Null.instance, 4);
 
-        final Encodable value = Encodable.readANY(queue, ObjectType.analogValue, PRIMITIVE_PROPERTY, null, 4);
+        Encodable value = Encodable.readANY(queue, ObjectType.analogValue, PRIMITIVE_PROPERTY, null, 4);
 
         assertEquals(Null.class, value.getClass());
         assertEquals("the whole value should be consumed", 0, queue.size());
@@ -68,9 +68,9 @@ public class EncodableNullPrimitiveBodyTest {
      */
     @Test
     public void loneNullWithExtendedTagDecodesAsNull() throws BACnetException {
-        final ByteQueue queue = wrap(Null.instance, 15);
+        ByteQueue queue = wrap(Null.instance, 15);
 
-        final Encodable value = Encodable.readANY(queue, ObjectType.analogValue, PRIMITIVE_PROPERTY, null, 15);
+        Encodable value = Encodable.readANY(queue, ObjectType.analogValue, PRIMITIVE_PROPERTY, null, 15);
 
         assertEquals(Null.class, value.getClass());
         assertEquals("the whole value should be consumed", 0, queue.size());
@@ -78,10 +78,10 @@ public class EncodableNullPrimitiveBodyTest {
 
     @Test
     public void priorityArrayWithNullFirstElementDecodesAsPriorityArray() throws BACnetException {
-        final PriorityArray array = new PriorityArray().put(8, new Real(12.3f));
-        final ByteQueue queue = wrap(array, 4);
+        PriorityArray array = new PriorityArray().put(8, new Real(12.3f));
+        ByteQueue queue = wrap(array, 4);
 
-        final Encodable value = Encodable.readANY(queue, ObjectType.analogValue, PropertyIdentifier.priorityArray,
+        Encodable value = Encodable.readANY(queue, ObjectType.analogValue, PropertyIdentifier.priorityArray,
                 null, 4);
 
         assertEquals(array, value);
@@ -90,10 +90,10 @@ public class EncodableNullPrimitiveBodyTest {
 
     @Test
     public void priorityArrayWithNullFirstElementAndExtendedTagDecodesAsPriorityArray() throws BACnetException {
-        final PriorityArray array = new PriorityArray().put(8, new Real(12.3f));
-        final ByteQueue queue = wrap(array, 15);
+        PriorityArray array = new PriorityArray().put(8, new Real(12.3f));
+        ByteQueue queue = wrap(array, 15);
 
-        final Encodable value = Encodable.readANY(queue, ObjectType.analogValue, PropertyIdentifier.priorityArray,
+        Encodable value = Encodable.readANY(queue, ObjectType.analogValue, PropertyIdentifier.priorityArray,
                 null, 15);
 
         assertEquals(array, value);
@@ -106,10 +106,10 @@ public class EncodableNullPrimitiveBodyTest {
      */
     @Test
     public void priorityArrayOfAllNullsDecodesAsPriorityArray() throws BACnetException {
-        final PriorityArray array = new PriorityArray();
-        final ByteQueue queue = wrap(array, 4);
+        PriorityArray array = new PriorityArray();
+        ByteQueue queue = wrap(array, 4);
 
-        final Encodable value = Encodable.readANY(queue, ObjectType.analogValue, PropertyIdentifier.priorityArray,
+        Encodable value = Encodable.readANY(queue, ObjectType.analogValue, PropertyIdentifier.priorityArray,
                 null, 4);
 
         assertEquals(array, value);
@@ -122,7 +122,7 @@ public class EncodableNullPrimitiveBodyTest {
      */
     @Test
     public void truncatedExtendedClosingTagIsReportedAsABACnetError() {
-        final ByteQueue queue = new ByteQueue();
+        ByteQueue queue = new ByteQueue();
         queue.push("4e"); // Opening tag, context id 4.
         queue.push("00"); // NULL.
         queue.push("ff"); // The first octet of an extended closing tag, with its tag number octet missing.
@@ -133,7 +133,7 @@ public class EncodableNullPrimitiveBodyTest {
 
     @Test
     public void missingClosingTagIsReportedAsABACnetError() {
-        final ByteQueue queue = new ByteQueue();
+        ByteQueue queue = new ByteQueue();
         queue.push("4e"); // Opening tag, context id 4.
         queue.push("00"); // NULL, and then nothing at all.
 
@@ -146,15 +146,15 @@ public class EncodableNullPrimitiveBodyTest {
      * which is how a property value is carried. Written here rather than with Encodable's own context write because
      * a primitive encodes itself with a single context tag instead.
      */
-    private static ByteQueue wrap(final Encodable value, final int contextId) {
-        final ByteQueue queue = new ByteQueue();
+    private static ByteQueue wrap(Encodable value, int contextId) {
+        ByteQueue queue = new ByteQueue();
         pushContextTag(queue, contextId, true);
         value.write(queue);
         pushContextTag(queue, contextId, false);
         return queue;
     }
 
-    private static void pushContextTag(final ByteQueue queue, final int contextId, final boolean start) {
+    private static void pushContextTag(ByteQueue queue, int contextId, boolean start) {
         if (contextId <= 14) {
             queue.push(contextId << 4 | (start ? 0xe : 0xf));
         } else {


### PR DESCRIPTION
### Problem

Reading `Priority_Array` from a peer fails whenever the array's **first** element is NULL. The `ReadPropertyAck` cannot be parsed and the request fails with:

BACnetException: property: missing-required-parameter
Caused by: BACnetErrorException: property: missing-required-parameter
    at Encodable.popEnd(Encodable.java:166)
    at Encodable.readANY(Encodable.java:447)
    at ReadPropertyAck.<init>(ReadPropertyAck.java:92)

This covers most commandable objects in practice: any object commanded at a priority other than 1, and any object that has never been commanded at all, since its array is 16 NULLs. An array with a non-NULL first element decodes fine, which is why the existing `ReadPriorityArrayTest` cases did not catch it.

### Cause

`Encodable.isNullPrimitiveBody`, added in 04b34d23 (MANGO-2956, #174) to support the addendum 135-2016br-2 relinquish-style NULL, decided that a property value was a bare NULL by looking at a single byte.

The comment states the requirement but the code never checked it. A priority array whose first element is NULL begins its body with 0x00 followed by the other 15 elements, so the check returned true. readANY then took the bare-NULL shortcut,
consumed one Null, and demanded the closing context tag — the remaining elements were there instead, so popEnd threw.

The array branch earlier in readANY does not intercept this because priority-array is declared with PriorityArray as its own class rather than as a collection, so def.isCollection() is false.

### Changes

Encodable.java:

1. isNullPrimitiveBody now requires the closing context tag to immediately follow the 0x00, so a constructed value that merely begins with a NULL is decoded normally.
2. New isEndTagAt helper performs that check without consuming bytes, handling the two-octet extended form used by context ids above 14.
3. isEndTagAt is bounds-checked, so a message truncated part way through a closing tag no longer reads past the end of the queue. That previously threw IllegalArgumentException out of the decoder; malformed input is now reported as a BACnetException like other decode failures.

The relinquish-style [n] 00 [/n] behaviour that #174 added is unchanged.
